### PR TITLE
Add qualcomm-edge-compiler plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -105,6 +105,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "qualcomm-edge-compiler",
+      "description": "Compile TrOCR/RF-DETR for QCS8550 OAK-4 via Qualcomm AI Hub",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dev-gp-1/qualcomm-edge-compiler.git",
+        "sha": "9e6eccf05cee2f20d751c0c26e339f6e96d65bb7"
+      },
+      "homepage": "https://github.com/dev-gp-1/qualcomm-edge-compiler",
+      "keywords": ["qualcomm", "qai-hub", "qcs8550", "trocr", "oak-4", "snpe", "depthai"],
+      "domains": ["aihub.qualcomm.com", "workbench.aihub.qualcomm.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -233,6 +233,27 @@
         ]
       }
     },
+    "qualcomm-edge-compiler": {
+      "sha": "9e6eccf05cee2f20d751c0c26e339f6e96d65bb7",
+      "components": {
+        "commands": [
+          {
+            "name": "qualcomm-compilation",
+            "description": "Compile, profile, and package RF-DETR and TrOCR models for QCS8550/OAK-4 via Qualcomm AI Hub"
+          },
+          {
+            "name": "trocr-fix",
+            "description": "Recompile TrOCR encoder/decoder DLCs to fix TROCR_DLC_FW_CRASH on OAK-4, then stage for device deploy"
+          }
+        ],
+        "skills": [
+          {
+            "name": "qualcomm-compilation",
+            "description": "Compile, profile, and package RF-DETR and TrOCR models for QCS8550/OAK-4 via Qualcomm AI Hub. Traces PyTorch graphs, su…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: qualcomm-edge-compiler
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/dev-gp-1/qualcomm-edge-compiler.git @ `9e6eccf05cee2f20d751c0c26e339f6e96d65bb7`
- Homepage: https://github.com/dev-gp-1/qualcomm-edge-compiler

Adds a third-party development plugin for compiling TrOCR/RF-DETR models for QCS8550 OAK-4 via Qualcomm AI Hub. Bundles skills, slash commands, and CLI tools for trace/compile/profile workflows and DepthAI `.tar` packaging.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Published under `dev-gp-1/qualcomm-edge-compiler` (Ghost Protocol org account).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT in upstream `plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `aihub.qualcomm.com` / `workbench.aihub.qualcomm.com` for Qualcomm AI Hub compile/profile jobs (user-provided `QAI_HUB_API_TOKEN`).
- Credentials/permissions it requires (and why): `QAI_HUB_API_TOKEN` for authenticated QAI Hub API access; local Python venv setup via bundled `scripts/setup-venv.sh`.

## Notes for reviewers

Brand-scoped keywords/domains: qualcomm, qai-hub, qcs8550, trocr, oak-4, snpe, depthai; domains limited to Qualcomm AI Hub hosts. No MCP servers or lifecycle hooks — skills, commands, and local CLI only.