### PR TITLE
Add Dynamo governance plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,30 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "dynamo",
+      "description": "Governance oracle with solar ingestion, neural resonance, Kuramoto coupling, and temporal vortex anchoring. Submit any proposal and receive a verdict informed by 7D resonance analysis, solar activity, and moral overlay. Includes 20 MCP tools and VortexToken NFT minting on Base.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/htafolla/chrono-warp-drive.git",
+        "sha": "a94e8a71af891ca0e89ec073d20b7fe842137f07"
+      },
+      "homepage": "https://dynamo.rippel.ai",
+      "keywords": [
+        "dynamo",
+        "governance",
+        "resonance",
+        "solar",
+        "temporal",
+        "vortex",
+        "kuramoto"
+      ],
+      "domains": [
+        "mcp-production-80e2.up.railway.app",
+        "dynamo.rippel.ai"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,41 @@
         ]
       }
     },
+    "dynamo": {
+      "sha": "a94e8a71af891ca0e89ec073d20b7fe842137f07",
+      "components": {
+        "commands": [
+          {
+            "name": "dynamo-explain",
+            "description": "Explain a governance output, resonance score, or temporal field term."
+          },
+          {
+            "name": "dynamo-govern",
+            "description": "Submit a proposal to Dynamo for a governance verdict informed by neural resonance and solar activity."
+          },
+          {
+            "name": "dynamo-vortex",
+            "description": "Query the Vortex token system — total supply, container statuses, or individual token/container data."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "dynamo",
+            "description": "http"
+          },
+          {
+            "name": "dynamo-neural",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "dynamo-governance",
+            "description": "Use Dynamo to get AI-powered governance verdicts on proposals, informed by real-time solar activity, neural resonance a…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## Summary

Adds the **Dynamo** governance oracle plugin to the marketplace — submit any proposal and receive a verdict informed by 7D neural resonance, solar activity, and moral overlay.

## What users can do

- **Submit proposals** via `/dynamo:govern` — get PASS / NEEDS_REVISION / FAIL verdicts with resonance scores and solar context
- **Browse the Vortex** at https://dynamo.rippel.ai/vortex — all proposals displayed as interactive cards sorted by rarity tier (Celestial, Resonant, Unstable, Dissonant)
- **Save to Chain** — persist a proposal to the Base on-chain registry, making it mintable
- **Mint as an NFT on Base** — mint a VortexToken (ERC-721) for any registry-backed container, anchoring the proposal + verdict + 7D resonance profile permanently on-chain
- **View 7D profiles** — each token has wave proximity, phase alignment, calibrated vortex, neural resonance, and Trinitarium Moral Overlay (TMO)
- **Query on-chain status** — `/dynamo:vortex info` shows total supply, donations, treasury

The mint flow is two-step: **Offchain → Save to Chain → Mintable → Mint → Minted (NFT on Base)**. The frontend shows the current state with appropriate actions for each step.

## Components

- **2 HTTP MCP servers** — `dynamo` (governance + vortex) and `dynamo-neural` (neural fusion pipeline)
- **3 slash commands** — `/dynamo:govern`, `/dynamo:vortex`, `/dynamo:explain`
- **Governance skill** — step-by-step guidance for proposals, resonance analysis, and vortex operations
- **Live frontend** at [dynamo.rippel.ai](https://dynamo.rippel.ai/vortex)

## Verification

- SHA pinned to `2af8b1a66ed0889846d83956ec5dd63088e70a2f`
- Plugin index regenerated with `generate-plugin-index.py`
- Plugin repo: https://github.com/htafolla/chrono-warp-drive
- MCP endpoint: `mcp-production-80e2.up.railway.app`

## Category

`development` — governance oracle and temporal analysis tools