### PR TITLE
Index MCP servers declared via manifest path string

### DIFF
--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -112,6 +112,12 @@
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {
+        "mcpServers": [
+          {
+            "name": "mongodb",
+            "description": "stdio"
+          }
+        ],
         "skills": [
           {
             "name": "mongodb-atlas-stream-processing",

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -221,12 +221,13 @@ def transport_hint(config: dict) -> str:
 
 def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
     servers: dict[str, dict] = {}
-    mcp_path = resolve_inside(root, ".mcp.json")
+    declared = manifest.get("mcpServers")
+    config_rel = declared if isinstance(declared, str) else ".mcp.json"
+    mcp_path = resolve_inside(root, config_rel)
     if mcp_path and mcp_path.is_file():
         data = load_json_file(mcp_path)
         if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
             servers.update(data["mcpServers"])
-    declared = manifest.get("mcpServers")
     if isinstance(declared, dict):
         for name, config in declared.items():
             servers.setdefault(name, config)


### PR DESCRIPTION
## Problem

The marketplace catalog summary for `mongodb` shows `7 skills` with no mention of its MCP server, even though the plugin ships one (it appears in the MCP Servers tab after install).

The mongodb plugin declares its MCP config as a **path string** in `.claude-plugin/plugin.json`:

```json
"mcpServers": "./mcp.json"
```

pointing at root-level `mcp.json` (no leading dot). `scan_mcp_servers` in `generate-plugin-index.py` only read `.mcp.json` at the plugin root and inline manifest dicts, so the path-string form was silently dropped from `plugin-index.json`. The Grok Build runtime *does* resolve the path form (`mcp_config_path` in `xai-grok-agent`), hence the post-install discrepancy.

## Fix

Mirror the runtime's resolution in the generator:
- manifest `mcpServers` is a **string** → read that file (contained within the plugin root)
- **inline dict** → read default `.mcp.json` and append inline entries (file wins on name collision)
- **absent** → default `.mcp.json`

Regenerated `plugin-index.json`: only the mongodb entry changes, gaining its MCP server.

```
"mcpServers": [{ "name": "mongodb", "description": "stdio" }]
```

Verified `python3 scripts/generate-plugin-index.py --check` passes.