### PR TITLE
Add generated plugin component index (plugin-index.json) with CI validation

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -21,3 +21,6 @@ jobs:
 
       - name: Validate catalog
         run: python3 scripts/validate-catalog.py
+
+      - name: Check plugin index is up to date
+        run: python3 scripts/generate-plugin-index.py --check

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,0 +1,522 @@
+{
+  "version": 1,
+  "plugins": {
+    "chrome-devtools": {
+      "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "chrome-devtools",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "a11y-debugging",
+            "description": "Uses Chrome DevTools MCP for accessibility (a11y) debugging and auditing based on web.dev guidelines. Use when testing…"
+          },
+          {
+            "name": "chrome-devtools",
+            "description": "Uses Chrome DevTools via MCP for efficient debugging, troubleshooting and browser automation. Use when debugging web pa…"
+          },
+          {
+            "name": "chrome-devtools-cli",
+            "description": "Use this skill to write shell scripts or run shell commands to automate tasks in the browser or otherwise use Chrome De…"
+          },
+          {
+            "name": "debug-optimize-lcp",
+            "description": "Guides debugging and optimizing Largest Contentful Paint (LCP) using Chrome DevTools MCP tools. Use this skill whenever…"
+          },
+          {
+            "name": "memory-leak-debugging",
+            "description": "Diagnoses and resolves memory leaks in JavaScript/Node.js applications. Use when a user reports high memory usage, OOM…"
+          },
+          {
+            "name": "troubleshooting",
+            "description": "Uses Chrome DevTools MCP and documentation to troubleshoot connection and target issues. Trigger this skill when list_p…"
+          }
+        ]
+      }
+    },
+    "cloudflare": {
+      "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
+      "components": {
+        "commands": [
+          {
+            "name": "build-agent",
+            "description": "Build an AI agent on Cloudflare using the Agents SDK"
+          },
+          {
+            "name": "build-mcp",
+            "description": "Build a remote MCP server on Cloudflare using McpAgent"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "cloudflare-api",
+            "description": "http"
+          },
+          {
+            "name": "cloudflare-bindings",
+            "description": "http"
+          },
+          {
+            "name": "cloudflare-builds",
+            "description": "http"
+          },
+          {
+            "name": "cloudflare-docs",
+            "description": "http"
+          },
+          {
+            "name": "cloudflare-observability",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agents-sdk",
+            "description": "Build AI agents on Cloudflare Workers using the Agents SDK. Load when creating stateful agents, durable workflows, real…"
+          },
+          {
+            "name": "cloudflare",
+            "description": "Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agent…"
+          },
+          {
+            "name": "cloudflare-email-service",
+            "description": "Send and receive transactional emails with Cloudflare Email Service (Email Sending + Email Routing). Use when building…"
+          },
+          {
+            "name": "durable-objects",
+            "description": "Create and review Cloudflare Durable Objects. Use when building stateful coordination (chat rooms, multiplayer games, b…"
+          },
+          {
+            "name": "sandbox-sdk",
+            "description": "Build sandboxed applications for secure code execution. Load when building AI code execution, code interpreters, CI/CD…"
+          },
+          {
+            "name": "web-perf",
+            "description": "Analyzes web performance using Chrome DevTools MCP. Measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics…"
+          },
+          {
+            "name": "workers-best-practices",
+            "description": "Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing…"
+          },
+          {
+            "name": "wrangler",
+            "description": "Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI,…"
+          }
+        ]
+      }
+    },
+    "mongodb": {
+      "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
+      "components": {
+        "skills": [
+          {
+            "name": "mongodb-atlas-stream-processing",
+            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
+          },
+          {
+            "name": "mongodb-connection",
+            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
+          },
+          {
+            "name": "mongodb-mcp-setup",
+            "description": "Guide users through configuring key MongoDB MCP server options. Use this skill when a user has the MongoDB MCP server i…"
+          },
+          {
+            "name": "mongodb-natural-language-querying",
+            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
+          },
+          {
+            "name": "mongodb-query-optimizer",
+            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
+          },
+          {
+            "name": "mongodb-schema-design",
+            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
+          },
+          {
+            "name": "mongodb-search-and-ai",
+            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
+          }
+        ]
+      }
+    },
+    "sentry": {
+      "sha": "849303a8411c242d250885ffe714235a3bc2f5fe",
+      "components": {
+        "commands": [
+          {
+            "name": "seer",
+            "description": "Ask natural language questions about your Sentry environment and get detailed insights using the Sentry MCP server"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "sentry",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "sentry-android-sdk",
+            "description": "Full Sentry SDK setup for Android. Use when asked to \"add Sentry to Android\", \"install sentry-android\", \"setup Sentry i…"
+          },
+          {
+            "name": "sentry-browser-sdk",
+            "description": "Full Sentry SDK setup for browser JavaScript. Use when asked to \"add Sentry to a website\", \"install @sentry/browser\", o…"
+          },
+          {
+            "name": "sentry-cloudflare-sdk",
+            "description": "Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to \"add Sentry to Cloudflare Workers\", \"install…"
+          },
+          {
+            "name": "sentry-cocoa-sdk",
+            "description": "Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS). Use when asked to \"add Sentry to iOS\",…"
+          },
+          {
+            "name": "sentry-code-review",
+            "description": "Analyze and resolve Sentry comments on GitHub Pull Requests. Use this when asked to review or fix issues identified by…"
+          },
+          {
+            "name": "sentry-create-alert",
+            "description": "Create Sentry alerts using the workflow engine API. Use when asked to create alerts, set up notifications, configure is…"
+          },
+          {
+            "name": "sentry-dotnet-sdk",
+            "description": "Full Sentry SDK setup for .NET. Use when asked to \"add Sentry to .NET\", \"install Sentry for C#\", or configure error mon…"
+          },
+          {
+            "name": "sentry-elixir-sdk",
+            "description": "Full Sentry SDK setup for Elixir. Use when asked to \"add Sentry to Elixir\", \"install sentry for Elixir\", or configure e…"
+          },
+          {
+            "name": "sentry-feature-setup",
+            "description": "Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry…"
+          },
+          {
+            "name": "sentry-fix-issues",
+            "description": "Find and fix issues from Sentry using MCP. Use when asked to fix Sentry errors, debug production issues, investigate ex…"
+          },
+          {
+            "name": "sentry-flutter-sdk",
+            "description": "Full Sentry SDK setup for Flutter and Dart. Use when asked to \"add Sentry to Flutter\", \"install sentry_flutter\", \"setup…"
+          },
+          {
+            "name": "sentry-go-sdk",
+            "description": "Full Sentry SDK setup for Go. Use when asked to \"add Sentry to Go\", \"install sentry-go\", \"setup Sentry in Go\", or confi…"
+          },
+          {
+            "name": "sentry-nestjs-sdk",
+            "description": "Full Sentry SDK setup for NestJS. Use when asked to \"add Sentry to NestJS\", \"install @sentry/nestjs\", \"setup Sentry in…"
+          },
+          {
+            "name": "sentry-nextjs-sdk",
+            "description": "Full Sentry SDK setup for Next.js. Use when asked to \"add Sentry to Next.js\", \"install @sentry/nextjs\", or configure er…"
+          },
+          {
+            "name": "sentry-node-sdk",
+            "description": "Full Sentry SDK setup for Node.js, Bun, and Deno. Use when asked to \"add Sentry to Node.js\", \"add Sentry to Bun\", \"add…"
+          },
+          {
+            "name": "sentry-otel-exporter-setup",
+            "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us…"
+          },
+          {
+            "name": "sentry-php-sdk",
+            "description": "Full Sentry SDK setup for PHP. Use when asked to \"add Sentry to PHP\", \"install sentry/sentry\", \"setup Sentry in PHP\", o…"
+          },
+          {
+            "name": "sentry-pr-code-review",
+            "description": "Review a project's PRs to check for issues detected in code review by Seer Bug Prediction. Use when asked to review or…"
+          },
+          {
+            "name": "sentry-python-sdk",
+            "description": "Full Sentry SDK setup for Python. Use when asked to \"add Sentry to Python\", \"install sentry-sdk\", \"setup Sentry in Pyth…"
+          },
+          {
+            "name": "sentry-react-native-sdk",
+            "description": "Full Sentry SDK setup for React Native and Expo. Use when asked to \"add Sentry to React Native\", \"install @sentry/react…"
+          },
+          {
+            "name": "sentry-react-router-framework-sdk",
+            "description": "Full Sentry SDK setup for React Router Framework mode. Use when asked to \"add Sentry to React Router Framework\", \"insta…"
+          },
+          {
+            "name": "sentry-react-sdk",
+            "description": "Full Sentry SDK setup for React. Use when asked to \"add Sentry to React\", \"install @sentry/react\", or configure error m…"
+          },
+          {
+            "name": "sentry-ruby-sdk",
+            "description": "Full Sentry SDK setup for Ruby. Use when asked to add Sentry to Ruby, install sentry-ruby, setup Sentry in Rails/Sinatr…"
+          },
+          {
+            "name": "sentry-sdk-setup",
+            "description": "Set up Sentry in any language or framework. Detects the user's platform and loads the right SDK skill. Use when asked t…"
+          },
+          {
+            "name": "sentry-sdk-skill-creator",
+            "description": "Create a complete Sentry SDK skill bundle for any platform. Use when asked to \"create an SDK skill\", \"add a new platfor…"
+          },
+          {
+            "name": "sentry-sdk-upgrade",
+            "description": "Upgrade the Sentry JavaScript SDK across major versions. Use when asked to upgrade Sentry, migrate to a newer version,…"
+          },
+          {
+            "name": "sentry-setup-ai-monitoring",
+            "description": "Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversati…"
+          },
+          {
+            "name": "sentry-svelte-sdk",
+            "description": "Full Sentry SDK setup for Svelte and SvelteKit. Use when asked to \"add Sentry to Svelte\", \"add Sentry to SvelteKit\", \"i…"
+          },
+          {
+            "name": "sentry-tanstack-start-sdk",
+            "description": "Full Sentry SDK setup for TanStack Start React. Use when asked to \"add Sentry to TanStack Start\", \"install @sentry/tans…"
+          },
+          {
+            "name": "sentry-workflow",
+            "description": "Fix production issues and review code with Sentry context. Use when asked to fix Sentry errors, debug issues, triage ex…"
+          }
+        ]
+      }
+    },
+    "superpowers": {
+      "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
+      "components": {
+        "hooks": [
+          {
+            "name": "SessionStart",
+            "description": "startup|clear|compact"
+          }
+        ],
+        "skills": [
+          {
+            "name": "brainstorming",
+            "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying…"
+          },
+          {
+            "name": "dispatching-parallel-agents",
+            "description": "Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies"
+          },
+          {
+            "name": "executing-plans",
+            "description": "Use when you have a written implementation plan to execute in a separate session with review checkpoints"
+          },
+          {
+            "name": "finishing-a-development-branch",
+            "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completi…"
+          },
+          {
+            "name": "receiving-code-review",
+            "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or techn…"
+          },
+          {
+            "name": "requesting-code-review",
+            "description": "Use when completing tasks, implementing major features, or before merging to verify work meets requirements"
+          },
+          {
+            "name": "subagent-driven-development",
+            "description": "Use when executing implementation plans with independent tasks in the current session"
+          },
+          {
+            "name": "systematic-debugging",
+            "description": "Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes"
+          },
+          {
+            "name": "test-driven-development",
+            "description": "Use when implementing any feature or bugfix, before writing implementation code"
+          },
+          {
+            "name": "using-git-worktrees",
+            "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - e…"
+          },
+          {
+            "name": "using-superpowers",
+            "description": "Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY…"
+          },
+          {
+            "name": "verification-before-completion",
+            "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verif…"
+          },
+          {
+            "name": "writing-plans",
+            "description": "Use when you have a spec or requirements for a multi-step task, before touching code"
+          },
+          {
+            "name": "writing-skills",
+            "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment"
+          }
+        ]
+      }
+    },
+    "vercel": {
+      "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
+      "components": {
+        "agents": [
+          {
+            "name": "ai-architect",
+            "description": "Specializes in architecting AI-powered applications on Vercel — choosing between AI SDK patterns, configuring providers…"
+          },
+          {
+            "name": "deployment-expert",
+            "description": "Specializes in Vercel deployment strategies, CI/CD pipelines, preview URLs, production promotions, rollbacks, environme…"
+          },
+          {
+            "name": "performance-optimizer",
+            "description": "Specializes in optimizing Vercel application performance — Core Web Vitals, rendering strategies, caching, image optimi…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "_conventions",
+            "description": "Every slash command in this plugin follows a consistent structure so that the AI agent produces reliable, verifiable re…"
+          },
+          {
+            "name": "bootstrap",
+            "description": "Bootstrap a repository with Vercel-linked resources by running preflight checks, provisioning integrations, verifying e…"
+          },
+          {
+            "name": "deploy",
+            "description": "Deploy the current project to Vercel. Pass \"prod\" or \"production\" as argument to deploy to production. Default is previ…"
+          },
+          {
+            "name": "env",
+            "description": "Manage Vercel environment variables. Commands include list, pull, add, remove, and diff. Use to sync environment variab…"
+          },
+          {
+            "name": "marketplace",
+            "description": "Discover and install Vercel Marketplace integrations. Use to find databases, CMS, auth providers, and other services av…"
+          },
+          {
+            "name": "status",
+            "description": "Show the status of the current Vercel project — recent deployments, linked project info, and environment overview."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart",
+            "description": "startup|resume|clear|compact"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "vercel",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ai-gateway",
+            "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu…"
+          },
+          {
+            "name": "ai-sdk",
+            "description": "Vercel AI SDK expert guidance. Use when building AI-powered features — chat interfaces, text generation, structured out…"
+          },
+          {
+            "name": "auth",
+            "description": "Authentication integration guidance — Clerk (native Vercel Marketplace), Descope, and Auth0 setup for Next.js applicati…"
+          },
+          {
+            "name": "bootstrap",
+            "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ…"
+          },
+          {
+            "name": "chat-sdk",
+            "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots — Slack, Telegram, Microsoft Teams, Discord…"
+          },
+          {
+            "name": "deployments-cicd",
+            "description": "Vercel deployment and CI/CD expert guidance. Use when deploying, promoting, rolling back, inspecting deployments, build…"
+          },
+          {
+            "name": "env-vars",
+            "description": "Vercel environment variable expert guidance. Use when working with .env files, vercel env commands, OIDC tokens, or man…"
+          },
+          {
+            "name": "knowledge-update",
+            "description": "Corrects outdated LLM knowledge about the Vercel platform and introduces new products. Injected at session start."
+          },
+          {
+            "name": "marketplace",
+            "description": "Vercel Marketplace expert guidance — discovering, installing, and building integrations, auto-provisioned environment v…"
+          },
+          {
+            "name": "next-cache-components",
+            "description": "Next.js 16 Cache Components guidance — PPR, use cache directive, cacheLife, cacheTag, updateTag, and migration from uns…"
+          },
+          {
+            "name": "next-forge",
+            "description": "next-forge expert guidance — production-grade Turborepo monorepo SaaS starter by Vercel. Use when working in a next-for…"
+          },
+          {
+            "name": "next-upgrade",
+            "description": "Upgrade Next.js to the latest version following official migration guides and codemods. Use when upgrading Next.js vers…"
+          },
+          {
+            "name": "nextjs",
+            "description": "Next.js App Router expert guidance. Use when building, debugging, or architecting Next.js applications — routing, Serve…"
+          },
+          {
+            "name": "react-best-practices",
+            "description": "React best-practices reviewer for TSX files. Triggers after editing multiple TSX components to run a condensed quality…"
+          },
+          {
+            "name": "routing-middleware",
+            "description": "Vercel Routing Middleware guidance — request interception before cache, rewrites, redirects, personalization. Works wit…"
+          },
+          {
+            "name": "runtime-cache",
+            "description": "Vercel Runtime Cache API guidance — ephemeral per-region key-value cache with tag-based invalidation. Shared across Fun…"
+          },
+          {
+            "name": "shadcn",
+            "description": "shadcn/ui expert guidance — CLI, component installation, composition patterns, custom registries, theming, Tailwind CSS…"
+          },
+          {
+            "name": "turbopack",
+            "description": "Turbopack expert guidance. Use when configuring the Next.js bundler, optimizing HMR, debugging build issues, or underst…"
+          },
+          {
+            "name": "vercel-agent",
+            "description": "Vercel Agent guidance — AI-powered code review, incident investigation, and SDK installation. Automates PR analysis and…"
+          },
+          {
+            "name": "vercel-cli",
+            "description": "Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, queryin…"
+          },
+          {
+            "name": "vercel-firewall",
+            "description": "Vercel Firewall expert guidance — automatic DDoS mitigation, the Vercel WAF (custom rules, IP blocking, managed ruleset…"
+          },
+          {
+            "name": "vercel-functions",
+            "description": "Vercel Functions expert guidance — Serverless Functions, Edge Functions, Fluid Compute, streaming, Cron Jobs, and runti…"
+          },
+          {
+            "name": "vercel-sandbox",
+            "description": "Vercel Sandbox guidance — ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge…"
+          },
+          {
+            "name": "vercel-storage",
+            "description": "Vercel storage expert guidance — Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch…"
+          },
+          {
+            "name": "verification",
+            "description": "Full-story verification — infers what the user is building, then verifies the complete flow end-to-end: browser → API →…"
+          },
+          {
+            "name": "workflow",
+            "description": "Vercel Workflow DevKit (WDK) expert guidance. Use when building durable workflows, long-running tasks, API routes or ag…"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The official catalog of plugins for Grok Build. This repo is an index that point
 | Path | Purpose |
 |---|---|
 | `.grok-plugin/marketplace.json` | The catalog index — the source of truth |
+| `.grok-plugin/plugin-index.json` | Generated component catalog — never hand-edit |
 | `plugins/` | First-party plugins owned and maintained by xAI |
 | `external_plugins/` | Third-party plugins |
 
@@ -100,13 +101,24 @@ Find the commit to pin:
 git ls-remote https://github.com/my-org/my-plugin.git HEAD
 ```
 
+## Plugin component index
+
+`.grok-plugin/plugin-index.json` lists what each plugin provides (skills, commands, agents, MCP servers, hooks, LSP servers) so clients can show plugin contents before install. It is **generated — never hand-edit it**. After adding or updating a plugin entry, regenerate it:
+
+```bash
+python3 scripts/generate-plugin-index.py
+```
+
+CI runs `python3 scripts/generate-plugin-index.py --check` and fails if the committed file is stale. For remote sources the index records the pinned `sha` it was generated from; clients ignore index data whose `sha` no longer matches the catalog entry.
+
 ## Add or update a plugin
 
 1. Place first-party plugins in `plugins/` and third-party plugins in `external_plugins/` (local sources), or reference an upstream repo with a remote source.
 2. Add or edit the entry in `.grok-plugin/marketplace.json`.
 3. For remote sources, set `sha` to the exact commit you want to ship.
-4. Validate locally:
+4. Regenerate the component index and validate locally:
    ```bash
+   python3 scripts/generate-plugin-index.py
    python3 scripts/validate-catalog.py
    ```
 5. Open a PR. CI runs the validator and code-owner review is required.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ git ls-remote https://github.com/my-org/my-plugin.git HEAD
 python3 scripts/generate-plugin-index.py
 ```
 
-CI runs `python3 scripts/generate-plugin-index.py --check` and fails if the committed file is stale. For remote sources the index records the pinned `sha` it was generated from; clients ignore index data whose `sha` no longer matches the catalog entry.
+CI runs `python3 scripts/generate-plugin-index.py --check` and fails if the committed file is stale. Generation fetches each pinned remote source (with retries), so CI depends on the upstream repos being reachable — by design, a missing pinned commit fails loudly rather than going silently stale. For remote sources the index records the pinned `sha` it was generated from; clients ignore index data whose `sha` no longer matches the catalog entry.
 
 ## Add or update a plugin
 

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -21,6 +21,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 INDEX_PATH = Path(".grok-plugin/plugin-index.json")
@@ -28,6 +29,11 @@ CATALOG_PATH = Path(".grok-plugin/marketplace.json")
 
 MAX_ITEMS_PER_CATEGORY = 50
 MAX_STRING_LEN = 120
+MAX_TEXT_READ_BYTES = 64 * 1024
+MAX_JSON_BYTES = 1 << 20
+FETCH_ATTEMPTS = 3
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 MANIFEST_PATHS = [
     Path(".grok-plugin/plugin.json"),
@@ -38,16 +44,50 @@ CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
 def clean(text: str) -> str:
-    text = CONTROL_CHARS_RE.sub("", text).strip()
+    text = re.sub(r"\s+", " ", CONTROL_CHARS_RE.sub("", text)).strip()
     if len(text) > MAX_STRING_LEN:
         text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
     return text
 
 
+def resolve_inside(root: Path, relative) -> Path | None:
+    """Resolve `relative` against `root`, returning None if the result
+    escapes `root` (via `..`, absolute paths, or symlinks). Plugin content
+    is untrusted; nothing outside the plugin tree may be read."""
+    try:
+        candidate = (root / relative).resolve()
+        if candidate.is_relative_to(root.resolve()):
+            return candidate
+    except OSError:
+        return None
+    return None
+
+
+def contained(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except OSError:
+        return False
+
+
+def read_text_limited(path: Path) -> str:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.read(MAX_TEXT_READ_BYTES)
+
+
+def load_json_file(path: Path):
+    try:
+        if path.stat().st_size > MAX_JSON_BYTES:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def parse_frontmatter(path: Path) -> dict[str, str]:
     """Tolerant YAML-ish frontmatter parser: top-level `key: value` lines only."""
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = read_text_limited(path)
     except OSError:
         return {}
     lines = text.splitlines()
@@ -84,7 +124,7 @@ def parse_frontmatter(path: Path) -> dict[str, str]:
 def first_body_line(path: Path) -> str:
     """First non-empty, non-heading line after any frontmatter block."""
     try:
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = read_text_limited(path)
     except OSError:
         return ""
     lines = text.splitlines()
@@ -111,12 +151,9 @@ def make_item(name: str, description: str = "") -> dict:
 
 def load_manifest(root: Path) -> dict:
     for rel in MANIFEST_PATHS:
-        path = root / rel
-        if path.is_file():
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                continue
+        path = resolve_inside(root, rel)
+        if path and path.is_file():
+            data = load_json_file(path)
             if isinstance(data, dict):
                 return data
     return {}
@@ -131,40 +168,42 @@ def as_list(value) -> list:
 
 
 def scan_skills(root: Path, manifest: dict) -> list[dict]:
-    skill_dirs: dict[Path, None] = {}
+    skill_dirs: dict[Path, str] = {}
     for base in [root / "skills"]:
         if base.is_dir():
             for child in sorted(base.iterdir()):
-                if (child / "SKILL.md").is_file():
-                    skill_dirs[child.resolve()] = None
+                skill_md = child / "SKILL.md"
+                if skill_md.is_file() and contained(skill_md, root):
+                    skill_dirs[child.resolve()] = child.name
     for entry in as_list(manifest.get("skills")):
         if isinstance(entry, str):
-            candidate = (root / entry.lstrip("./")).resolve()
-            if (candidate / "SKILL.md").is_file():
-                skill_dirs[candidate] = None
+            candidate = resolve_inside(root, entry)
+            if candidate and (candidate / "SKILL.md").is_file() and contained(candidate / "SKILL.md", root):
+                skill_dirs.setdefault(candidate, candidate.name)
     items = []
-    for skill_dir in skill_dirs:
+    for skill_dir, dirname in skill_dirs.items():
         fm = parse_frontmatter(skill_dir / "SKILL.md")
-        items.append(make_item(fm.get("name") or skill_dir.name, fm.get("description", "")))
+        items.append(make_item(fm.get("name") or dirname, fm.get("description", "")))
     return items
 
 
 def scan_markdown_dir(root: Path, dirname: str, manifest_key: str, manifest: dict) -> list[dict]:
-    files: dict[Path, None] = {}
+    files: dict[Path, str] = {}
     base = root / dirname
     if base.is_dir():
         for path in sorted(base.rglob("*.md")):
-            files[path.resolve()] = None
+            if path.is_file() and contained(path, root):
+                files[path.resolve()] = path.stem
     for entry in as_list(manifest.get(manifest_key)):
         if isinstance(entry, str):
-            candidate = (root / entry.lstrip("./")).resolve()
-            if candidate.is_file() and candidate.suffix == ".md":
-                files[candidate] = None
+            candidate = resolve_inside(root, entry)
+            if candidate and candidate.is_file() and candidate.suffix == ".md":
+                files.setdefault(candidate, candidate.stem)
     items = []
-    for path in files:
+    for path, stem in files.items():
         fm = parse_frontmatter(path)
         description = fm.get("description") or first_body_line(path)
-        items.append(make_item(fm.get("name") or path.stem, description))
+        items.append(make_item(fm.get("name") or stem, description))
     return items
 
 
@@ -182,12 +221,9 @@ def transport_hint(config: dict) -> str:
 
 def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
     servers: dict[str, dict] = {}
-    mcp_path = root / ".mcp.json"
-    if mcp_path.is_file():
-        try:
-            data = json.loads(mcp_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            data = {}
+    mcp_path = resolve_inside(root, ".mcp.json")
+    if mcp_path and mcp_path.is_file():
+        data = load_json_file(mcp_path)
         if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
             servers.update(data["mcpServers"])
     declared = manifest.get("mcpServers")
@@ -199,16 +235,17 @@ def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
 
 def scan_hooks(root: Path, manifest: dict) -> list[dict]:
     data = None
-    hooks_path = root / "hooks" / "hooks.json"
-    if hooks_path.is_file():
-        try:
-            data = json.loads(hooks_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            data = None
+    hooks_path = resolve_inside(root, Path("hooks") / "hooks.json")
+    if hooks_path and hooks_path.is_file():
+        data = load_json_file(hooks_path)
     if data is None:
         declared = manifest.get("hooks")
         if isinstance(declared, dict):
             data = declared
+        elif isinstance(declared, str):
+            declared_path = resolve_inside(root, declared)
+            if declared_path and declared_path.is_file():
+                data = load_json_file(declared_path)
     if not isinstance(data, dict):
         return []
     hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
@@ -227,12 +264,9 @@ def scan_hooks(root: Path, manifest: dict) -> list[dict]:
 
 def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
     servers: dict[str, dict] = {}
-    lsp_path = root / ".lsp.json"
-    if lsp_path.is_file():
-        try:
-            data = json.loads(lsp_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            data = {}
+    lsp_path = resolve_inside(root, ".lsp.json")
+    if lsp_path and lsp_path.is_file():
+        data = load_json_file(lsp_path)
         if isinstance(data, dict):
             servers.update(data.get("lspServers") if isinstance(data.get("lspServers"), dict) else data)
     declared = manifest.get("lspServers")
@@ -260,44 +294,71 @@ def scan_plugin(root: Path) -> dict:
     return components
 
 
+def run_git(cmd: list[str], url: str, sha: str) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
+            f"{result.returncode}: {result.stderr.strip()}"
+        )
+
+
 def fetch_pinned(url: str, sha: str, dest: Path) -> None:
-    cmds = [
-        ["git", "init", "--quiet", str(dest)],
-        ["git", "-C", str(dest), "fetch", "--quiet", "--depth", "1", url, sha],
-        ["git", "-C", str(dest), "checkout", "--quiet", sha],
+    run_git(["git", "init", "--quiet", "--", str(dest)], url, sha)
+    fetch_cmd = [
+        "git", "-C", str(dest), "fetch", "--quiet", "--depth", "1",
+        "--end-of-options", url, sha,
     ]
-    for cmd in cmds:
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
-                f"{result.returncode}: {result.stderr.strip()}"
-            )
+    last_error: RuntimeError | None = None
+    for attempt in range(FETCH_ATTEMPTS):
+        try:
+            run_git(fetch_cmd, url, sha)
+            last_error = None
+            break
+        except RuntimeError as e:
+            last_error = e
+            if attempt < FETCH_ATTEMPTS - 1:
+                time.sleep(2 ** attempt)
+    if last_error is not None:
+        raise last_error
+    run_git(["git", "-C", str(dest), "checkout", "--quiet", "--detach", sha], url, sha)
 
 
-def resolve_source(entry: dict, repo_root: Path, tmp_root: Path) -> tuple[Path, str | None]:
+def resolve_local(repo_root: Path, path: str, name: str) -> Path:
+    resolved = resolve_inside(repo_root, path)
+    if resolved is None:
+        raise RuntimeError(f"plugin '{name}': local source path escapes the repo: {path!r}")
+    return resolved
+
+
+def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tuple[Path, str | None]:
     """Return (plugin root dir, pinned sha or None for local sources)."""
     name = entry.get("name", "<unnamed>")
     source = entry.get("source")
     if isinstance(source, str):
-        return (repo_root / source.lstrip("./")).resolve(), None
+        return resolve_local(repo_root, source, name), None
     if isinstance(source, dict):
         if source.get("source") == "url" or source.get("type") == "url":
             url = source.get("url")
             sha = source.get("sha")
-            if not url:
-                raise RuntimeError(f"plugin '{name}': url source has no url")
+            if not isinstance(url, str) or not url.startswith("https://"):
+                raise RuntimeError(f"plugin '{name}': url source must be an https:// url, got {url!r}")
             if not sha:
                 raise RuntimeError(
                     f"plugin '{name}': url source has no pinned sha. All url "
                     f"sources must pin a full commit sha (see README)."
                 )
-            dest = tmp_root / name
+            if not isinstance(sha, str) or not SHA_RE.match(sha):
+                raise RuntimeError(
+                    f"plugin '{name}': sha {sha!r} is not a 40-character "
+                    f"lowercase hex commit sha"
+                )
+            dest = tmp_root / f"plugin-{idx}"
             fetch_pinned(url, sha, dest)
             return dest, sha
         path = source.get("path")
         if isinstance(path, str):
-            return (repo_root / path.lstrip("./")).resolve(), None
+            return resolve_local(repo_root, path, name), None
     raise RuntimeError(f"plugin '{name}': unsupported source {source!r}")
 
 
@@ -306,11 +367,11 @@ def generate(repo_root: Path) -> dict:
     plugins_out: dict[str, dict] = {}
     with tempfile.TemporaryDirectory(prefix="plugin-index-") as tmp:
         tmp_root = Path(tmp)
-        for entry in catalog.get("plugins", []):
+        for idx, entry in enumerate(catalog.get("plugins", [])):
             name = entry.get("name")
             if not name:
                 raise RuntimeError("catalog entry without a name")
-            root, sha = resolve_source(entry, repo_root, tmp_root)
+            root, sha = resolve_source(entry, repo_root, tmp_root, idx)
             if not root.is_dir():
                 raise RuntimeError(f"plugin '{name}': source dir not found: {root}")
             record: dict = {}
@@ -339,8 +400,8 @@ def main() -> int:
 
     index_file = repo_root / INDEX_PATH
     if check:
-        committed = index_file.read_text(encoding="utf-8") if index_file.exists() else ""
-        if committed != output:
+        committed = index_file.read_bytes() if index_file.exists() else b""
+        if committed != output.encode("utf-8"):
             print(
                 f"ERROR: {INDEX_PATH} is out of date. "
                 f"Run `python3 scripts/generate-plugin-index.py` and commit the result.",
@@ -350,7 +411,7 @@ def main() -> int:
         print(f"Plugin index OK ({INDEX_PATH})")
         return 0
 
-    index_file.write_text(output, encoding="utf-8")
+    index_file.write_bytes(output.encode("utf-8"))
     print(f"Wrote {INDEX_PATH}")
     return 0
 

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Generate the plugin component catalog (.grok-plugin/plugin-index.json).
+
+For every entry in `.grok-plugin/marketplace.json`, this script resolves the
+plugin's source (local directories are scanned in place; url sources are
+shallow-fetched at their pinned commit sha) and records which components the
+plugin provides: skills, commands, agents, MCP servers, hooks, and LSP
+servers. Clients use this to show what a plugin contains before installing it.
+
+The output is deterministic — sorted keys, items sorted by name, no
+timestamps — so CI can regenerate it and fail on any diff.
+
+Generate:       python3 scripts/generate-plugin-index.py
+Verify (CI):    python3 scripts/generate-plugin-index.py --check
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+INDEX_PATH = Path(".grok-plugin/plugin-index.json")
+CATALOG_PATH = Path(".grok-plugin/marketplace.json")
+
+MAX_ITEMS_PER_CATEGORY = 50
+MAX_STRING_LEN = 120
+
+MANIFEST_PATHS = [
+    Path(".grok-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+]
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def clean(text: str) -> str:
+    text = CONTROL_CHARS_RE.sub("", text).strip()
+    if len(text) > MAX_STRING_LEN:
+        text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
+    return text
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    """Tolerant YAML-ish frontmatter parser: top-level `key: value` lines only."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: dict[str, str] = {}
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() in ("---", "..."):
+            break
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if re.match(r"^[|>][+-]?$", value):
+            block: list[str] = []
+            j = i + 1
+            while j < len(lines) and (lines[j].startswith((" ", "\t")) or not lines[j].strip()):
+                if lines[j].strip():
+                    block.append(lines[j].strip())
+                j += 1
+            value = " ".join(block)
+            i = j
+        else:
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            i += 1
+        fields[key] = value
+    return fields
+
+
+def first_body_line(path: Path) -> str:
+    """First non-empty, non-heading line after any frontmatter block."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    lines = text.splitlines()
+    i = 0
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() in ("---", "..."):
+                i = j + 1
+                break
+    for line in lines[i:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def make_item(name: str, description: str = "") -> dict:
+    item = {"name": clean(name)}
+    description = clean(description)
+    if description:
+        item["description"] = description
+    return item
+
+
+def load_manifest(root: Path) -> dict:
+    for rel in MANIFEST_PATHS:
+        path = root / rel
+        if path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(data, dict):
+                return data
+    return {}
+
+
+def as_list(value) -> list:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def scan_skills(root: Path, manifest: dict) -> list[dict]:
+    skill_dirs: dict[Path, None] = {}
+    for base in [root / "skills"]:
+        if base.is_dir():
+            for child in sorted(base.iterdir()):
+                if (child / "SKILL.md").is_file():
+                    skill_dirs[child.resolve()] = None
+    for entry in as_list(manifest.get("skills")):
+        if isinstance(entry, str):
+            candidate = (root / entry.lstrip("./")).resolve()
+            if (candidate / "SKILL.md").is_file():
+                skill_dirs[candidate] = None
+    items = []
+    for skill_dir in skill_dirs:
+        fm = parse_frontmatter(skill_dir / "SKILL.md")
+        items.append(make_item(fm.get("name") or skill_dir.name, fm.get("description", "")))
+    return items
+
+
+def scan_markdown_dir(root: Path, dirname: str, manifest_key: str, manifest: dict) -> list[dict]:
+    files: dict[Path, None] = {}
+    base = root / dirname
+    if base.is_dir():
+        for path in sorted(base.rglob("*.md")):
+            files[path.resolve()] = None
+    for entry in as_list(manifest.get(manifest_key)):
+        if isinstance(entry, str):
+            candidate = (root / entry.lstrip("./")).resolve()
+            if candidate.is_file() and candidate.suffix == ".md":
+                files[candidate] = None
+    items = []
+    for path in files:
+        fm = parse_frontmatter(path)
+        description = fm.get("description") or first_body_line(path)
+        items.append(make_item(fm.get("name") or path.stem, description))
+    return items
+
+
+def transport_hint(config: dict) -> str:
+    if not isinstance(config, dict):
+        return ""
+    transport = config.get("type") or config.get("transport")
+    if not transport:
+        if config.get("command"):
+            transport = "stdio"
+        elif config.get("url"):
+            transport = "http"
+    return str(transport) if transport else ""
+
+
+def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    mcp_path = root / ".mcp.json"
+    if mcp_path.is_file():
+        try:
+            data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+            servers.update(data["mcpServers"])
+    declared = manifest.get("mcpServers")
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [make_item(name, transport_hint(config)) for name, config in servers.items()]
+
+
+def scan_hooks(root: Path, manifest: dict) -> list[dict]:
+    data = None
+    hooks_path = root / "hooks" / "hooks.json"
+    if hooks_path.is_file():
+        try:
+            data = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = None
+    if data is None:
+        declared = manifest.get("hooks")
+        if isinstance(declared, dict):
+            data = declared
+    if not isinstance(data, dict):
+        return []
+    hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
+    items = []
+    for event, entries in hooks_obj.items():
+        if not isinstance(entries, list):
+            continue
+        matchers = [
+            e["matcher"]
+            for e in entries
+            if isinstance(e, dict) and isinstance(e.get("matcher"), str) and e["matcher"]
+        ]
+        items.append(make_item(event, ", ".join(matchers)))
+    return items
+
+
+def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    lsp_path = root / ".lsp.json"
+    if lsp_path.is_file():
+        try:
+            data = json.loads(lsp_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        if isinstance(data, dict):
+            servers.update(data.get("lspServers") if isinstance(data.get("lspServers"), dict) else data)
+    declared = manifest.get("lspServers")
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [make_item(name) for name, config in servers.items() if isinstance(config, dict)]
+
+
+def scan_plugin(root: Path) -> dict:
+    manifest = load_manifest(root)
+    categories = {
+        "skills": scan_skills(root, manifest),
+        "commands": scan_markdown_dir(root, "commands", "commands", manifest),
+        "agents": scan_markdown_dir(root, "agents", "agents", manifest),
+        "mcpServers": scan_mcp_servers(root, manifest),
+        "hooks": scan_hooks(root, manifest),
+        "lspServers": scan_lsp_servers(root, manifest),
+    }
+    components = {}
+    for key in sorted(categories):
+        items = sorted(categories[key], key=lambda i: i["name"])[:MAX_ITEMS_PER_CATEGORY]
+        if items:
+            components[key] = items
+    return components
+
+
+def fetch_pinned(url: str, sha: str, dest: Path) -> None:
+    cmds = [
+        ["git", "init", "--quiet", str(dest)],
+        ["git", "-C", str(dest), "fetch", "--quiet", "--depth", "1", url, sha],
+        ["git", "-C", str(dest), "checkout", "--quiet", sha],
+    ]
+    for cmd in cmds:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
+                f"{result.returncode}: {result.stderr.strip()}"
+            )
+
+
+def resolve_source(entry: dict, repo_root: Path, tmp_root: Path) -> tuple[Path, str | None]:
+    """Return (plugin root dir, pinned sha or None for local sources)."""
+    name = entry.get("name", "<unnamed>")
+    source = entry.get("source")
+    if isinstance(source, str):
+        return (repo_root / source.lstrip("./")).resolve(), None
+    if isinstance(source, dict):
+        if source.get("source") == "url" or source.get("type") == "url":
+            url = source.get("url")
+            sha = source.get("sha")
+            if not url:
+                raise RuntimeError(f"plugin '{name}': url source has no url")
+            if not sha:
+                raise RuntimeError(
+                    f"plugin '{name}': url source has no pinned sha. All url "
+                    f"sources must pin a full commit sha (see README)."
+                )
+            dest = tmp_root / name
+            fetch_pinned(url, sha, dest)
+            return dest, sha
+        path = source.get("path")
+        if isinstance(path, str):
+            return (repo_root / path.lstrip("./")).resolve(), None
+    raise RuntimeError(f"plugin '{name}': unsupported source {source!r}")
+
+
+def generate(repo_root: Path) -> dict:
+    catalog = json.loads((repo_root / CATALOG_PATH).read_text(encoding="utf-8"))
+    plugins_out: dict[str, dict] = {}
+    with tempfile.TemporaryDirectory(prefix="plugin-index-") as tmp:
+        tmp_root = Path(tmp)
+        for entry in catalog.get("plugins", []):
+            name = entry.get("name")
+            if not name:
+                raise RuntimeError("catalog entry without a name")
+            root, sha = resolve_source(entry, repo_root, tmp_root)
+            if not root.is_dir():
+                raise RuntimeError(f"plugin '{name}': source dir not found: {root}")
+            record: dict = {}
+            if sha:
+                record["sha"] = sha
+            record["components"] = scan_plugin(root)
+            plugins_out[name] = record
+    return {
+        "version": 1,
+        "plugins": {name: plugins_out[name] for name in sorted(plugins_out)},
+    }
+
+
+def render(index: dict) -> str:
+    return json.dumps(index, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    check = "--check" in sys.argv[1:]
+    repo_root = Path(__file__).resolve().parent.parent
+    try:
+        output = render(generate(repo_root))
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    index_file = repo_root / INDEX_PATH
+    if check:
+        committed = index_file.read_text(encoding="utf-8") if index_file.exists() else ""
+        if committed != output:
+            print(
+                f"ERROR: {INDEX_PATH} is out of date. "
+                f"Run `python3 scripts/generate-plugin-index.py` and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"Plugin index OK ({INDEX_PATH})")
+        return 0
+
+    index_file.write_text(output, encoding="utf-8")
+    print(f"Wrote {INDEX_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -58,7 +58,7 @@ def resolve_inside(root: Path, relative) -> Path | None:
         candidate = (root / relative).resolve()
         if candidate.is_relative_to(root.resolve()):
             return candidate
-    except OSError:
+    except (OSError, ValueError):
         return None
     return None
 
@@ -66,7 +66,7 @@ def resolve_inside(root: Path, relative) -> Path | None:
 def contained(path: Path, root: Path) -> bool:
     try:
         return path.resolve().is_relative_to(root.resolve())
-    except OSError:
+    except (OSError, ValueError):
         return False
 
 


### PR DESCRIPTION
## Demo
<img width="530" height="524" alt="image" src="https://github.com/user-attachments/assets/fe4bcb2d-1b16-4d3e-bb98-271ecdd5e05c" />


## What

Adds `.grok-plugin/plugin-index.json`, a generated catalog of what each plugin provides (skills, commands, agents, MCP servers, hooks, LSP servers), so clients can show plugin contents before install.

- `scripts/generate-plugin-index.py` — generates the index from `.grok-plugin/marketplace.json`. Local sources are scanned in place; `url` sources are shallow-fetched at their pinned commit `sha` (a url source without a pinned sha fails generation). Supports `--check` for CI.
- CI — `validate-catalog.yml` now re-runs the generator in `--check` mode on PRs and pushes to main, failing if the committed index is stale.
- README — documents the file, that it is generated (never hand-edit), and the regenerate command.

## Index contract

```json
{
  "version": 1,
  "plugins": {
    "<entry name>": {
      "sha": "<pinned sha, url sources only>",
      "components": {
        "skills": [{"name": "...", "description": "..."}],
        "commands": [], "agents": [], "mcpServers": [], "hooks": [], "lspServers": []
      }
    }
  }
}
```

- `description` is optional per item; empty categories are omitted.
- Hooks use the event name, with the matcher (if any) as description. MCP servers come from the plugin's `.mcp.json` (or manifest), with a short transport hint as description.
- Strings are capped at 120 chars and each category at 50 items, matching client-side limits.
- For url sources, clients only trust index data when its `sha` matches the catalog entry's pinned `source.sha`.
- Output is deterministic (sorted plugins, items sorted by name, no timestamps), so regeneration is byte-stable and CI can diff it.

## Verification

- Ran the generator twice: byte-identical output; `--check` passes.
- Spot-checked the `superpowers` entry against upstream at its pinned sha: 14 skills + `SessionStart` hook with `startup|clear|compact` matcher match exactly.