### PR TITLE
Add CodeRifts API governance plugin (MCP server + skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "base44",
@@ -78,8 +100,17 @@
         "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
-      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
-      "domains": ["base44.com", "docs.base44.com"]
+      "keywords": [
+        "base44",
+        "base44 cli",
+        "base44 sdk",
+        "base44 app",
+        "base44 deploy"
+      ],
+      "domains": [
+        "base44.com",
+        "docs.base44.com"
+      ]
     },
     {
       "name": "mongodb",
@@ -92,8 +123,16 @@
         "path": "plugins/mongodb"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
-      "domains": ["mongodb.com"]
+      "keywords": [
+        "mongodb community",
+        "mongo",
+        "mongosh",
+        "mongodb local mcp",
+        "enterprise advanced"
+      ],
+      "domains": [
+        "mongodb.com"
+      ]
     },
     {
       "name": "mongodb-atlas",
@@ -106,8 +145,17 @@
         "path": "plugins/mongodb-atlas"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb atlas",
+        "atlas",
+        "mongodb",
+        "atlas cluster",
+        "atlas mcp"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -119,8 +167,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -131,8 +184,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "wix",
@@ -144,8 +206,18 @@
         "sha": "abff05613bf82101095a96b43b033150bfd8e145"
       },
       "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
-      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
+      "keywords": [
+        "wix",
+        "wix cli",
+        "wix mcp",
+        "wix apps",
+        "wix headless"
+      ],
+      "domains": [
+        "wix.com",
+        "dev.wix.com",
+        "manage.wix.com"
+      ]
     },
     {
       "name": "netlify",
@@ -157,8 +229,15 @@
         "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
       },
       "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
-      "domains": ["netlify.com", "app.netlify.com"]
+      "keywords": [
+        "netlify",
+        "netlify deploy",
+        "deploy to netlify"
+      ],
+      "domains": [
+        "netlify.com",
+        "app.netlify.com"
+      ]
     },
     {
       "name": "firecrawl",
@@ -170,8 +249,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -183,8 +268,14 @@
         "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -196,8 +287,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -209,8 +308,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -223,8 +331,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -237,8 +352,18 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
@@ -251,8 +376,17 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
     },
     {
       "name": "pstack",
@@ -265,7 +399,35 @@
         "path": "pstack"
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": ["pstack", "poteto-mode", "poteto"]
+      "keywords": [
+        "pstack",
+        "poteto-mode",
+        "poteto"
+      ]
+    },
+    {
+      "name": "coderifts",
+      "description": "CodeRifts API governance for agents (MCP Server + Skill). Three tools: preflight_change_set returns an ALLOW/WARN/REQUIRE_APPROVAL/BLOCK decision plus execution_action for a base→head contract change set (OpenAPI, GraphQL, gRPC, AsyncAPI, MCP manifest, agent tool schemas) and can mint an Ed25519-signed chain receipt; verify_receipt checks a receipt you already hold, offline-verifiable, for authenticity and current authorization; get_decision_details retrieves a past decision by id. Use before a tool call, merge, deploy, or publish.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/coderifts"
+      },
+      "homepage": "https://coderifts.com",
+      "keywords": [
+        "coderifts",
+        "api governance",
+        "breaking change",
+        "openapi diff",
+        "contract safety",
+        "api contract",
+        "signed receipt",
+        "agent safety"
+      ],
+      "domains": [
+        "coderifts.com",
+        "app.coderifts.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,22 @@
         ]
       }
     },
+    "coderifts": {
+      "components": {
+        "mcpServers": [
+          {
+            "name": "coderifts",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "api-governance",
+            "description": "Use before merging or shipping any API or tool-contract change. Runs CodeRifts preflight on OpenAPI specs and MCP manif…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -192,7 +192,7 @@
         "skills": [
           {
             "name": "api-governance",
-            "description": "Use before merging or shipping any API or tool-contract change. Runs CodeRifts preflight on OpenAPI specs and MCP manif…"
+            "description": "Before merging or shipping any API or tool-contract change: preflight the change set, then branch on execution_action."
           }
         ]
       }

--- a/external_plugins/coderifts/.mcp.json
+++ b/external_plugins/coderifts/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "coderifts": {
+      "type": "http",
+      "url": "https://app.coderifts.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CODERIFTS_API_KEY}"
+      }
+    }
+  }
+}

--- a/external_plugins/coderifts/skills/api-governance/SKILL.md
+++ b/external_plugins/coderifts/skills/api-governance/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: api-governance
+description: Use before merging or shipping any API or tool-contract change. Runs CodeRifts preflight on OpenAPI specs and MCP manifests to detect breaking changes, score blast radius and agent impact, and return an ALLOW/WARN/REQUIRE_APPROVAL/BLOCK decision. Trigger when a PR touches an API spec, when endpoints or fields are renamed, removed, or made required, or when an MCP or agent tool schema changes.
+---
+
+# CodeRifts API Governance
+
+CodeRifts checks API and tool-contract changes for safety before they reach production. It answers not just what changed, but how dangerous it is, who it affects, and whether deployment should be blocked.
+
+## When to use
+
+Run a CodeRifts check whenever a change could alter an API contract:
+
+- A pull request modifies an OpenAPI or Swagger spec.
+- Endpoints or fields are renamed, removed, or made required.
+- Request or response schemas, status codes, or auth scopes change.
+- An MCP manifest or agent tool schema changes.
+- Before connecting an agent to an external API whose spec just changed.
+
+## Tools
+
+The coderifts MCP server exposes:
+
+- preflight_check - diff two OpenAPI specs (before, after); returns risk score, blast radius, agent impact, and a merge decision.
+- agent_tool_check - detect changes that break agent tool calling.
+- mcp_diff - compare two MCP manifests for breaking tool-schema changes.
+- agent_readiness_score - score a spec or manifest (0-100) for agent readiness.
+- governance_health - A-F governance grade for a spec.
+- agent_preflight, registry_validate, traffic_analyze - workflow, registry, and traffic-based checks.
+
+## Decision protocol
+
+Every check returns one decision, always in the same shape:
+
+- ALLOW - safe to merge.
+- WARN - non-breaking but worth noting.
+- REQUIRE_APPROVAL - risky; get a human sign-off.
+- BLOCK - breaking change; do not merge without remediation.
+
+On REQUIRE_APPROVAL or BLOCK, surface the detected patterns and blast radius to the user, and suggest the safer path (deprecate-then-remove, additive change, versioning) rather than shipping the break.
+
+## Setup
+
+Authentication uses a CodeRifts API key. Set CODERIFTS_API_KEY in your environment (get a key at https://coderifts.com). Discovery (initialize, tools/list) works without a key; running a check requires one.

--- a/external_plugins/coderifts/skills/api-governance/SKILL.md
+++ b/external_plugins/coderifts/skills/api-governance/SKILL.md
@@ -19,26 +19,55 @@ Run a CodeRifts check whenever a change could alter an API contract:
 
 ## Tools
 
-The coderifts MCP server exposes:
+The coderifts MCP server (`https://app.coderifts.com/mcp`) exposes exactly three tools
+(from live `tools/list` — do not invent others):
 
-- preflight_check - diff two OpenAPI specs (before, after); returns risk score, blast radius, agent impact, and a merge decision.
-- agent_tool_check - detect changes that break agent tool calling.
-- mcp_diff - compare two MCP manifests for breaking tool-schema changes.
-- agent_readiness_score - score a spec or manifest (0-100) for agent readiness.
-- governance_health - A-F governance grade for a spec.
-- agent_preflight, registry_validate, traffic_analyze - workflow, registry, and traffic-based checks.
+- **preflight_change_set** — Preflight a complete base→head change set of contract
+  artifacts. Returns risk score and breaking-change analysis. With
+  `preflight_mode: "authorize"` (and `context.operation`), also returns a governance
+  decision (ALLOW / WARN / REQUIRE_APPROVAL / BLOCK) and may mint a signed chain-receipt.
+  With `preflight_mode: "analyze"`, returns informational risk only (`analysis_outcome`,
+  `may_execute: false`, no decision, no receipt). Requires `artifacts` and
+  `preflight_mode`. Artifact types include OpenAPI/Swagger, GraphQL SDL, gRPC/protobuf,
+  AsyncAPI, MCP manifest, and agent tool schemas. Use for a **new** decision on the
+  **current** pending change set — not to re-check an existing receipt (use
+  `verify_receipt`) or look up a past `decision_id` (use `get_decision_details`).
+
+- **verify_receipt** — Verify a signed chain-receipt you **already hold**: signature
+  authenticity, body binding, and (when lifecycle indices are available) whether it is
+  currently authorized for a stated operation/target (not expired, superseded, or
+  revoked). Requires `token`. Optional: `operation`, `target_id`, `environment`,
+  `fingerprint`, `audience`, `decision_result`. Branch on `currently_authorized`
+  (bool or null when not evaluated). Does **not** re-diff specs or re-issue a decision.
+
+- **get_decision_details** — Retrieve a **past** decision by `decision_id` (preferred)
+  or `fingerprint`: stored report, breaking changes, scores, and linked receipt metadata
+  if present. For explaining or auditing a prior ALLOW/WARN/BLOCK — not for a new
+  analysis of current before/after specs (use `preflight_change_set`).
 
 ## Decision protocol
 
-Every check returns one decision, always in the same shape:
+On the **authorize** path of `preflight_change_set`, every successful check returns one
+decision in a consistent shape:
 
-- ALLOW - safe to merge.
-- WARN - non-breaking but worth noting.
-- REQUIRE_APPROVAL - risky; get a human sign-off.
-- BLOCK - breaking change; do not merge without remediation.
+- ALLOW — safe to merge / proceed under the stated operation.
+- WARN — non-breaking but worth noting.
+- REQUIRE_APPROVAL — risky; get a human sign-off.
+- BLOCK — breaking change; do not merge without remediation.
 
-On REQUIRE_APPROVAL or BLOCK, surface the detected patterns and blast radius to the user, and suggest the safer path (deprecate-then-remove, additive change, versioning) rather than shipping the break.
+The companion control signal is `execution_action` (CONTINUE / CONTINUE_WITH_MONITORING /
+REQUEST_APPROVAL / STOP). Prefer branching on `execution_action` when present; an
+unrecognized value is not permission.
+
+On REQUIRE_APPROVAL or BLOCK, surface the detected patterns and blast radius to the user,
+and suggest the safer path (deprecate-then-remove, additive change, versioning) rather
+than shipping the break.
+
+Analyze mode (`preflight_mode: "analyze"`) does **not** return that decision vocabulary —
+it is informational only (`may_execute: false`, no receipt).
 
 ## Setup
 
-Authentication uses a CodeRifts API key. Set CODERIFTS_API_KEY in your environment (get a key at https://coderifts.com). Discovery (initialize, tools/list) works without a key; running a check requires one.
+Authentication uses a CodeRifts API key. Set `CODERIFTS_API_KEY` in your environment
+(get a key at https://coderifts.com). Discovery (`initialize`, `tools/list`) works without
+a key; running tools that need authorization requires one.

--- a/external_plugins/coderifts/skills/api-governance/SKILL.md
+++ b/external_plugins/coderifts/skills/api-governance/SKILL.md
@@ -1,73 +1,50 @@
 ---
 name: api-governance
-description: Use before merging or shipping any API or tool-contract change. Runs CodeRifts preflight on OpenAPI specs and MCP manifests to detect breaking changes, score blast radius and agent impact, and return an ALLOW/WARN/REQUIRE_APPROVAL/BLOCK decision. Trigger when a PR touches an API spec, when endpoints or fields are renamed, removed, or made required, or when an MCP or agent tool schema changes.
+description: Before merging or shipping any API or tool-contract change: preflight the change set, then branch on execution_action.
 ---
 
 # CodeRifts API Governance
 
-CodeRifts checks API and tool-contract changes for safety before they reach production. It answers not just what changed, but how dangerous it is, who it affects, and whether deployment should be blocked.
+<!-- GENERATED from CodeRifts agent-host-rule (single source). Do not edit rule sentences by hand; run: node scripts/generate-agent-host-files.js -->
 
-## When to use
+Call `preflight_change_set` before merge, deploy, publish, or tool registration when a contract artifact changed (OpenAPI/Swagger, GraphQL, gRPC/protobuf, AsyncAPI, MCP manifest, or agent tool schemas).
 
-Run a CodeRifts check whenever a change could alter an API contract:
+Send the complete base-to-head change set: every changed contract artifact with full before and after content. Do not send a single-file subset when other contract files also change.
 
-- A pull request modifies an OpenAPI or Swagger spec.
-- Endpoints or fields are renamed, removed, or made required.
-- Request or response schemas, status codes, or auth scopes change.
-- An MCP manifest or agent tool schema changes.
-- Before connecting an agent to an external API whose spec just changed.
+Branch on `execution_action` only. Do not branch on `decision` and do not branch on `safe_for_agent` (not_for_control_flow_use_execution_action). Canonical `execution_action` values: CONTINUE, CONTINUE_WITH_MONITORING, REQUEST_APPROVAL, STOP.
 
-## Tools
+An unrecognised `execution_action` is not permission: fail closed (halt or re-preflight). Well-known code: `not_permission_fail_closed`.
 
-The coderifts MCP server (`https://app.coderifts.com/mcp`) exposes exactly three tools
-(from live `tools/list` — do not invent others):
+When `execution_action` is REQUEST_APPROVAL or STOP, surface the detected patterns and the blast radius, and propose the safer path — deprecate-then-remove, an additive change, or a new version — rather than shipping the break.
 
-- **preflight_change_set** — Preflight a complete base→head change set of contract
-  artifacts. Returns risk score and breaking-change analysis. With
-  `preflight_mode: "authorize"` (and `context.operation`), also returns a governance
-  decision (ALLOW / WARN / REQUIRE_APPROVAL / BLOCK) and may mint a signed chain-receipt.
-  With `preflight_mode: "analyze"`, returns informational risk only (`analysis_outcome`,
-  `may_execute: false`, no decision, no receipt). Requires `artifacts` and
-  `preflight_mode`. Artifact types include OpenAPI/Swagger, GraphQL SDL, gRPC/protobuf,
-  AsyncAPI, MCP manifest, and agent tool schemas. Use for a **new** decision on the
-  **current** pending change set — not to re-check an existing receipt (use
-  `verify_receipt`) or look up a past `decision_id` (use `get_decision_details`).
+`CONTINUE_WITH_MONITORING` requires a wired monitoring sink (`monitoringSinkWired`). It is not "proceed with caution" without monitoring.
 
-- **verify_receipt** — Verify a signed chain-receipt you **already hold**: signature
-  authenticity, body binding, and (when lifecycle indices are available) whether it is
-  currently authorized for a stated operation/target (not expired, superseded, or
-  revoked). Requires `token`. Optional: `operation`, `target_id`, `environment`,
-  `fingerprint`, `audience`, `decision_result`. Branch on `currently_authorized`
-  (bool or null when not evaluated). Does **not** re-diff specs or re-issue a decision.
+Do not call CodeRifts tools for a documentation-only change (README, guides, comments) with no contract artifact content change.
 
-- **get_decision_details** — Retrieve a **past** decision by `decision_id` (preferred)
-  or `fingerprint`: stored report, breaking changes, scores, and linked receipt metadata
-  if present. For explaining or auditing a prior ALLOW/WARN/BLOCK — not for a new
-  analysis of current before/after specs (use `preflight_change_set`).
+If you already hold a chain receipt and only need authenticity/lifecycle: `verify_receipt`. If you need a past decision by id: `get_decision_details`. Neither replaces preflight for a new change set.
 
-## Decision protocol
+The CodeRifts MCP server exposes exactly three tools — `preflight_change_set`, `verify_receipt`, `get_decision_details`. Do not invent or assume others.
 
-On the **authorize** path of `preflight_change_set`, every successful check returns one
-decision in a consistent shape:
+A receipt authorizes ONE operation: a merge receipt does not authorize a deploy. Before a different operation (deploy, publish), call `preflight_change_set` with `context.operation` set to that operation — reusing a differently-scoped receipt is not permitted and will fail at the gate.
 
-- ALLOW — safe to merge / proceed under the stated operation.
-- WARN — non-breaking but worth noting.
-- REQUIRE_APPROVAL — risky; get a human sign-off.
-- BLOCK — breaking change; do not merge without remediation.
+A stale or superseded receipt on a changed head requires a NEW preflight — `verify_receipt` cannot re-diff.
 
-The companion control signal is `execution_action` (CONTINUE / CONTINUE_WITH_MONITORING /
-REQUEST_APPROVAL / STOP). Prefer branching on `execution_action` when present; an
-unrecognized value is not permission.
+For mutating tools, put only the guarded version in the agent's tool table; keep the raw handler host-only and unreachable from that table. How you name tools is yours — this is a reachability property, not a product rename of host tools. CodeRifts cannot see or stop a raw call the host makes outside the table it returns; adopt this as a host convention, not as a guarantee from the package.
 
-On REQUIRE_APPROVAL or BLOCK, surface the detected patterns and blast radius to the user,
-and suggest the safer path (deprecate-then-remove, additive change, versioning) rather
-than shipping the break.
+CodeRifts reports a governance decision and `execution_action`; it does not by itself block merges. Blocking requires separate repository configuration (required status checks, enforcement) that this rule file does not set.
 
-Analyze mode (`preflight_mode: "analyze"`) does **not** return that decision vocabulary —
-it is informational only (`may_execute: false`, no receipt).
+To act (mutate a contract, merge, deploy, or publish): call `preflight_change_set` with `preflight_mode` authorize. Analyze is informational (`may_execute` is always false) and is not permission. Read `execution_action` on the `decision_result` envelope.
 
-## Setup
+Before acting under a held receipt: call `verify_receipt` with the intended `context` (operation, environment, repository, branch, pull_request) for THIS attempt. Do not act on a receipt whose scope does not match.
 
-Authentication uses a CodeRifts API key. Set `CODERIFTS_API_KEY` in your environment
-(get a key at https://coderifts.com). Discovery (`initialize`, `tools/list`) works without
-a key; running tools that need authorization requires one.
+Act only when `currently_authorized` is true (`control_envelope.receipt_view.currently_authorized`). A valid-looking token is not permission if `currently_authorized` is false or omitted.
+
+Commit / CAS evidence is a separate measurement (`commit_observation` on GuardOutcome). It is not a substitute for authorize + `currently_authorized`. Production hosts that want the fail-closed conjunction lock it with `profile: ENFORCING_STRICT` on withCodeRifts.
+
+If the host requests an execution grant (opt-in `include_execution_grant`), the grant is bound to operation + target + after-payload (`scope_hash`) and is short-lived — never reuse it after the after-payload changes.
+
+An ATOMIC-profile grant carries `state_nonce` and is single-use at the executor — if the executor has consumed the nonce, re-preflight; do not retry the same grant.
+
+With a proven tenant↔repo binding you may request `derivation:"server"` instead of assembling `artifacts[]` yourself (`context.repository` + `context.base` + `context.head` required; caller-supplied artifacts are rejected on that path).
+
+A commit is only proven when an executor attestation verifies (customer-held executor key, `cas_evidence: executor_attested`); otherwise say "authorized, commit not proven".


### PR DESCRIPTION
Adds CodeRifts as a third-party plugin (local source under external_plugins/coderifts).

- MCP server: remote Streamable HTTP at https://app.coderifts.com/mcp (type: http). Also listed in the official MCP registry as io.github.coderifts/api-governance.
- Skill (api-governance): guides the agent to run a CodeRifts preflight before merging or shipping API or MCP/tool-schema changes, returning an ALLOW/WARN/REQUIRE_APPROVAL/BLOCK decision.
- Auth: CODERIFTS_API_KEY env var; discovery (initialize, tools/list) works without a key, tool calls require one. No secrets in the repo.

Validated locally: scripts/generate-plugin-index.py and scripts/validate-catalog.py both pass (Catalog OK).