### PR TITLE
Add ablo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,42 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
+    },
+    {
+      "name": "ablo",
+      "description": "Official plugin for Ablo \u2014 The Collaboration Layer For AI Agents. Skills for SDK setup, schema definition, guarded writes, and multi-agent coordination (claims) on shared state in your own Postgres, plus Ablo's hosted docs MCP server.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/abloatai/plugin.git",
+        "sha": "416433d1469d33532da773b04e525140763a05fa"
+      },
+      "homepage": "https://docs.abloatai.com",
+      "keywords": [
+        "ablo",
+        "agents",
+        "multi-agent",
+        "coordination",
+        "claims",
+        "shared-state",
+        "postgres",
+        "realtime"
+      ],
+      "domains": [
+        "abloatai.com",
+        "docs.abloatai.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -119,7 +119,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/abloatai/plugin.git",
-        "sha": "416433d1469d33532da773b04e525140763a05fa"
+        "sha": "ff11911d3c5ab605dbd0b38a75a9f3214826c5fc"
       },
       "homepage": "https://docs.abloatai.com",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,41 @@
 {
   "version": 1,
   "plugins": {
+    "ablo": {
+      "sha": "416433d1469d33532da773b04e525140763a05fa",
+      "components": {
+        "commands": [
+          {
+            "name": "status",
+            "description": "Check Ablo auth, mode, project, and server health, and diagnose common setup problems"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "ablo-docs",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ablo-coordination",
+            "description": "Coordinate multiple agents and humans writing the same rows with Ablo claims — FIFO leases via `await using`, presence…"
+          },
+          {
+            "name": "ablo-schema",
+            "description": "Define and evolve an Ablo schema with defineSchema/model, push it with `ablo push`, provision tables with `ablo migrate…"
+          },
+          {
+            "name": "ablo-setup",
+            "description": "Set up the Ablo SDK (@abloatai/ablo) in a project — install, scaffold with `ablo init`, authenticate with API keys, pus…"
+          },
+          {
+            "name": "ablo-writes",
+            "description": "Read and write rows through the typed ablo.<model> resource surface — retrieve, list, create, update, delete with idemp…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "ablo": {
-      "sha": "416433d1469d33532da773b04e525140763a05fa",
+      "sha": "ff11911d3c5ab605dbd0b38a75a9f3214826c5fc",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
## Summary

Adds [abloatai/plugin](https://github.com/abloatai/plugin) to the marketplace as a remote plugin pinned to commit `416433d1469d33532da773b04e525140763a05fa`.

[Ablo](https://docs.abloatai.com) is a shared state layer for AI agents: humans, server code, and agents read and write the same typed models in your own Postgres. Writes fan out live to every connected client, and claims serialize writers on the same row so agents don't overwrite each other.

The plugin bundles:

- **ablo-setup** — install the SDK, scaffold a project, authenticate, push a schema, and provision tables
- **ablo-schema** — define and evolve schemas, migrations, and adopting existing tables
- **ablo-writes** — the typed model API with idempotency keys and stale-write protection
- **ablo-coordination** — claims for multi-agent writes: FIFO leases, presence, and conflict handling
- **/ablo:status** — check auth, mode, and server health
- Ablo's hosted docs MCP server (public, no auth)

`generate-plugin-index.py` and `validate-catalog.py` both pass locally.