### PR TITLE
Add mongodb plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -67,6 +67,19 @@
       },
       "homepage": "https://github.com/obra/superpowers",
       "keywords": ["superpowers"]
+    },
+    {
+      "name": "mongodb",
+      "description": "Official plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mongodb/agent-skills.git",
+        "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
+      },
+      "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
+      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
+      "domains": ["mongodb.com", "cloud.mongodb.com"]
     }
   ]
 }


### PR DESCRIPTION
Adds the official MongoDB plugin (MCP Server + Skills) as a remote-source entry pinned to `9ea7387`.

- keywords: mongodb, mongo, mongosh, mongodb atlas, mongoose
- domains: mongodb.com, cloud.mongodb.com

Validated with `python3 scripts/validate-catalog.py`.