### PR TITLE
Add code-map plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -105,6 +105,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "code-map",
+      "description": "Token-efficient, drift-resistant code reads for coding agents. grep finds; code-map's `read` pulls the exact symbol slice by coordinate and re-anchors it when files move (0 silently-wrong bytes at churn scale). Bundles a retrieval-routing skill that prevents the discovery double-call. TS/JS + Python, one dependency.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/annyeong844/map.git",
+        "sha": "a2d678e78b05525ba7950667c590abd60db82fd2"
+      },
+      "homepage": "https://github.com/annyeong844/map",
+      "author": { "name": "annyeong844" },
+      "keywords": ["code-map", "drift-resistant read", "symbol slice", "code-map read"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -109,6 +109,17 @@
         ]
       }
     },
+    "code-map": {
+      "sha": "a2d678e78b05525ba7950667c590abd60db82fd2",
+      "components": {
+        "skills": [
+          {
+            "name": "code-map-retrieval",
+            "description": "How to read code efficiently in a repo indexed by code-map (a `.map-index.json` is present, or a `code-map` / `map-mcp`…"
+          }
+        ]
+      }
+    },
     "firecrawl": {
       "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
       "components": {


### PR DESCRIPTION
Adds a catalog entry for **code-map** — token-efficient, drift-resistant code reads for coding agents.

- **Source:** https://github.com/annyeong844/map (MIT), pinned to a full commit SHA.
- **What it is:** `grep` finds; code-map's `read` pulls the exact symbol slice by coordinate and re-anchors it when files move (0 silently-wrong bytes at churn scale). Bundles a retrieval-routing skill. TS/JS + Python, one runtime dependency.
- **Components:** one MCP `read` tool + a `code-map-retrieval` skill.
- **Evidence:** reproducible benchmarks at https://github.com/annyeong844/code-map-bench (verifier included).

Checklist:
- [x] One entry in `.grok-plugin/marketplace.json`, valid JSON, kebab-case unique name.
- [x] Remote source pins a full 40-char lowercase SHA (public, reachable).
- [x] `.grok-plugin/plugin-index.json` regenerated (validate-catalog + index --check pass).
- [x] homepage + clear description + brand-scoped keywords + category.
- [x] Licensed (MIT).