### PR TITLE
Add Airhug plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -80,6 +80,19 @@
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
       "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
       "domains": ["mongodb.com", "cloud.mongodb.com"]
+    },
+    {
+      "name": "airhug",
+      "description": "Control Airhug companies from Grok Build using the public Airhug MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mitchellbernstein/bot-host.git",
+        "sha": "6cfae8d2a00e4d4d2b5a69ecc0e2007c75872e1c"
+      },
+      "homepage": "https://airhug.ai",
+      "keywords": ["airhug", "company", "agents", "mcp", "startup"],
+      "domains": ["airhug.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,43 @@
 {
   "version": 1,
   "plugins": {
+    "airhug": {
+      "sha": "6cfae8d2a00e4d4d2b5a69ecc0e2007c75872e1c",
+      "components": {
+        "agents": [
+          {
+            "name": "airhug-operator",
+            "description": "Airhug operations helper for inspecting workspace status, coordinating goals, resolving blockers, and keeping company e…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "airhug-create-company",
+            "description": "Create or update an Airhug company and optionally launch execution."
+          },
+          {
+            "name": "airhug-resolve-blocker",
+            "description": "List and resolve Airhug blockers by approving, denying, pausing, or answering a question."
+          },
+          {
+            "name": "airhug-status",
+            "description": "Show the current Airhug company status, active initiatives, blockers, daily pace, and agent work."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "airhug",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "airhug-company-control",
+            "description": "Control an Airhug company from Grok Build. Use when the user wants to create a company, check Airhug status, start goal…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {


### PR DESCRIPTION
## Summary\n- Add Airhug as a Grok Build marketplace plugin\n- Pin the plugin source to mitchellbernstein/bot-host@e218512188b7a20d667c5a048f0c6d622859f2b7\n- Regenerate the component index so Grok can show the Airhug skill, commands, agent, and MCP server before install\n\n## Validation\n- python3 scripts/generate-plugin-index.py\n- python3 scripts/validate-catalog.py\n\n## Plugin\nThe Airhug plugin connects Grok Build to the public Airhug MCP server at https://airhug.ai/mcp using Airhug OAuth.