### PR TITLE
Add CTA trigger keywords to marketplace plugins

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,8 @@
         "url": "https://github.com/vercel/vercel-plugin.git",
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
-      "homepage": "https://github.com/vercel/vercel-plugin"
+      "homepage": "https://github.com/vercel/vercel-plugin",
+      "keywords": ["vercel", "vercel.com", "vercel deploy", "deploy to vercel"]
     },
     {
       "name": "sentry",
@@ -25,7 +26,8 @@
         "url": "https://github.com/getsentry/sentry-for-ai.git",
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
-      "homepage": "https://github.com/getsentry/sentry-for-ai"
+      "homepage": "https://github.com/getsentry/sentry-for-ai",
+      "keywords": ["sentry", "sentry.io"]
     },
     {
       "name": "chrome-devtools",
@@ -36,7 +38,8 @@
         "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
-      "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp"
+      "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
     },
     {
       "name": "cloudflare",
@@ -47,7 +50,8 @@
         "url": "https://github.com/cloudflare/skills.git",
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
-      "homepage": "https://github.com/cloudflare/skills"
+      "homepage": "https://github.com/cloudflare/skills",
+      "keywords": ["cloudflare", "cloudflare.com", "wrangler", "cloudflare workers"]
     },
     {
       "name": "superpowers",
@@ -58,7 +62,8 @@
         "url": "https://github.com/obra/superpowers.git",
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
-      "homepage": "https://github.com/obra/superpowers"
+      "homepage": "https://github.com/obra/superpowers",
+      "keywords": ["superpowers"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,7 +15,8 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel.com", "vercel deploy", "deploy to vercel"]
+      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
+      "domains": ["vercel.com"]
     },
     {
       "name": "sentry",
@@ -27,7 +28,8 @@
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry", "sentry.io"]
+      "keywords": ["sentry"],
+      "domains": ["sentry.io"]
     },
     {
       "name": "chrome-devtools",
@@ -51,7 +53,8 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "cloudflare.com", "wrangler", "cloudflare workers"]
+      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
+      "domains": ["cloudflare.com"]
     },
     {
       "name": "superpowers",


### PR DESCRIPTION
## What

Adds a per-plugin `keywords` array to the official marketplace index (`.grok-plugin/marketplace.json`) for all five plugins (vercel, sentry, chrome-devtools, cloudflare, superpowers).

## Why

This is the data half of the Grok Build pager's **keyword-match plugin-recommendation CTA**. As a user types in the pager prompt, if their text mentions one of a plugin's `keywords`, the pager surfaces a one-line "Connect <plugin> to Grok?" CTA. Keeping the trigger terms as data in the marketplace index (rather than hardcoded in the pager) means they can be tuned without a pager release.

The pager-side implementation is the stacked PR set starting at xai-org/xai#208392 (behind the `official_marketplace_auto_register` flag, default off — so this change is inert until both land and the flag is enabled).

## Notes

- **Additive & backward-compatible**: `keywords` is an optional field; older pagers ignore it.
- Keywords were chosen to be specific (brand names + product domains, e.g. `vercel.com`, `cloudflare.com`) to avoid over-firing on generic terms.
- `homepage` values are intentionally left as the existing repo URLs. The pager matcher also derives a trigger from the homepage *domain*; since these are all `github.com`, the matcher should be hardened to ignore code-host domains so it doesn't over-fire on "github" (tracked as a follow-up on the pager stack — not this repo).
- Validated with `scripts/validate-catalog.py` (Catalog OK).
