### PR TITLE
Add nimvault MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -177,7 +177,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "a47c406aa439da3582e6e7f6136d979b0a05bc12"
+        "sha": "6eed50708238afacdf7e51ac061b847e91a9a981"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -177,7 +177,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "6eed50708238afacdf7e51ac061b847e91a9a981"
+        "sha": "96de06ad8903f900aab56a0d270bdeacf64e45f7"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -172,12 +172,12 @@
     },
     {
       "name": "nimvault",
-      "description": "GPG opaque-blob vault via nimvault: list/status/scan; gated add/seal/unseal for agent-safe secrets in git repos. Local CLI only \u2014 no cloud.",
+      "description": "GPG opaque-blob vault via nimvault MCP (list/status/scan; gated add/seal/unseal). Local CLI + optional libnimvault in-process. Agent-safe secrets in git repos.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "96de06ad8903f900aab56a0d270bdeacf64e45f7"
+        "sha": "53992822761f4faad4130ef1d39c34fb4d8b4343"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -177,7 +177,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "0f6f34751c829feae7b563a3080c7a550513bdbe"
+        "sha": "1882064824cf645dbc8bf78a58f7d04e04f72297"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,35 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
+    },
+    {
+      "name": "nimvault",
+      "description": "GPG opaque-blob vault via nimvault: list/status/scan; gated add/seal/unseal for agent-safe secrets in git repos. Local CLI only \u2014 no cloud.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/HaoZeke/nimvault-mcp.git",
+        "sha": "0f6f34751c829feae7b563a3080c7a550513bdbe"
+      },
+      "homepage": "https://github.com/HaoZeke/nimvault-mcp",
+      "keywords": [
+        "nimvault",
+        "nimvault mcp",
+        "opaque-blob",
+        "gpg vault"
+      ],
+      "domains": [
+        "nimvault.rgoswami.me",
+        "github.com/HaoZeke/nimvault"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -177,7 +177,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "53992822761f4faad4130ef1d39c34fb4d8b4343"
+        "sha": "66344b53ba9ad95b7f77d09a4e149e2be9414bf0"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -177,7 +177,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "1882064824cf645dbc8bf78a58f7d04e04f72297"
+        "sha": "a47c406aa439da3582e6e7f6136d979b0a05bc12"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -556,7 +556,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "4cca2e1aaffbb46b678259cd0123fe44dc464800"
+        "sha": "44766cb7170307b95d795099570a0eaa0570c1ad"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -556,7 +556,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/HaoZeke/nimvault-mcp.git",
-        "sha": "828d14e6db7ba9436caffd29fcc4b0c92767b366"
+        "sha": "4cca2e1aaffbb46b678259cd0123fe44dc464800"
       },
       "homepage": "https://github.com/HaoZeke/nimvault-mcp",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "a47c406aa439da3582e6e7f6136d979b0a05bc12",
+      "sha": "6eed50708238afacdf7e51ac061b847e91a9a981",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "0f6f34751c829feae7b563a3080c7a550513bdbe",
+      "sha": "1882064824cf645dbc8bf78a58f7d04e04f72297",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "53992822761f4faad4130ef1d39c34fb4d8b4343",
+      "sha": "66344b53ba9ad95b7f77d09a4e149e2be9414bf0",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "96de06ad8903f900aab56a0d270bdeacf64e45f7",
+      "sha": "53992822761f4faad4130ef1d39c34fb4d8b4343",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "6eed50708238afacdf7e51ac061b847e91a9a981",
+      "sha": "96de06ad8903f900aab56a0d270bdeacf64e45f7",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -274,6 +274,29 @@
         ]
       }
     },
+    "nimvault": {
+      "sha": "0f6f34751c829feae7b563a3080c7a550513bdbe",
+      "components": {
+        "commands": [
+          {
+            "name": "nimvault-status",
+            "description": "Run nimvault status on a vault repo (defaults to NIMVAULT_DEFAULT_REPO or CWD)"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "nimvault",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "nimvault",
+            "description": "Use when sealing/unsealing GPG vault blobs, checking nimvault status, adding secrets to .vault/, or when the user menti…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,7 +275,7 @@
       }
     },
     "nimvault": {
-      "sha": "1882064824cf645dbc8bf78a58f7d04e04f72297",
+      "sha": "a47c406aa439da3582e6e7f6136d979b0a05bc12",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -591,8 +591,8 @@
       }
     },
     "nimvault": {
-      "sha": "828d14e6db7ba9436caffd29fcc4b0c92767b366",
-      "version": "0.3.4",
+      "sha": "4cca2e1aaffbb46b678259cd0123fe44dc464800",
+      "version": "0.3.6",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -591,8 +591,8 @@
       }
     },
     "nimvault": {
-      "sha": "4cca2e1aaffbb46b678259cd0123fe44dc464800",
-      "version": "0.3.6",
+      "sha": "44766cb7170307b95d795099570a0eaa0570c1ad",
+      "version": "0.3.7",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
## Summary
Adds third-party plugin **nimvault**: GPG opaque-blob vault MCP (list/status/scan; gated mutate). Local CLI + optional **libnimvault** in-process path.

- Source: https://github.com/HaoZeke/nimvault-mcp (MIT)
- Pinned SHA: `66344b53ba9ad95b7f77d09a4e149e2be9414bf0` (**v0.3.3**)
- CLI/lib: [nimvault **v0.4.2**](https://github.com/HaoZeke/nimvault/releases/tag/v0.4.2) (`nimble buildLib` / `NIMVAULT_LIB` for in-process)
- MCP releases: https://github.com/HaoZeke/nimvault-mcp/releases/tag/v0.3.3 (also v0.3.2 Unix assets)
- Mutating tools require `NIMVAULT_MCP_ALLOW_MUTATE=1`
- Includes skill + plugin.json + .mcp.json

## Checklist
- [x] Pin full commit SHA (0.3.3 / 66344b5…)
- [x] Regenerated plugin-index.json
- [x] validate-catalog.py passes locally
- [x] Keywords brand-scoped (nimvault)

## Test plan
- [ ] `grok plugin install` from marketplace after merge
- [ ] `nimvault_doctor` shows CLI + optional libnimvault line
- [ ] `nimvault_status` with `repo_path` set