### PR TITLE
Add woodstock-mcp plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -80,6 +80,15 @@
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
       "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
       "domains": ["mongodb.com", "cloud.mongodb.com"]
+    },
+    {
+      "name": "woodstock-mcp",
+      "description": "Woodstock stock-trading platform integration (remote MCP server). Check your portfolio, balances, and orders, fetch US market data and fundamentals, and place trades on Woodstock — the Japanese app for trading US stocks in JPY.",
+      "category": "finance",
+      "source": { "type": "local", "path": "./external_plugins/woodstock-mcp" },
+      "homepage": "https://woodstock.co",
+      "keywords": ["woodstock", "woodstock mcp", "us stocks", "stock trading", "japanese stocks app"],
+      "domains": ["woodstock.co"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -517,6 +517,16 @@
           }
         ]
       }
+    },
+    "woodstock-mcp": {
+      "components": {
+        "mcpServers": [
+          {
+            "name": "woodstock",
+            "description": "http"
+          }
+        ]
+      }
     }
   }
 }

--- a/external_plugins/woodstock-mcp/.mcp.json
+++ b/external_plugins/woodstock-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "woodstock": {
+      "type": "http",
+      "url": "https://mcp.app.woodstock.co/mcp"
+    }
+  }
+}

--- a/external_plugins/woodstock-mcp/README.md
+++ b/external_plugins/woodstock-mcp/README.md
@@ -1,0 +1,21 @@
+# Woodstock MCP
+
+Connect to [Woodstock](https://woodstock.co), the Japanese stock-trading service for buying US stocks in JPY (fractional shares supported), over the Model Context Protocol.
+
+This plugin configures the hosted Woodstock MCP server at `https://mcp.app.woodstock.co/mcp` (streamable HTTP). On first use you authenticate with your Woodstock account via OAuth; no API keys are required.
+
+## What you can do
+
+- **Account & funds** — account info, deposit/withdraw history, withdrawal availability, virtual bank details for deposits, estimated US wallet balance. All monetary values are JPY-denominated.
+- **Portfolio** — held assets, individual positions by ticker, dividend history.
+- **Orders & trading** — list and inspect orders, pre-check and place market/limit orders (by quantity or notional amount), cancel orders, view executions.
+- **Market data** — US market status and holidays, real-time quotes/trades/snapshots, historical bars, previous close, tradable-symbol checks, and company fundamentals.
+
+## Notes
+
+- A Woodstock account is required. Trading tools operate on your real account — pre-check tools (`check_order`, `check_cancel_order`) let an agent validate before committing.
+- All monetary fields are JPY even for US-stock data; tool descriptions call this out explicitly.
+
+## Links
+
+- Homepage: https://woodstock.co

--- a/external_plugins/woodstock-mcp/plugin.json
+++ b/external_plugins/woodstock-mcp/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "woodstock-mcp",
+  "version": "1.0.0",
+  "description": "Woodstock stock-trading platform integration (remote MCP server). Check your portfolio, balances, and orders, fetch US market data and fundamentals, and place trades on Woodstock — the Japanese app for trading US stocks in JPY.",
+  "author": {
+    "name": "Woodstock",
+    "url": "https://woodstock.co"
+  },
+  "homepage": "https://woodstock.co"
+}


### PR DESCRIPTION
## Summary

Adds **Woodstock MCP** as a third-party plugin, vendored under `external_plugins/woodstock-mcp/` with a local catalog source, following the conventions in the README.

[Woodstock](https://woodstock.co) is a Japanese stock-trading service for buying US stocks in JPY (fractional shares supported). The plugin ships an `.mcp.json` that connects to our hosted remote MCP server:

- **Endpoint:** `https://mcp.app.woodstock.co/mcp` (streamable HTTP)
- **Auth:** OAuth (authorization code + PKCE) against the user's Woodstock account — no API keys; the 401 challenge advertises the OAuth metadata for client-driven sign-in
- **Tools:** account & funds (balances, deposit/withdraw info), portfolio & dividends, order management (pre-check, place, cancel market/limit orders), US market status & holidays, real-time and historical market data, and company fundamentals

## Changes

- `external_plugins/woodstock-mcp/` — `.mcp.json`, `plugin.json`, `README.md`
- `.grok-plugin/marketplace.json` — catalog entry (`source: { type: local }`, category `finance`)
- `.grok-plugin/plugin-index.json` — regenerated with `python3 scripts/generate-plugin-index.py`

## Validation

- `python3 scripts/generate-plugin-index.py` — index committed, `--check` clean
- `python3 scripts/validate-catalog.py` — Catalog OK
- Endpoint verified live: `/status` returns 200; `/mcp` returns 401 with OAuth challenge when unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)