### PR TITLE
Harden CI for going public

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 # Every change to the official marketplace requires code-owner review.
-# Replace @ykeremy with the appropriate xAI team handle (e.g. @xai-org/grok-cli)
-# once one exists. Enforced by branch protection: "Require review from Code Owners".
-* @ykeremy
+# Enforced by branch protection: "Require review from Code Owners".
+* @xai-org/grok-build-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every change to the official marketplace requires code-owner review.
+# Replace @ykeremy with the appropriate xAI team handle (e.g. @xai-org/grok-cli)
+# once one exists. Enforced by branch protection: "Require review from Code Owners".
+* @ykeremy

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -5,9 +5,12 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
-    runs-on: cpu-minimal-amd64-onprem
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/validate-catalog.py
+++ b/scripts/validate-catalog.py
@@ -14,9 +14,9 @@ every user who installs or updates that plugin. Pinning to a specific
 commit + content-verifying it at install time is the only thing that
 survives that class of attack.
 
-The runtime side lives in xai-org/xai (xai-grok-agent::plugins::git_install)
-and verifies `git rev-parse HEAD == sha` after clone — these two layers
-together give us content-addressable plugin pinning.
+The runtime side (the Grok CLI plugin installer) verifies
+`git rev-parse HEAD == sha` after clone — these two layers together give
+us content-addressable plugin pinning.
 
 Run locally:    python3 scripts/validate-catalog.py
 """
@@ -30,7 +30,7 @@ from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
-# Lookup order matches xai-grok-plugin-marketplace::index::load_index.
+# Lookup order matches the marketplace index loader in the Grok CLI.
 CATALOG_PATHS = [
     Path(".grok-plugin/marketplace.json"),
     Path(".claude-plugin/marketplace.json"),


### PR DESCRIPTION
Pre-public hardening for the official marketplace.

## Changes
- **CI runner → `ubuntu-latest`**: the validate-catalog workflow ran on the on-prem self-hosted runner (`cpu-minimal-amd64-onprem`). On a public repo, fork PRs could target internal infra. The job only runs a Python script, so GitHub-hosted is the right fit.
- **Least-privilege token**: added `permissions: contents: read` to the workflow.
- **CODEOWNERS**: added so every change requires code-owner review (needs branch protection "Require review from Code Owners" enabled). Currently set to `@ykeremy` — swap for a team handle if/when one exists.
- **Docstring cleanup**: removed internal repo/crate names (`xai-org/xai`, `xai-grok-*::*`) from `scripts/validate-catalog.py`.

## Follow-ups that can't be done in YAML (repo settings, only after repo is public)
- Set fork-PR workflow approval to **all outside collaborators** (Settings → Actions → General, or `PUT /repos/xai-org/plugin-marketplace/actions/permissions/fork-pr-contributor-approval` with `{"approval_policy":"all_external_contributors"}`). This endpoint is rejected while the repo is private.
- Enable branch protection on `main` requiring code-owner review.