### PR TITLE
Add base44 plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "base44",
+      "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/base44/skills.git",
+        "sha": "aef0fa35f21b3c0c000d5ab8c0b068e6188618b6"
+      },
+      "homepage": "https://docs.base44.com",
+      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
+      "domains": ["base44.com", "docs.base44.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -100,7 +100,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/base44/skills.git",
-        "sha": "aef0fa35f21b3c0c000d5ab8c0b068e6188618b6"
+        "sha": "7b301e25d0952235c985bb159ca71cc520f27bcf"
       },
       "homepage": "https://docs.base44.com",
       "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -75,7 +75,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/base44/skills.git",
-        "sha": "7b301e25d0952235c985bb159ca71cc520f27bcf"
+        "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
       "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,25 @@
 {
   "version": 1,
   "plugins": {
+    "base44": {
+      "sha": "aef0fa35f21b3c0c000d5ab8c0b068e6188618b6",
+      "components": {
+        "skills": [
+          {
+            "name": "base44-cli",
+            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
+          },
+          {
+            "name": "base44-sdk",
+            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r…"
+          },
+          {
+            "name": "base44-troubleshooter",
+            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "base44": {
-      "sha": "aef0fa35f21b3c0c000d5ab8c0b068e6188618b6",
+      "sha": "7b301e25d0952235c985bb159ca71cc520f27bcf",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -44,13 +44,21 @@
       }
     },
     "base44": {
-      "sha": "7b301e25d0952235c985bb159ca71cc520f27bcf",
+      "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
       "version": "1.0.0-beta.1",
       "components": {
         "skills": [
           {
             "name": "base44-cli",
             "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
+          },
+          {
+            "name": "base44-remote-dev",
+            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t…"
+          },
+          {
+            "name": "base44-sandbox",
+            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent — no local checkout and no deploy/push…"
           },
           {
             "name": "base44-sdk",


### PR DESCRIPTION
## What

Adds the **base44** plugin to the marketplace catalog as a remote source.

| Field | Value |
|---|---|
| Source | [base44/skills](https://github.com/base44/skills) (`url`) |
| Pinned SHA | `aef0fa35f21b3c0c000d5ab8c0b068e6188618b6` |
| Category | `development` |
| Components | 3 skills (`base44-cli`, `base44-sdk`, `base44-troubleshooter`); no MCP server |

## Details

Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills. The catalog entry's `description` and `homepage` mirror the upstream repo's canonical `plugin.json` metadata. Keywords are natural-language search phrases consistent with existing entries (`neon`, `mongodb`). No `(MCP Server + Skills)` marker, since the plugin ships skills only (consistent with `cloudflare`/`superpowers`).

## Validation

- `python3 scripts/validate-catalog.py` → **Catalog OK**
- `python3 scripts/generate-plugin-index.py --check` → **Plugin index OK**

`.grok-plugin/plugin-index.json` regenerated; captured the 3 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)