### PR TITLE
Add Firecrawl plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "firecrawl",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — browser-OAuth sign-in, no API key to paste. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
+        "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
+      },
+      "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
+      "keywords": ["firecrawl", "fire crawl"],
+      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -95,7 +95,7 @@
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — browser-OAuth sign-in, no API key to paste. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,65 @@
         ]
       }
     },
+    "firecrawl": {
+      "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
+      "components": {
+        "commands": [
+          {
+            "name": "skill-gen",
+            "description": "Generate a complete Agent Skill from a documentation URL using Firecrawl"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "firecrawl",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "firecrawl",
+            "description": "Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the w…"
+          },
+          {
+            "name": "firecrawl-agent",
+            "description": "AI-powered autonomous data extraction that navigates complex sites and returns structured JSON. Use this skill when the…"
+          },
+          {
+            "name": "firecrawl-crawl",
+            "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac…"
+          },
+          {
+            "name": "firecrawl-download",
+            "description": "Download an entire website as local files — markdown, screenshots, or multiple formats per page. Use this skill when th…"
+          },
+          {
+            "name": "firecrawl-interact",
+            "description": "Control and interact with a live browser session on any scraped page — click buttons, fill forms, navigate flows, and e…"
+          },
+          {
+            "name": "firecrawl-map",
+            "description": "Discover and list all URLs on a website, with optional search filtering. Use this skill when the user wants to find a s…"
+          },
+          {
+            "name": "firecrawl-monitor",
+            "description": "Detect when content on a website changes and get notified by webhook or email — no cron jobs, scrapers, or diff scripts…"
+          },
+          {
+            "name": "firecrawl-parse",
+            "description": "Efficiently extract and convert the contents of any local file—such as PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, or HTML—int…"
+          },
+          {
+            "name": "firecrawl-scrape",
+            "description": "Extract clean markdown from any URL, including JavaScript-rendered SPAs. Use this skill whenever the user provides a UR…"
+          },
+          {
+            "name": "firecrawl-search",
+            "description": "Web search with full page content extraction. Use this skill whenever the user asks to search the web, find articles, r…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## Summary

Adds **Firecrawl** to the marketplace — turn any website into clean, LLM-ready markdown or structured data: search, scrape, map, crawl, and extract live web data, with automatic JS rendering, anti-bot handling, and proxy rotation. Fills a current gap (no web-data plugin in the catalog yet); category `development`.

## How it works

- **Source:** `url` pin to [`firecrawl/firecrawl-grok-plugin`](https://github.com/firecrawl/firecrawl-grok-plugin) at a full commit SHA, same shape as the existing entries.
- **Primary path — hosted MCP:** the plugin bundles Firecrawl's hosted MCP server (`https://mcp.firecrawl.dev/v2/mcp`, `type: "http"`). Auth is browser OAuth on first use — no API key to paste. Indexed with transport `http`.
- **Fallback — CLI skills:** 10 skills (search, scrape, map, crawl, agent, interact, monitor, parse, download, plus the core CLI skill) and a `/skill-gen` command, used when the MCP isn't connected or for local-file workflows the hosted server can't do.

## Changes

- `.grok-plugin/marketplace.json` — Firecrawl catalog entry (url source + SHA, homepage, keywords, domains).
- `.grok-plugin/plugin-index.json` — regenerated; records the MCP server, 10 skills, and the `skill-gen` command.

## Validation

```
python3 scripts/validate-catalog.py             # Catalog OK
python3 scripts/generate-plugin-index.py --check # Plugin index OK
```

Both pass — the same two steps CI runs. The pinned MCP endpoint responds with a proper OAuth challenge (`401` + `WWW-Authenticate: Bearer` → `.well-known/oauth-protected-resource`), confirming the browser-OAuth flow.