### PR TITLE
scripts: support subdir `path` on url marketplace sources

### DIFF
--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -356,6 +356,18 @@ def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tu
                 )
             dest = tmp_root / f"plugin-{idx}"
             fetch_pinned(url, sha, dest)
+            subdir = source.get("path")
+            if isinstance(subdir, str) and subdir:
+                resolved = resolve_inside(dest, subdir)
+                if resolved is None:
+                    raise RuntimeError(
+                        f"plugin '{name}': url source path escapes the repo: {subdir!r}"
+                    )
+                if not resolved.is_dir():
+                    raise RuntimeError(
+                        f"plugin '{name}': url source path not found: {subdir!r}"
+                    )
+                return resolved, sha
             return dest, sha
         path = source.get("path")
         if isinstance(path, str):

--- a/scripts/validate-catalog.py
+++ b/scripts/validate-catalog.py
@@ -73,6 +73,22 @@ def validate_entry(entry: dict, idx: int) -> list[str]:
             f"abbreviated SHA."
         )
 
+    path = source.get("path")
+    if path is not None:
+        if not isinstance(path, str) or not path.strip():
+            errors.append(
+                f"plugin '{name}': url source `path` must be a non-empty string when present."
+            )
+        elif (
+            path.startswith("/")
+            or "\\" in path
+            or any(part in ("..", "") for part in path.split("/"))
+        ):
+            errors.append(
+                f"plugin '{name}': url source `path` {path!r} must be a relative "
+                f"subdirectory inside the repo (no leading '/', no '..', no backslashes)."
+            )
+
     return errors
 
 


### PR DESCRIPTION
## What this PR does

Adds optional `path` (subdirectory) support for `url`-typed marketplace sources, **in the catalog tooling only — no plugin entries change here.**

- `scripts/generate-plugin-index.py`: when a `url` source has a `path`, the pinned clone is scanned at that subdirectory (via the existing `resolve_inside` traversal guard) instead of the repo root.
- `scripts/validate-catalog.py`: validates that a `url` source's `path`, when present, is a safe relative subdirectory (rejects leading `/`, `..`, backslashes, and empty).

This unblocks vendors who ship multiple plugins from one repo under subdirectories (e.g. `plugins/foo`, `plugins/bar`): each becomes its own catalog entry pointing at the same repo + SHA with a different `path`. The matching Grok Build CLI runtime support (scan → install → load → update at the subdir) is in xai-org/xai#224389. A follow-up vendor PR (MongoDB) will add the first `path`-using entries.

- Plugin name: n/a (tooling only)
- Type: n/a
- Source URL + pinned SHA: n/a

## Ownership

- [x] n/a — no plugin added; tooling change only.

## Checklist

- [x] No catalog entries added/changed (this PR is tooling only).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally — the change is a **no-op for existing path-less entries**, so `plugin-index.json` is unchanged.
- [n/a] one-entry / sha-pin / homepage / license items — no plugin entry in this PR.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Least-privilege.
- Network endpoints: none added. The generator already shallow-fetches pinned `url` sources; this only changes **which directory inside the already-cloned repo** is scanned.
- Credentials/permissions: none.

## Notes for reviewers

Tooling-only; no catalog entries added or modified. A url-source `path` is validated in `validate-catalog.py` (no `..` / absolute / backslash / empty) and additionally guarded by `resolve_inside` in the generator, so a malicious subdir can't escape the cloned repo. Verified the validator accepts `plugins/foo` and rejects `../escape`, `/etc`, `a/../b`, backslash, empty, and trailing-slash; local sources are unaffected.
