### PR TITLE
Add superpowers plugin to marketplace

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -48,6 +48,17 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills"
+    },
+    {
+      "name": "superpowers",
+      "description": "Core skills library for software development: test-driven development, systematic debugging, collaboration patterns, and proven engineering workflows and techniques.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/obra/superpowers.git",
+        "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
+      },
+      "homepage": "https://github.com/obra/superpowers"
     }
   ]
 }


### PR DESCRIPTION
Adds the [superpowers](https://github.com/obra/superpowers) plugin to the marketplace catalog.

- **name:** `superpowers`
- **category:** `development`
- **url:** `https://github.com/obra/superpowers.git`
- **sha:** `6fd4507659784c351abbd2bc264c7162cfd386dc` (HEAD of `main`)
- **homepage:** https://github.com/obra/superpowers

Verified the repo is a valid plugin (`.claude-plugin/plugin.json`, v5.1.0) and pinned the full commit SHA. `python3 scripts/validate-catalog.py` passes.