### PR TITLE
Add Axiom skills plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -80,6 +80,19 @@
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
       "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
       "domains": ["mongodb.com", "cloud.mongodb.com"]
+    },
+    {
+      "name": "axiom",
+      "description": "Axiom observability skills for incident response, log investigation, and production debugging. Includes hypothesis-driven SRE investigation with APL queries, dashboards, alerting, metrics, and cost optimization.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/axiomhq/skills.git",
+        "sha": "76f5af39bdf47b62acb8c36c1dd9fdc404919438"
+      },
+      "homepage": "https://github.com/axiomhq/skills",
+      "keywords": ["axiom", "axiom-sre", "sre", "incident", "observability", "apl", "logs", "debugging"],
+      "domains": ["axiom.co", "app.axiom.co"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -84,7 +84,7 @@
     {
       "name": "axiom",
       "description": "Axiom observability skills for incident response, log investigation, and production debugging. Includes hypothesis-driven SRE investigation with APL queries, dashboards, alerting, metrics, and cost optimization.",
-      "category": "monitoring",
+      "category": "observability",
       "source": {
         "source": "url",
         "url": "https://github.com/axiomhq/skills.git",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,41 @@
 {
   "version": 1,
   "plugins": {
+    "axiom": {
+      "sha": "76f5af39bdf47b62acb8c36c1dd9fdc404919438",
+      "components": {
+        "skills": [
+          {
+            "name": "axiom-alerting",
+            "description": "Create and manage Axiom monitors and notifiers via the v2 public API. Use when building alerting, routing notifications…"
+          },
+          {
+            "name": "axiom-sre",
+            "description": "Expert SRE investigator for incidents and debugging. Uses hypothesis-driven methodology and systematic triage. Can quer…"
+          },
+          {
+            "name": "building-dashboards",
+            "description": "Designs and builds Axiom dashboards via API. Covers chart types, APL and metrics/MPL query patterns, SmartFilters, layo…"
+          },
+          {
+            "name": "controlling-costs",
+            "description": "Analyzes Axiom query patterns to find unused data, then builds dashboards and monitors for cost optimization. Use when…"
+          },
+          {
+            "name": "query-metrics",
+            "description": "Runs metrics queries against Axiom MetricsDB via scripts. Discovers available metrics, tags, and tag values. Use when a…"
+          },
+          {
+            "name": "spl-to-apl",
+            "description": "Translates Splunk SPL queries to Axiom APL. Provides command mappings, function equivalents, and syntax transformations…"
+          },
+          {
+            "name": "writing-evals",
+            "description": "Scaffolds evaluation suites for the Axiom AI SDK. Generates eval files, scorers, flag schemas, and config from natural-…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {


### PR DESCRIPTION
## Summary

Adds [axiomhq/skills](https://github.com/axiomhq/skills) to the official Grok plugin marketplace as a remote plugin pinned to commit `76f5af39bdf47b62acb8c36c1dd9fdc404919438`.

The plugin bundles Axiom observability skills, including:

- **axiom-sre** — hypothesis-driven incident response, root cause analysis, and production debugging with APL queries
- axiom-alerting — monitor and notifier management
- building-dashboards — dashboard design and API workflows
- query-metrics — MetricsDB discovery and queries
- controlling-costs — query pattern analysis and cost optimization
- spl-to-apl — Splunk SPL to Axiom APL translation
- writing-evals — Axiom AI SDK evaluation scaffolding

## Test plan

- [x] `python3 scripts/validate-catalog.py`
- [x] `python3 scripts/generate-plugin-index.py --check`