### PR TITLE
Add Spider Cloud plugin (MCP server + skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -105,6 +105,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "spider",
+      "description": "Spider Cloud web data integration (MCP Server + Skills). Crawl sites, scrape pages, search the web, extract structured data with AI, and drive remote browsers — via the hosted Spider MCP server with anti-bot bypass, proxy rotation, and stealth escalation. Needs a SPIDER_API_KEY (pay-per-use credits; AI tools require a subscription).",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/spider-rs/spider-grok-plugin.git",
+        "sha": "d2184669d1576562bebc3c9d7a2591c798d34f1b"
+      },
+      "homepage": "https://spider.cloud/mcp",
+      "keywords": ["spider", "spider cloud", "spider crawl", "spider scrape", "spider mcp"],
+      "domains": ["spider.cloud"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -108,12 +108,12 @@
     },
     {
       "name": "spider",
-      "description": "Spider Cloud web data integration (MCP Server + Skills). Crawl sites, scrape pages, search the web, extract structured data with AI, and drive remote browsers — via the hosted Spider MCP server with anti-bot bypass, proxy rotation, and stealth escalation. Needs a SPIDER_API_KEY (pay-per-use credits; AI tools require a subscription).",
+      "description": "Spider Cloud web data integration (MCP Server + Skills). Crawl sites, scrape pages, search the web, extract structured data with AI, and drive remote browsers — via the hosted Spider MCP server with anti-bot bypass, proxy rotation, and stealth escalation. OAuth sign-in on first use (no API key to paste); pay-per-use credits, AI tools require a subscription.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/spider-rs/spider-grok-plugin.git",
-        "sha": "d2184669d1576562bebc3c9d7a2591c798d34f1b"
+        "sha": "1fe10b7627368fd35cb5d6d887fa74eda4ec5672"
       },
       "homepage": "https://spider.cloud/mcp",
       "keywords": ["spider", "spider cloud", "spider crawl", "spider scrape", "spider mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -385,7 +385,7 @@
       }
     },
     "spider": {
-      "sha": "d2184669d1576562bebc3c9d7a2591c798d34f1b",
+      "sha": "1fe10b7627368fd35cb5d6d887fa74eda4ec5672",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -384,6 +384,31 @@
         ]
       }
     },
+    "spider": {
+      "sha": "d2184669d1576562bebc3c9d7a2591c798d34f1b",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "spider",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "spider",
+            "description": "Overview and tool-selection guide for Spider Cloud — crawl, scrape, search the web, extract structured data with AI, an…"
+          },
+          {
+            "name": "spider-browser",
+            "description": "Drive a real remote browser with Spider Cloud — open a session, navigate, click, fill forms, run JavaScript, screenshot…"
+          },
+          {
+            "name": "spider-crawl-scrape",
+            "description": "Crawl websites, scrape individual pages, search the web, extract links, and bypass bot protection with Spider Cloud. Us…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the **Spider Cloud** plugin — web crawling, scraping, search, and remote browser automation for Grok Build via the hosted Spider MCP server (anti-bot bypass, proxy rotation, AI extraction).

- Plugin name: `spider`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/spider-rs/spider-grok-plugin.git` @ `d2184669d1576562bebc3c9d7a2591c798d34f1b`
- Homepage: https://spider.cloud/mcp

Ships **1 MCP server** (hosted, HTTP) + **3 skills** (`spider` overview/tool-guide, `spider-crawl-scrape`, `spider-browser`).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org — `spider-rs` (the official Spider org, same org as the `spider`/`spider-rs` crates and tooling).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin is a hosted MCP config + markdown skills; it ships no executable scripts and no hooks.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. The only credential used is `SPIDER_API_KEY`, sent solely as the `Authorization: Bearer` header to the Spider endpoint.
- [x] Hooks and MCP scope are least-privilege. No hooks; a single scoped HTTP MCP server (no shell-exec server).
- Network endpoints this plugin calls (and why): **`https://mcp.spider.cloud/mcp`** only — the official Spider Cloud hosted MCP server that provides the crawl/scrape/search/browser tools.
- Credentials/permissions it requires (and why): **`SPIDER_API_KEY`** — the user's Spider API key (https://spider.cloud/api-keys), required to authenticate to the hosted MCP server. Supplied via env-var interpolation (`Bearer ${SPIDER_API_KEY}`) so no secret is committed.

## Notes for reviewers

Source repo `spider-rs/spider-grok-plugin` is under the official Spider org. The same hosted Spider MCP server is also published in the official MCP Registry as `cloud.spider/mcp` (DNS-verified on `spider.cloud`). This mirrors the structure of the existing `firecrawl` entry (hosted web-data MCP); the difference is Spider authenticates with a Bearer API key rather than OAuth.
