### PR TITLE
Add synapsis plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -69,6 +69,26 @@
       "keywords": ["superpowers"]
     },
     {
+      "name": "synapsis",
+      "description": "Unified durable memory MCP for Grok Build: sessions, tasks, structured handoffs (hf), unified search, compression, and hygiene. Ships with /synapsis and /handoff skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/teamolimpo/synapsis.git",
+        "sha": "9b80664a416d3a1774dfea8d02ad4b42da255eda"
+      },
+      "homepage": "https://github.com/teamolimpo/synapsis",
+      "keywords": [
+        "memory",
+        "handoff",
+        "tasks",
+        "sessions",
+        "mcp",
+        "agent-memory",
+        "synapsis"
+      ]
+    },
+    {
       "name": "mongodb",
       "description": "Official plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
       "category": "database",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -394,6 +394,31 @@
         ]
       }
     },
+    "synapsis": {
+      "sha": "9b80664a416d3a1774dfea8d02ad4b42da255eda",
+      "components": {
+        "hooks": [
+          {
+            "name": "PreCompact"
+          },
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "synapsis",
+            "description": "stdio"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
       "components": {


### PR DESCRIPTION
Adds the synapsis memory plug in for Grok Build

- Durable sessions, tasks, and structured handoff
- Unified seach + knowledge layer
- Includes '/Synapsis' and '/handoff' skills
- Auto init and hygene via hooks