### PR TITLE
Add display.dev plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -100,7 +100,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/display-dev/skill.git",
-        "sha": "bd2aa88e059c07f321acbac183f027c41f333a07"
+        "sha": "909fd7c0e6016b5a490d1dbdbebc7ef142595952"
       },
       "homepage": "https://display.dev/docs/skill",
       "keywords": ["display.dev", "publish html", "publish markdown", "share artifact", "share behind sso", "company auth", "private link"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "display-dev",
+      "description": "Publish HTML and Markdown artifacts as shareable URLs behind company auth, public sharing, or private links.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/display-dev/skill.git",
+        "sha": "bd2aa88e059c07f321acbac183f027c41f333a07"
+      },
+      "homepage": "https://display.dev/docs/skill",
+      "keywords": ["display.dev", "publish html", "publish markdown", "share artifact", "share behind sso", "company auth", "private link"],
+      "domains": ["display.dev", "dsp.so"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -110,7 +110,7 @@
       }
     },
     "display-dev": {
-      "sha": "bd2aa88e059c07f321acbac183f027c41f333a07",
+      "sha": "909fd7c0e6016b5a490d1dbdbebc7ef142595952",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,17 @@
         ]
       }
     },
+    "display-dev": {
+      "sha": "bd2aa88e059c07f321acbac183f027c41f333a07",
+      "components": {
+        "skills": [
+          {
+            "name": "display-dev",
+            "description": "Publishes HTML or Markdown files as shareable URLs on display.dev — behind company authentication, with specific email…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
Adds the **display-dev** plugin: publish HTML and Markdown artifacts as shareable display.dev URLs behind company auth, public sharing, private links, or email access.

- **Source:** remote, `github.com/display-dev/skill`, pinned to full commit SHA `909fd7c0e6016b5a490d1dbdbebc7ef142595952`.
- **Category:** `development`
- **Contents:** 1 skill — `display-dev`, for publishing HTML/Markdown artifacts via display.dev. No deployment, build, or CI behavior.

### Why remote

The upstream repo already exposes root plugin metadata via `.claude-plugin/plugin.json` and the Grok-indexed skill at `skills/display-dev/SKILL.md`, so no vendored copy is needed.

### Validation

- `python3 scripts/generate-plugin-index.py` → regenerated `.grok-plugin/plugin-index.json`
- `python3 scripts/generate-plugin-index.py --check` → Plugin index OK
- `python3 scripts/validate-catalog.py` → Catalog OK

### Smoke

Installed directly in Grok Build before marketplace submission:

```bash
grok plugin install display-dev/skill --trust
```

Confirmed Grok loaded the plugin-installed `display-dev` skill and published a public display.dev smoke artifact via the skill's `publish.sh` helper, without running a deployment/build workflow.

Smoke artifact: https://display.dsp.so/ktVDosyH-grok-display-dev-smoke

