### PR TITLE
Add slack plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -59,6 +59,17 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers"
+    },
+    {
+      "name": "slack",
+      "description": "Slack workspace integration. Search messages, files, channels, and users, send messages, read threads and channel history, manage canvases, and look up user profiles directly from Grok.",
+      "category": "communication",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/slackapi/slack-mcp-plugin.git",
+        "sha": "38fb959299386a6d2c202511ef7e76909a072663"
+      },
+      "homepage": "https://github.com/slackapi/slack-mcp-plugin"
     }
   ]
 }


### PR DESCRIPTION
Adds the [Slack plugin](https://github.com/slackapi/slack-mcp-plugin) to the official marketplace catalog.

- **name**: `slack`
- **category**: `communication`
- **source**: url-pinned to commit `38fb959299386a6d2c202511ef7e76909a072663` (current `main` HEAD)
- **homepage**: https://github.com/slackapi/slack-mcp-plugin

The plugin wires up Slack's hosted MCP server (`https://mcp.slack.com/mcp`, OAuth) for searching messages/files/channels/users, sending messages, reading threads and channel history, managing canvases, and looking up user profiles.

`python3 scripts/validate-catalog.py` passes locally (SHA is a full 40-char lowercase hex pin).