### PR TITLE
Add decks plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,41 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
+    },
+    {
+      "name": "ablo-decks",
+      "description": "Official Ablo Decks plugin \u2014 create and edit slide decks with AI. Connects Ablo's deck MCP server so an agent can build presentations directly: slides, layers, themes, layouts, AI image generation, and a screenshot review loop, with every change landing live in the editor.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/abloatai/decks-plugin.git",
+        "sha": "888daf29197cbadf52dff8bb2d23c745455a8d62"
+      },
+      "homepage": "https://www.tryablo.com",
+      "keywords": [
+        "ablo",
+        "slides",
+        "decks",
+        "presentations",
+        "pitch-deck",
+        "slide-deck",
+        "ai-slides"
+      ],
+      "domains": [
+        "tryablo.com",
+        "www.tryablo.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,23 @@
 {
   "version": 1,
   "plugins": {
+    "ablo-decks": {
+      "sha": "888daf29197cbadf52dff8bb2d23c745455a8d62",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "ablo-decks",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ablo-decks",
+            "description": "Create and edit slide decks in Ablo through the deck MCP server — run code in the slide sandbox, generate images, apply…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {


### PR DESCRIPTION
## Summary

Adds [abloatai/decks-plugin](https://github.com/abloatai/decks-plugin) to the marketplace as a remote plugin pinned to commit `888daf29197cbadf52dff8bb2d23c745455a8d62`.

[Ablo](https://www.tryablo.com) is an AI-powered presentation editor. The plugin connects Ablo's hosted deck MCP server (OAuth on first use, no API keys) so an agent can build and edit slide decks directly: slides, layers, themes, layouts, and AI image generation, with a screenshot review loop for design quality. Changes commit through Ablo's sync engine and appear live in the open editor.

The plugin bundles:

- **ablo-decks** — the full workflow skill: get the deck from its link, the execute_code slide sandbox and deck.* API, mandatory screenshot review checkpoints, themes, layouts, image generation
- The deck MCP server (execute_code, get_slide_screenshot, get_guide, memory)

This is the consumer counterpart to the ablo developer plugin (#26) — separate plugin since the audiences, categories, and auth models differ.

`generate-plugin-index.py` and `validate-catalog.py` both pass locally.