### PR TITLE
Add conversiontools plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -95,12 +95,12 @@
     },
     {
       "name": "conversiontools",
-      "description": "Convert files between 140+ formats from your terminal, or build a custom converter from a plain-language description when no standard one fits. Documents (Word, Excel, PowerPoint, PDF), data formats (JSON, CSV, XML, YAML, Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. CLI + MCP server, powered by Conversion Tools.",
+      "description": "Convert files between 140+ formats from your terminal, or build a custom converter from a plain-language description (and re-run it on new files) when no standard one fits. Documents (Word, Excel, PowerPoint, PDF), data formats (JSON, CSV, XML, YAML, Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. CLI + MCP server, powered by Conversion Tools.",
       "category": "data",
       "source": {
         "source": "url",
         "url": "https://github.com/conversiontools/agent-skills.git",
-        "sha": "00dff1dfd7bac19e21a472f610dbdb792147143a"
+        "sha": "8eb96f7277f8d1e2d007c8ccbf646dc26077db99"
       },
       "homepage": "https://conversiontools.io/docs/agents",
       "keywords": ["conversiontools", "convert", "file conversion", "xml to excel", "json to excel", "pdf to excel", "pdf to json", "ocr", "ai extraction"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "conversiontools",
+      "description": "Convert files between 140+ formats from your terminal. Documents (Word, Excel, PowerPoint, PDF), data formats (JSON, CSV, XML, YAML, Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. CLI + MCP server, powered by the ConversionTools.io API.",
+      "category": "data",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/conversiontools/agent-skills.git",
+        "sha": "e0d74fd6be3ef534591bce07dc5d56c714763ebf"
+      },
+      "homepage": "https://conversiontools.io/docs/agents",
+      "keywords": ["conversiontools", "convert", "file conversion", "xml to excel", "json to excel", "pdf to excel", "pdf to json", "ocr", "ai extraction"],
+      "domains": ["conversiontools.io"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -95,12 +95,12 @@
     },
     {
       "name": "conversiontools",
-      "description": "Convert files between 140+ formats from your terminal. Documents (Word, Excel, PowerPoint, PDF), data formats (JSON, CSV, XML, YAML, Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. CLI + MCP server, powered by the ConversionTools.io API.",
+      "description": "Convert files between 140+ formats from your terminal, or build a custom converter from a plain-language description when no standard one fits. Documents (Word, Excel, PowerPoint, PDF), data formats (JSON, CSV, XML, YAML, Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. CLI + MCP server, powered by Conversion Tools.",
       "category": "data",
       "source": {
         "source": "url",
         "url": "https://github.com/conversiontools/agent-skills.git",
-        "sha": "8765c9995ba106a0ad03c6e2573b7461453ff4c1"
+        "sha": "00dff1dfd7bac19e21a472f610dbdb792147143a"
       },
       "homepage": "https://conversiontools.io/docs/agents",
       "keywords": ["conversiontools", "convert", "file conversion", "xml to excel", "json to excel", "pdf to excel", "pdf to json", "ocr", "ai extraction"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -100,7 +100,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/conversiontools/agent-skills.git",
-        "sha": "e0d74fd6be3ef534591bce07dc5d56c714763ebf"
+        "sha": "8765c9995ba106a0ad03c6e2573b7461453ff4c1"
       },
       "homepage": "https://conversiontools.io/docs/agents",
       "keywords": ["conversiontools", "convert", "file conversion", "xml to excel", "json to excel", "pdf to excel", "pdf to json", "ocr", "ai extraction"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,23 @@
         ]
       }
     },
+    "conversiontools": {
+      "sha": "e0d74fd6be3ef534591bce07dc5d56c714763ebf",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "conversiontools",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "convert",
+            "description": "Convert files between 140+ formats using Conversion Tools. Two surfaces are available - the `ctio` CLI (preferred when…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -110,7 +110,7 @@
       }
     },
     "conversiontools": {
-      "sha": "8765c9995ba106a0ad03c6e2573b7461453ff4c1",
+      "sha": "00dff1dfd7bac19e21a472f610dbdb792147143a",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -110,7 +110,7 @@
       }
     },
     "conversiontools": {
-      "sha": "e0d74fd6be3ef534591bce07dc5d56c714763ebf",
+      "sha": "8765c9995ba106a0ad03c6e2573b7461453ff4c1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -110,7 +110,7 @@
       }
     },
     "conversiontools": {
-      "sha": "00dff1dfd7bac19e21a472f610dbdb792147143a",
+      "sha": "8eb96f7277f8d1e2d007c8ccbf646dc26077db99",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
Adds the **Conversion Tools** plugin (third-party, remote source) to the catalog.

Convert files between 140+ formats from your terminal - documents, data formats (incl. Parquet), images, audio, video, e-books, OCR, AI-powered data extraction, text-to-speech, and speech-to-text. Bundles a hosted MCP server plus the `ctio` CLI.

- **Source:** `https://github.com/conversiontools/agent-skills.git` pinned to `e0d74fd6be3ef534591bce07dc5d56c714763ebf`
- Same flat plugin layout as the existing `mongodb` entry (shared `skills/` + `mcp.json`; Grok reads the `.claude-plugin/` directory)
- `scripts/validate-catalog.py` -> `Catalog OK` and `scripts/generate-plugin-index.py` both pass locally (plugin-index.json regenerated and included)
- Docs: https://conversiontools.io/docs/agents