### PR TITLE
Add spacex-daily-briefing (Solid State)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "neon",
@@ -90,8 +121,54 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
+    },
+    {
+      "name": "spacex-daily-briefing",
+      "description": "Daily intelligence briefing on SpaceX / SPCX (post-IPO; includes the merged xAI/Grok + X). Live X + web search, a price-moving lens, sourced and dated. Read-only; informational only, not financial advice.",
+      "category": "research",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/solidstatecc/spacex-daily-briefing.git",
+        "sha": "1cee0bbda46e1bfddf4723ea16dd1baca42a6457"
+      },
+      "homepage": "https://solidstate.cc/skills/spacex-daily-briefing",
+      "keywords": [
+        "spacex",
+        "spcx",
+        "starlink",
+        "grok",
+        "xai",
+        "investing",
+        "briefing",
+        "research"
+      ],
+      "domains": [
+        "spacex.com",
+        "nasdaq.com",
+        "x.ai"
+      ],
+      "version": "1.2.0",
+      "author": {
+        "name": "Solid State",
+        "url": "https://solidstate.cc"
+      },
+      "tags": [
+        "spacex",
+        "spcx",
+        "investing",
+        "research"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/solidstatecc/spacex-daily-briefing.git",
-        "sha": "1cee0bbda46e1bfddf4723ea16dd1baca42a6457"
+        "sha": "58ebe80ea9dab1e10cba7c3ad5b9125cf2b7f5fa"
       },
       "homepage": "https://solidstate.cc/skills/spacex-daily-briefing",
       "keywords": [
@@ -158,7 +158,7 @@
         "nasdaq.com",
         "x.ai"
       ],
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Solid State",
         "url": "https://solidstate.cc"

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -313,6 +313,23 @@
         ]
       }
     },
+    "spacex-daily-briefing": {
+      "sha": "1cee0bbda46e1bfddf4723ea16dd1baca42a6457",
+      "components": {
+        "commands": [
+          {
+            "name": "spacex-brief",
+            "description": "Generate today's SpaceX / SPCX investor briefing — live X + web search, price-moving lens, tiered output. Optional argu…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "spacex-daily-briefing",
+            "description": "Generate a daily, investor-grade intelligence briefing on SpaceX — now public as SPCX on Nasdaq (IPO June 12, 2026) and…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -314,7 +314,7 @@
       }
     },
     "spacex-daily-briefing": {
-      "sha": "1cee0bbda46e1bfddf4723ea16dd1baca42a6457",
+      "sha": "58ebe80ea9dab1e10cba7c3ad5b9125cf2b7f5fa",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
Submitting to the open catalog. `spacex-daily-briefing` is a **read-only** daily intelligence briefing on SpaceX / SPCX — the post-IPO entity, which now includes **xAI/Grok and X** after the Feb 2026 merger. It drives Grok's live X + web search, applies a price-moving lens, cites every figure, and is explicitly **informational — not financial advice**. Free, MIT, SHA-pinned to solidstatecc/spacex-daily-briefing.

This is a research/finance plugin rather than dev-infra — flagging in case that's outside the catalog's intended scope. Happy to adjust the category/framing or withdraw if you'd prefer the catalog stay dev-focused. — Solid State (solidstate.cc)