### PR TITLE
Add cloudflare/skills plugin to marketplace

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -37,6 +37,17 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp"
+    },
+    {
+      "name": "cloudflare",
+      "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cloudflare/skills.git",
+        "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
+      },
+      "homepage": "https://github.com/cloudflare/skills"
     }
   ]
 }


### PR DESCRIPTION
Adds the [cloudflare/skills](https://github.com/cloudflare/skills) plugin to the official marketplace catalog.

## What
- New `cloudflare` entry in `.grok-plugin/marketplace.json`, category `development`.
- Pinned to current `main` HEAD `60147cbb773649eadca89cee92b4e0caf02234b4`.

## Why it's valid
- Repo ships a `.claude-plugin/plugin.json` manifest (plugin name `cloudflare`) and 8 skills: agents-sdk, cloudflare, cloudflare-email-service, durable-objects, sandbox-sdk, web-perf, workers-best-practices, wrangler.
- `python3 scripts/validate-catalog.py` passes (SHA pin present and well-formed).