### PR TITLE
Add Hindsight plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -105,6 +105,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "hindsight",
+      "description": "Automatic long-term memory for Grok via Hindsight. Recalls relevant memories before each prompt, retains conversation transcripts, and exposes knowledge-page tools (recall, ingest, create/update/delete pages) through the bundled Hindsight MCP server. Runs a local hindsight-embed daemon on 127.0.0.1; bring your own LLM key for fact extraction.",
+      "category": "memory",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vectorize-io/hindsight-grok-plugin.git",
+        "sha": "31a126047666fc569e83069a07a7953607170214"
+      },
+      "homepage": "https://vectorize.io/hindsight",
+      "keywords": ["hindsight", "hindsight memory", "vectorize hindsight", "agent memory"],
+      "domains": ["vectorize.io", "hindsight.vectorize.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -168,6 +168,37 @@
         ]
       }
     },
+    "hindsight": {
+      "sha": "31a126047666fc569e83069a07a7953607170214",
+      "components": {
+        "hooks": [
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "hindsight",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "create-agent",
+            "description": "Create a new Hindsight-powered subagent with long-term memory. Use when the user wants a specialized agent that learns…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## Summary

Adds **Hindsight** to the marketplace — automatic long-term memory for Grok Build. Hindsight recalls relevant memories before each prompt, retains conversation transcripts, and exposes knowledge-page tools (recall, ingest, create/update/delete pages) through a bundled MCP server. It fills a gap in the catalog: there's no agent-memory plugin yet. Category `memory`.

cc @ykeremy

## How it works

- **Source:** `type: local`, vendored under `external_plugins/hindsight/` — same shape as the merged [`neon` entry (#18)](https://github.com/xai-org/plugin-marketplace/pull/18). The plugin's canonical home is a subdirectory of the `vectorize-io/hindsight` monorepo (`hindsight-integrations/claude-code/`), so a root-cloning `url` source can't target it; vendoring locally is the clean path, matching `neon`.
- **MCP server (`hindsight`, stdio):** `.mcp.json` launches `scripts/run_mcp.sh`, which creates a per-plugin venv and `pip install`s `mcp>=1.0.0` from the vendored `requirements.txt` (no `curl|bash`, no remote `eval`), then execs the local `mcp_server.py`.
- **Memory backend:** the server talks to Hindsight's own `hindsight-embed` package, run via `uvx hindsight-embed@latest` and reached over **localhost only (`http://127.0.0.1:9077`)**. Pinnable via `HINDSIGHT_EMBED_VERSION` in `settings.json`.
- **Hooks:** four lifecycle hooks (`SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd`) run local Python scripts to recall before prompts and retain transcripts after.
- **Skill:** `create-agent` — scaffold a Hindsight-powered subagent with long-term memory.

## Network & credentials (for security review)

- Local daemon over loopback `127.0.0.1:9077` — no inbound, no external endpoint by default.
- Optional outbound **only when the user configures it**: a chosen LLM provider (OpenAI/Anthropic/etc.) for fact extraction using the user's own env key, or an external Hindsight API URL set explicitly in config.
- No reading of `~/.ssh`/`.env`/tokens for exfiltration; hooks are scoped to lifecycle events; no obfuscated payloads. MIT licensed.

## Changes

- `.grok-plugin/marketplace.json` — Hindsight catalog entry (local source, homepage, keywords, domains).
- `.grok-plugin/plugin-index.json` — regenerated; records the `hindsight` MCP server (stdio), 4 hooks, and the `create-agent` skill.
- `external_plugins/hindsight/**` — vendored plugin (manifest, `.mcp.json`, hooks, scripts, skill, README, LICENSE).

## Validation

\`\`\`
python3 scripts/validate-catalog.py              # Catalog OK
python3 scripts/generate-plugin-index.py --check  # Plugin index OK
\`\`\`

Both pass — the same two steps CI runs.

## Note

The plugin uses `\${CLAUDE_PLUGIN_ROOT}` / `\${CLAUDE_PLUGIN_DATA}` (Claude-ecosystem convention, which this repo already accepts via `.claude-plugin/` manifests). Happy to swap to `\${GROK_PLUGIN_ROOT}` if Grok Build expects that variable instead — just let me know.