### PR TITLE
feat(axiom): bump skills SHA and add MCP to plugin index

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -83,12 +83,12 @@
     },
     {
       "name": "axiom",
-      "description": "Agent skills for the Axiom observability platform. Run hypothesis-driven SRE investigations, query logs and metrics with APL, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+      "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
       "category": "observability",
       "source": {
         "source": "url",
         "url": "https://github.com/axiomhq/skills.git",
-        "sha": "76f5af39bdf47b62acb8c36c1dd9fdc404919438"
+        "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
       "keywords": ["axiom"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,8 +2,14 @@
   "version": 1,
   "plugins": {
     "axiom": {
-      "sha": "76f5af39bdf47b62acb8c36c1dd9fdc404919438",
+      "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "components": {
+        "mcpServers": [
+          {
+            "name": "axiom",
+            "description": "http"
+          }
+        ],
         "skills": [
           {
             "name": "axiom-alerting",


### PR DESCRIPTION
Pins axiomhq/skills@0e98ebae which bundles the hosted Axiom MCP server alongside existing agent skills.

Updates the existing `axiom` marketplace entry (not a new plugin): bumps the pinned SHA to include `.mcp.json` and `.grok-plugin/plugin.json` from [axiomhq/skills#55](https://github.com/axiomhq/skills/pull/55) follow-up merge, refreshes the catalog description to "MCP Server + Skills", and regenerates the plugin index so `mcpServers: axiom (http)` appears alongside the 7 existing skills.

Upstream changes (already merged to `axiomhq/skills` main):
- `.mcp.json` → hosted endpoint `https://mcp.axiom.co/mcp` (OAuth)
- `.grok-plugin/plugin.json` → installs as `axiom` (not `skills-<hash>`)

Tested locally: plugin installs as `axiom`, MCP server discovered from plugin, OAuth handshake succeeds in Grok TUI.

## What this PR does

- Plugin name: `axiom`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/axiomhq/skills.git` @ `0e98ebaeec76a70c8fda9a7737605800c2f1245d`
- Homepage: `https://github.com/axiomhq/skills`

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in upstream `axiomhq/skills`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.axiom.co/mcp` — official Axiom hosted MCP server (query APL, list datasets, dashboards, monitors, etc.). OAuth handled by Grok; no tokens in plugin config.
  - Skills scripts may call `https://api.axiom.co` when users configure `~/.axiom.toml` (optional, separate from MCP OAuth path).
- Credentials/permissions it requires (and why):
  - **MCP:** OAuth via browser on first connection to `mcp.axiom.co` (standard Axiom MCP setup; credentials stored by Grok in `~/.grok/mcp_credentials.json`).
  - **Skills (optional):** User-provided API token in `~/.axiom.toml` for script-based workflows (SRE investigations, dashboard builds, etc.) — not required for MCP-only use.

## Notes for reviewers

- This is an **update** to the existing `axiom` entry from #22, not a duplicate.
- MCP server implementation lives in [axiomhq/mcp](https://github.com/axiomhq/mcp); the plugin references the **hosted** endpoint (same pattern as Sentry, Neon, Firecrawl).
- `keywords` and `domains` remain brand-scoped (`axiom`, `axiom.co`, `app.axiom.co`).
- Prior art: Sentry/Firecrawl use dedicated `*-grok-plugin` repos; we bundled MCP config into `axiomhq/skills` (closer to MongoDB's `agent-skills` approach).