### PR TITLE
Add skill-vetter (Solid State): vet a third-party skill before you run it

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/solidstatecc/skill-vetter.git",
-        "sha": "49cfbe7d0dc324ac68d2ae73ab37cba2316fdfbf"
+        "sha": "ce49a31811414612d0091ef96c31ea6c7d914392"
       },
       "homepage": "https://solidstate.cc",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "neon",
@@ -90,8 +121,40 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
+    },
+    {
+      "name": "skill-vetter",
+      "description": "Vet a third-party agent skill before you install or run it: provenance, license, pinning, and dangerous capabilities (shell, network, secrets, file writes), with a RUN / REVIEW / DO NOT RUN verdict. Read-only.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/solidstatecc/skill-vetter.git",
+        "sha": "49cfbe7d0dc324ac68d2ae73ab37cba2316fdfbf"
+      },
+      "homepage": "https://solidstate.cc",
+      "keywords": [
+        "skill-vetter",
+        "vet",
+        "audit",
+        "provenance",
+        "supply chain",
+        "security",
+        "skills"
+      ],
+      "domains": [
+        "solidstate.cc"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/solidstatecc/skill-provenance.git",
-        "sha": "eb6197b6a2bce9724c1f291ec28e3f8e9a43b3ab"
+        "sha": "2fbfa34797a4c9ad21b8f94d6ef93e2d93987cf9"
       },
       "homepage": "https://solidstate.cc",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -134,13 +134,13 @@
       ]
     },
     {
-      "name": "skill-vetter",
+      "name": "skill-provenance",
       "description": "Vet a third-party agent skill before you install or run it: provenance, license, pinning, and dangerous capabilities (shell, network, secrets, file writes), with a RUN / REVIEW / DO NOT RUN verdict. Read-only.",
       "category": "security",
       "source": {
         "source": "url",
-        "url": "https://github.com/solidstatecc/skill-vetter.git",
-        "sha": "ce49a31811414612d0091ef96c31ea6c7d914392"
+        "url": "https://github.com/solidstatecc/skill-provenance.git",
+        "sha": "eb6197b6a2bce9724c1f291ec28e3f8e9a43b3ab"
       },
       "homepage": "https://solidstate.cc",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -313,6 +313,23 @@
         ]
       }
     },
+    "skill-vetter": {
+      "sha": "49cfbe7d0dc324ac68d2ae73ab37cba2316fdfbf",
+      "components": {
+        "commands": [
+          {
+            "name": "vet",
+            "description": "Vet a third-party skill before you install it — provenance, license, pinning, capabilities. Returns RUN / REVIEW / DO N…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "skill-vetter",
+            "description": "Vet a third-party agent skill BEFORE you install or run it. Reads the skill and reports provenance, license, pinning, a…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -314,7 +314,7 @@
       }
     },
     "skill-provenance": {
-      "sha": "eb6197b6a2bce9724c1f291ec28e3f8e9a43b3ab",
+      "sha": "2fbfa34797a4c9ad21b8f94d6ef93e2d93987cf9",
       "components": {
         "commands": [
           {
@@ -325,7 +325,7 @@
         "skills": [
           {
             "name": "skill-provenance",
-            "description": "Vet a third-party agent skill BEFORE you install or run it. Reads the skill and reports provenance, license, pinning, a…"
+            "description": "Vet a third-party agent skill BEFORE you install or run it. Reads the skill and reports provenance, license, hidden or…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -313,8 +313,8 @@
         ]
       }
     },
-    "skill-vetter": {
-      "sha": "ce49a31811414612d0091ef96c31ea6c7d914392",
+    "skill-provenance": {
+      "sha": "eb6197b6a2bce9724c1f291ec28e3f8e9a43b3ab",
       "components": {
         "commands": [
           {
@@ -324,7 +324,7 @@
         ],
         "skills": [
           {
-            "name": "skill-vetter",
+            "name": "skill-provenance",
             "description": "Vet a third-party agent skill BEFORE you install or run it. Reads the skill and reports provenance, license, pinning, a…"
           }
         ]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -314,7 +314,7 @@
       }
     },
     "skill-vetter": {
-      "sha": "49cfbe7d0dc324ac68d2ae73ab37cba2316fdfbf",
+      "sha": "ce49a31811414612d0091ef96c31ea6c7d914392",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
Read-only plugin that vets a third-party agent skill before you install or run it — provenance, license, SHA-pinning, and dangerous capabilities (shell, network, secrets, file writes) — returns RUN / REVIEW / DO NOT RUN. Source: github.com/solidstatecc/skill-vetter pinned to 49cfbe7d0dc324ac68d2ae73ab37cba2316fdfbf. Applies the same SHA-pinned, verify-before-you-run principle the catalog enforces, to skills themselves. — Solid State (solidstate.cc)