### PR TITLE
Add Resend plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/resend/resend-skills.git",
-        "sha": "233618f8de2d11fbfcb1736f51efffa53dfca39f"
+        "sha": "2caefffaf938c3c4ed539d5b29e3cd2bd2555bbe"
       },
       "homepage": "https://github.com/resend/resend-skills",
       "keywords": ["resend", "email", "send email", "react email"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,19 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "resend",
+      "description": "Resend email platform integration. Send transactional and batch email, receive inbound email securely, build React Email templates, run the Resend CLI, and follow deliverability best practices — directly from Grok.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/resend/resend-skills.git",
+        "sha": "233618f8de2d11fbfcb1736f51efffa53dfca39f"
+      },
+      "homepage": "https://github.com/resend/resend-skills",
+      "keywords": ["resend", "email", "send email", "react email"],
+      "domains": ["resend.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -331,6 +331,39 @@
         ]
       }
     },
+    "resend": {
+      "sha": "233618f8de2d11fbfcb1736f51efffa53dfca39f",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "resend",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agent-email-inbox",
+            "description": "Use when building any system where email content triggers actions — AI agent inboxes, automated support handlers, email…"
+          },
+          {
+            "name": "email-best-practices",
+            "description": "Use when building email features, emails going to spam, high bounce rates, setting up SPF/DKIM/DMARC authentication, im…"
+          },
+          {
+            "name": "react-email",
+            "description": "Use when building HTML email templates with React components, adding a visual email editor to an application using the…"
+          },
+          {
+            "name": "resend",
+            "description": "Use when working with the Resend email API — sending transactional emails (single or batch), receiving inbound emails v…"
+          },
+          {
+            "name": "resend-cli",
+            "description": "Operate the Resend platform from the terminal — send emails (including React Email .tsx templates via --react-email), m…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -332,7 +332,7 @@
       }
     },
     "resend": {
-      "sha": "233618f8de2d11fbfcb1736f51efffa53dfca39f",
+      "sha": "2caefffaf938c3c4ed539d5b29e3cd2bd2555bbe",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What

Adds the official [Resend](https://resend.com) plugin to the catalog as a remote source, pinned to commit `2caefffaf938c3c4ed539d5b29e3cd2bd2555bbe` of [resend/resend-skills](https://github.com/resend/resend-skills).

`resend-skills` is Resend's multi-platform plugin repo (Claude Code, Cursor, Codex, and Grok via `.grok-plugin/`) over one shared, auto-synced `skills/` directory — so the Grok listing stays current with the same source the other ecosystems use.

## What the plugin provides

5 skills plus the Resend MCP server:

- `resend` — the Resend email API: sending (single and batch), receiving via webhooks, templates, domains, contacts, broadcasts, webhooks, API keys, logs, automations, and events
- `agent-email-inbox` — secure inbound email workflows for AI agents: webhook setup, sender allowlists, content filtering, and safe processing of untrusted email
- `resend-cli` — operate Resend from the terminal, scripts, and CI/CD with the `resend` CLI
- `react-email` — build HTML email templates with React components, render them, and send with Resend
- `email-best-practices` — deliverability (SPF/DKIM/DMARC), compliance (CAN-SPAM, GDPR, CASL), retries, list management, and transactional vs marketing decisions
- `resend` MCP server — tool access to the Resend API, authenticated via OAuth (sign-in on first connect; no API key or header configuration needed)

## Checklist

- [x] `python3 scripts/generate-plugin-index.py` — index regenerated, 5 skills + MCP server discovered
- [x] `python3 scripts/validate-catalog.py` — Catalog OK
- [x] `python3 scripts/generate-plugin-index.py --check` — index up to date
- [x] Full 40-character commit SHA pinned