### PR TITLE
Add ServiceNow Fluent SDK as external plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -105,6 +105,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "servicenow",
+      "description": "Create, edit, and deploy ServiceNow applications with the Fluent SDK. Agent skills teach Grok how to use the @servicenow/sdk CLI for SDK documentation, metadata conventions, project structure, and live instance queries.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/servicenow/sdk.git",
+        "sha": "4aadc235ad57a7442e42529869e68ff19c59596c"
+      },
+      "homepage": "https://servicenow.github.io/sdk/",
+      "keywords": ["servicenow", "fluent", "now-sdk"],
+      "domains": ["servicenow.com", "servicenow.github.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -384,6 +384,17 @@
         ]
       }
     },
+    "servicenow": {
+      "sha": "4aadc235ad57a7442e42529869e68ff19c59596c",
+      "components": {
+        "skills": [
+          {
+            "name": "now-sdk",
+            "description": "Use whenever the user mentions fluent, ServiceNow, or the now-sdk, OR when the user prompts for edits within a fluent a…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {


### PR DESCRIPTION
Register the servicenow plugin from servicenow/sdk with a pinned commit SHA and regenerate the component index to include the now-sdk skill.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name: servicenow
- Type: remote source
- https://github.com/servicenow/sdk 4aadc235ad57a7442e42529869e68ff19c59596c
- Homepage: https://github.com/servicenow/sdk

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
- Credentials/permissions it requires (and why):

## Notes for reviewers

Maintainer and engineer owner for the ServiceNow SDK at: https://github.com/ServiceNow/sdk
