### PR TITLE
Add web-cli browser agent plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -92,6 +92,19 @@
       "homepage": "https://neon.com",
       "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
       "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "web-cli",
+      "description": "Real browser sessions for coding agents. Inspect live pages, act on numbered refs, fill forms, switch frames, and reuse persistent logins — not screenshots or brittle selectors.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/BrowserBox/WebCLI.git",
+        "sha": "a456e124bf83494c4e74071cd38fcf511c61a93f"
+      },
+      "homepage": "https://webcli.sh",
+      "keywords": ["web", "web-cli", "webcli", "browser", "inspect", "browser automation", "agent browser"],
+      "domains": ["webcli.sh"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -100,7 +100,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/BrowserBox/WebCLI.git",
-        "sha": "a456e124bf83494c4e74071cd38fcf511c61a93f"
+        "sha": "8e1e9e703aa8acc99d0865caf8c61e4cf466dcfc"
       },
       "homepage": "https://webcli.sh",
       "keywords": ["web", "web-cli", "webcli", "browser", "inspect", "browser automation", "agent browser"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -547,6 +547,17 @@
           }
         ]
       }
+    },
+    "web-cli": {
+      "sha": "a456e124bf83494c4e74071cd38fcf511c61a93f",
+      "components": {
+        "skills": [
+          {
+            "name": "web-cli",
+            "description": "Use the `web` CLI to browse, search, inspect, and act on live web pages from an agent workflow. Prefer this skill when…"
+          }
+        ]
+      }
     }
   }
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -549,7 +549,7 @@
       }
     },
     "web-cli": {
-      "sha": "a456e124bf83494c4e74071cd38fcf511c61a93f",
+      "sha": "8e1e9e703aa8acc99d0865caf8c61e4cf466dcfc",
       "components": {
         "skills": [
           {


### PR DESCRIPTION
## Summary

Adds **web-cli** to the official xAI plugin marketplace catalog.

WebCLI gives coding agents a real, persistent browser session with numbered action refs (`web inspect`, `web do`, forms, frames, profiles) — complementary to chrome-devtools (debugging/MCP) rather than overlapping.

## Plugin source

- **Repo:** https://github.com/BrowserBox/WebCLI
- **Pinned SHA:** `a456e124bf83494c4e74071cd38fcf511c61a93f` (adds `.grok-plugin/plugin.json` + `skills/web-cli/SKILL.md`)
- **WebCLI PR:** https://github.com/BrowserBox/WebCLI/pull/6

## Components

- Skill: `web-cli` — full browser loop for agents (inspect → act → re-inspect)
- Homepage: https://webcli.sh
- Domains: `webcli.sh`

## Checklist

- [x] Catalog entry added to `.grok-plugin/marketplace.json`
- [x] Remote source pinned to full 40-char SHA
- [x] `python3 scripts/generate-plugin-index.py` run
- [x] `python3 scripts/validate-catalog.py` passes