### PR TITLE
Add xpntl connector

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,18 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "xpntl",
+      "description": "xpntl — the coordination layer for human + AI engineering teams. Read and create issues, comment and @-mention, move work across workflow states and cycles, manage projects, labels, and workspace docs, and check your agent inbox. Connects over OAuth (no key needed).",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/xpntl"
+      },
+      "homepage": "https://xpntl.dev",
+      "keywords": ["xpntl", "issue tracker", "project management", "kanban", "agent board"],
+      "domains": ["xpntl.dev", "app.xpntl.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -547,6 +547,16 @@
           }
         ]
       }
+    },
+    "xpntl": {
+      "components": {
+        "mcpServers": [
+          {
+            "name": "xpntl",
+            "description": "http"
+          }
+        ]
+      }
     }
   }
 }

--- a/external_plugins/xpntl/.grok-plugin/plugin.json
+++ b/external_plugins/xpntl/.grok-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "xpntl",
+  "version": "1.0.0",
+  "description": "Connect Grok to xpntl — the coordination layer for human + AI engineering teams. Read and create issues, comment and @-mention, move work across workflow states and cycles, manage projects, labels, and workspace docs, and check your agent inbox.",
+  "author": {
+    "name": "xpntl",
+    "url": "https://xpntl.dev"
+  },
+  "homepage": "https://xpntl.dev",
+  "repository": "https://github.com/xpntl/xpntl",
+  "license": "BSL-1.1",
+  "keywords": ["xpntl", "issue tracker", "project management", "mcp", "agents", "kanban"],
+  "logo": "assets/logo.svg"
+}

--- a/external_plugins/xpntl/.mcp.json
+++ b/external_plugins/xpntl/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "xpntl": {
+      "type": "http",
+      "url": "https://api.xpntl.dev/mcp"
+    }
+  }
+}

--- a/external_plugins/xpntl/assets/logo.svg
+++ b/external_plugins/xpntl/assets/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="64" height="64" fill="none">
+  <rect width="16" height="16" rx="0.6" ry="0.6" fill="#F3CB00"></rect>
+  <path d="M 3 12 L 13.3 11.2 L 13.3 3.2 C 10.7 9.8, 6.7 12, 3 12 Z" fill="#BC9200"></path>
+  <line x1="3" y1="12" x2="13.3" y2="11.2" stroke="#4E3413" stroke-width="1.2" stroke-dasharray="0 1.5" stroke-linecap="round"></line>
+  <path d="M 3 12 C 6.7 12, 10.7 9.8, 13.3 3.2" stroke="#180F09" stroke-width="1.5" stroke-linecap="square" fill="none"></path>
+</svg>


### PR DESCRIPTION
## Summary
Adds **xpntl** as a third-party connector. xpntl is the coordination layer for human + AI engineering teams — a source-available issue tracker / project board with a full **MCP** surface so Grok can read and create issues, comment and @-mention, move work across workflow states and cycles, and manage projects, labels, and workspace docs.

## What's included (`external_plugins/xpntl/`)
- **`.mcp.json`** — remote MCP server at `https://api.xpntl.dev/mcp` (Streamable HTTP). Connects over **OAuth 2.1** (no key to copy); harness keys are also supported for headless use.
- **`.grok-plugin/plugin.json`** — manifest + brand logo (`assets/logo.svg`).
- Catalog entry appended to **`.grok-plugin/marketplace.json`** (local source, `./external_plugins/xpntl`).
- Regenerated **`.grok-plugin/plugin-index.json`**.

## Validation
- `python3 scripts/validate-catalog.py` → Catalog OK
- `python3 scripts/generate-plugin-index.py --check` → Plugin index OK

Homepage: https://xpntl.dev · Docs: https://xpntl.dev/docs/mcp