### PR TITLE
Add browser-harness plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -100,7 +100,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/browser-use/browser-harness.git",
-        "sha": "f20e4aae79af6de3bd76bc352240d60675929424"
+        "sha": "b33fced546fe8154ba67be2db38ad96bbb904a20"
       },
       "homepage": "https://github.com/browser-use/browser-harness",
       "keywords": ["browser", "browser-use", "automation", "cdp", "chrome", "scraping", "screenshot"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "browser-harness",
+      "description": "Direct CDP browser control for coding agents: coordinate clicks, screenshots, a persistent Python session, and bulk HTTP — driving the user's real Chrome or a Browser Use cloud browser. Ships skills only; the browser-harness CLI is a one-time install prerequisite.",
+      "category": "automation",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/browser-use/browser-harness.git",
+        "sha": "f20e4aae79af6de3bd76bc352240d60675929424"
+      },
+      "homepage": "https://github.com/browser-use/browser-harness",
+      "keywords": ["browser", "browser-use", "automation", "cdp", "chrome", "scraping", "screenshot"],
+      "domains": ["browser-use.com", "docs.browser-use.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "plugins": {
+    "browser-harness": {
+      "sha": "f20e4aae79af6de3bd76bc352240d60675929424",
+      "components": {
+        "skills": [
+          {
+            "name": "browser-harness",
+            "description": "Direct browser control via CDP — automate, scrape, test, or interact with web pages by driving the user's already-runni…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "browser-harness": {
-      "sha": "f20e4aae79af6de3bd76bc352240d60675929424",
+      "sha": "b33fced546fe8154ba67be2db38ad96bbb904a20",
       "components": {
         "skills": [
           {


### PR DESCRIPTION
Adds **browser-harness** — direct CDP browser control for coding agents.

## What it does
Drives the user's real Chrome (or a Browser Use cloud browser) over the Chrome DevTools Protocol: coordinate clicks, screenshots, a persistent Python session, bulk HTTP, and raw CDP. The design default is *screenshot → read pixel → coordinate-click*, so hit-testing passes through iframes / shadow DOM / cross-origin without selector hunting.

## Catalog entry
- **Source:** remote, `github.com/browser-use/browser-harness`, pinned to a full 40-char commit SHA (`f20e4aa`).
- **Components:** skills only. The `browser-harness` CLI is a one-time install prerequisite (documented in the skill's `references/install.md`), following the chrome-devtools-cli pattern — plugins don't ship binaries.

## Validation
```
python3 scripts/validate-catalog.py        # Catalog OK
python3 scripts/generate-plugin-index.py   # regenerated
python3 scripts/generate-plugin-index.py --check   # Plugin index OK (not stale)
```
`plugin-index.json` is included and regenerated from the pinned source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)