### PR TITLE
Update sentry plugin to canonical sentry-for-ai URL

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -22,10 +22,10 @@
       "category": "monitoring",
       "source": {
         "source": "url",
-        "url": "https://github.com/getsentry/sentry-for-claude.git",
-        "sha": "fb398fdfff2055abc3d55917f6b6f0c0d5ad5e3b"
+        "url": "https://github.com/getsentry/sentry-for-ai.git",
+        "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
-      "homepage": "https://github.com/getsentry/sentry-for-claude"
+      "homepage": "https://github.com/getsentry/sentry-for-ai"
     },
     {
       "name": "chrome-devtools",


### PR DESCRIPTION
`getsentry/sentry-for-claude` was **renamed** to [`getsentry/sentry-for-ai`](https://github.com/getsentry/sentry-for-ai). The old URL now just 302-redirects to the new one — both resolve to the identical HEAD `849303a8411c242d250885ffe714235a3bc2f5fe`.

This updates the existing `sentry` catalog entry to the canonical repo URL and bumps the pin to current HEAD. Not adding a new entry, since the repo declares plugin name `sentry` and a second entry would duplicate the existing one against identical content.

## Changes
- `url`: `sentry-for-claude.git` -> `sentry-for-ai.git`
- `sha`: `fb398fdf…` -> `849303a8…` (current HEAD)
- `homepage` updated to match

`python3 scripts/validate-catalog.py` passes.