### PR TITLE
feat: add ultraswarm orchestration plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/fubak/ultraswarm.git",
-        "sha": "0a2ea72dcde2195c8febf02841e8848d23e76cdf"
+        "sha": "877bf956682132388f17e55cd8d14e45c1cafc8d"
       },
       "homepage": "https://github.com/fubak/ultraswarm",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/fubak/ultraswarm.git",
-        "sha": "4a8a22a1e653cad2c18cb664c0cfecce5c506d4f"
+        "sha": "0a2ea72dcde2195c8febf02841e8848d23e76cdf"
       },
       "homepage": "https://github.com/fubak/ultraswarm",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "neon",
@@ -90,8 +121,32 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
+    },
+    {
+      "name": "ultraswarm",
+      "description": "Durable multi-worker coding orchestrator for Claude, Codex, Grok, Cursor, local models and more. Plans tasks with complexity/effort analysis, routes to specialized workers, supervises isolated git worktrees, handles approvals, integration, recovery and reporting.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/fubak/ultraswarm.git",
+        "sha": "4a8a22a1e653cad2c18cb664c0cfecce5c506d4f"
+      },
+      "homepage": "https://github.com/fubak/ultraswarm",
+      "keywords": [
+        "ultraswarm"
+      ],
+      "author": "Fubak"
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/fubak/ultraswarm.git",
-        "sha": "877bf956682132388f17e55cd8d14e45c1cafc8d"
+        "sha": "fb375e21ea2b05685381de6dd03146289a043cda"
       },
       "homepage": "https://github.com/fubak/ultraswarm",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/fubak/ultraswarm.git",
-        "sha": "fb375e21ea2b05685381de6dd03146289a043cda"
+        "sha": "04131d2736def35d74b56297001b5a0bac1cbfc6"
       },
       "homepage": "https://github.com/fubak/ultraswarm",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,7 +395,7 @@
       }
     },
     "ultraswarm": {
-      "sha": "fb375e21ea2b05685381de6dd03146289a043cda",
+      "sha": "04131d2736def35d74b56297001b5a0bac1cbfc6",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,7 +395,7 @@
       }
     },
     "ultraswarm": {
-      "sha": "4a8a22a1e653cad2c18cb664c0cfecce5c506d4f",
+      "sha": "0a2ea72dcde2195c8febf02841e8848d23e76cdf",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,7 +395,7 @@
       }
     },
     "ultraswarm": {
-      "sha": "0a2ea72dcde2195c8febf02841e8848d23e76cdf",
+      "sha": "877bf956682132388f17e55cd8d14e45c1cafc8d",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -394,6 +394,17 @@
         ]
       }
     },
+    "ultraswarm": {
+      "sha": "4a8a22a1e653cad2c18cb664c0cfecce5c506d4f",
+      "components": {
+        "skills": [
+          {
+            "name": "ultraswarm",
+            "description": "Orchestrate complex coding work through the ultraswarm v3 standalone runner."
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,7 +395,7 @@
       }
     },
     "ultraswarm": {
-      "sha": "877bf956682132388f17e55cd8d14e45c1cafc8d",
+      "sha": "fb375e21ea2b05685381de6dd03146289a043cda",
       "components": {
         "skills": [
           {


### PR DESCRIPTION
## What this PR does

- New third-party plugin: **ultraswarm**
- Type: remote source
- Source URL + pinned SHA: https://github.com/fubak/ultraswarm.git @ 4a8a22a1e653cad2c18cb664c0cfecce5c506d4f
- Homepage: https://github.com/fubak/ultraswarm

Ultraswarm is a durable multi-CLI coding orchestrator supporting Codex, Claude Code, Grok, Cursor Agent, local/private models (via pi), and shell workers. It owns:
- Complexity + effort-aware task decomposition
- Capability and repo-metric based worker routing with explanations
- Isolated git worktree execution + supervision + timeouts + cancellation
- Explicit plan / merge approvals, transactional integration, recovery, exportable provenance

The plugin surfaces a `ultraswarm` skill (with `/ultraswarm` or `ultraswarm` invocation) that delegates planning/execution to the user's installed standalone runner (`bin/ultraswarm.mjs`).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

Sourced from personal account `fubak/ultraswarm` (the project brand/username). Similar to other entries (e.g. superpowers from `obra`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT in plugin manifest).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars (the skill is instructional).
- [x] Hooks and MCP scope: none shipped by this plugin.
- Network endpoints this plugin calls (and why): None from the skill/plugin itself. The delegated runner invokes user-chosen AI CLIs (which may make their own API calls using the user's keys).
- Credentials/permissions it requires (and why): The user must have the worker CLIs authenticated in their environment (as documented). The plugin skill itself requires no additional credentials.

The skill instructs the host to locate and invoke the separately cloned `~/projects/ultraswarm` (or ULTRASWARM_HOME) runner. All privileged operations (process spawning, git worktrees, writes) happen in that runner under user control.

## Notes for reviewers

- The root of the ultraswarm repo contains:
  - `skills/ultraswarm/SKILL.md` (with frontmatter)
  - `.grok-plugin/plugin.json` and `.claude-plugin/plugin.json` (for compatibility)
- The skill is deliberately thin: "use the standalone runner, do not reimplement orchestration here."
- This enables Grok Build users to orchestrate ambitious multi-model/agent workflows directly from the chat with proper gates and provenance.
- Related project README has install instructions for multiple hosts.