### PR TITLE
Add Grafana observability plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -69,6 +69,19 @@
       "keywords": ["superpowers"]
     },
     {
+      "name": "grafana",
+      "description": "Grafana observability platform integration. Access dashboards, query Prometheus and Loki, manage alerts, create incidents, and interact with OnCall directly from Grok.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/grafana/ai-marketplace.git",
+        "sha": "a5c72f2d74c640e9675eb0249526447968535015"
+      },
+      "homepage": "https://github.com/grafana/ai-marketplace",
+      "keywords": ["grafana", "grafana mcp", "grafana cloud"],
+      "domains": ["grafana.com", "grafana.net"]
+    },
+    {
       "name": "mongodb",
       "description": "Official plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
       "category": "database",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,31 @@
         ]
       }
     },
+    "grafana": {
+      "sha": "a5c72f2d74c640e9675eb0249526447968535015",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "grafana",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "grafana-assistant-cli",
+            "description": "Use the grafana-assistant CLI to interact with Grafana Assistant via A2A API. Covers installation, configuration, promp…"
+          },
+          {
+            "name": "grafana-cloud-mcp-tools",
+            "description": "Connect to and use the Grafana Cloud MCP server effectively. Covers setup, OAuth authorization, tool categories, read/w…"
+          },
+          {
+            "name": "grafana-mcp-tools",
+            "description": "Install, configure, and use the Grafana MCP server effectively. Covers setup via Docker or binary, environment variable…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## What

Adds the **grafana** plugin to the marketplace catalog as a remote source.

| Field | Value |
|---|---|
| Source | [grafana/ai-marketplace](https://github.com/grafana/ai-marketplace) (`url`) |
| Category | `monitoring` |
| Components | Grafana MCP server + 3 skills (`grafana-mcp-tools`, `grafana-cloud-mcp-tools`, `grafana-assistant-cli`) |

## Details

Grafana's AI marketplace provides MCP-based observability tools for querying dashboards, Prometheus and Loki, managing alerts, creating incidents, and interacting with OnCall directly from Grok.

## Validation

- `python3 scripts/validate-catalog.py` → **Catalog OK**
- `python3 scripts/generate-plugin-index.py` → **Plugin index OK**

`.grok-plugin/plugin-index.json` regenerated to include the `grafana` MCP server and 3 skills.