### PR TITLE
Add fastcrw plugin (local source)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,18 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "fastcrw",
+      "description": "Scrape, crawl, map, and search the web with fastCRW — an open-source, self-hostable Rust web crawler & search API for AI agents. Hosted MCP server with browser OAuth sign-in (no API key to paste); native crw_scrape / crw_crawl / crw_map / crw_search tools, plus SearXNG-backed search. Self-host the same engine from a single ~6 MB static binary.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/fastcrw"
+      },
+      "homepage": "https://fastcrw.com",
+      "keywords": ["fastcrw", "fast crw", "fastcrw scrape", "fastcrw crawl", "fastcrw search"],
+      "domains": ["fastcrw.com", "api.fastcrw.com", "docs.fastcrw.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -150,6 +150,22 @@
         ]
       }
     },
+    "fastcrw": {
+      "components": {
+        "mcpServers": [
+          {
+            "name": "fastcrw",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "crw",
+            "description": "Scrape, crawl, map, and search the web with fastCRW. Use whenever the user needs web page content, site-wide extraction…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098",
       "components": {

--- a/external_plugins/fastcrw/.grok-plugin/plugin.json
+++ b/external_plugins/fastcrw/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "fastcrw",
+  "version": "0.1.0",
+  "description": "Scrape, crawl, map, and search the web with fastCRW — an open-source, self-hostable Rust web crawler & search API for AI agents, available as a hosted MCP server with browser OAuth sign-in.",
+  "author": {
+    "name": "fastCRW",
+    "url": "https://fastcrw.com"
+  },
+  "homepage": "https://fastcrw.com",
+  "repository": "https://github.com/us/crw",
+  "license": "AGPL-3.0",
+  "keywords": ["fastcrw", "scrape", "crawl", "web-search", "markdown", "mcp"]
+}

--- a/external_plugins/fastcrw/.mcp.json
+++ b/external_plugins/fastcrw/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "fastcrw": {
+      "type": "http",
+      "url": "https://fastcrw.com/mcp",
+      "note": "Hosted fastCRW MCP server. Uses OAuth — the first connection opens a browser sign-in through your fastCRW account; no API key to paste. Tools: crw_scrape, crw_crawl, crw_check_crawl_status, crw_map, crw_search. Prefer a key in the URL? https://fastcrw.com/mcp/<API_KEY> also works."
+    }
+  }
+}

--- a/external_plugins/fastcrw/README.md
+++ b/external_plugins/fastcrw/README.md
@@ -1,0 +1,89 @@
+# fastCRW Plugin for Grok Build
+
+Give your agents reliable web access: **scrape, crawl, map, and search** any site
+and get clean, LLM-ready markdown — straight from Grok Build.
+
+fastCRW is an **open-source, self-hostable web crawler & search API written in
+Rust**. The engine is a single ~6 MB static binary (no Redis, no Node, no Python
+venv, no headless-browser sidecar in the request path), so you can run the exact
+same engine yourself or use the managed cloud. This plugin bundles the **hosted
+fastCRW MCP server** — connect once, sign in through your browser, and Grok gets
+native `crw_*` tools for the whole web.
+
+## Why fastCRW
+
+- **Open core, self-hostable.** AGPL-3.0 engine ([github.com/us/crw](https://github.com/us/crw))
+  — one static binary, ~50 MB RAM idle. Use the managed cloud or host it yourself.
+- **Fast + high recall.** Reproducible 1K-URL benchmarks: faster than Firecrawl and
+  Tavily, with higher truth-recall than Crawl4AI/Firecrawl on the same set. See the
+  benchmark on [fastcrw.com](https://fastcrw.com).
+- **SearXNG-optimized search.** Web search via a tuned SearXNG backend (embedded
+  sidecar when self-hosting, managed when hosted).
+- **Drop-in migration.** Firecrawl-compatible REST API (`/v1/*` and `/v2/*`) if
+  you're moving an existing pipeline — but the MCP tools below are the native path.
+
+## Installation
+
+In Grok Build, run `/plugin` and search for **fastcrw**, then install it. This
+wires up the bundled fastCRW MCP server.
+
+### Sign in (no API key)
+
+The first time Grok uses a fastCRW tool, you'll be prompted to authorize in your
+browser through your fastCRW account (OAuth). Approve once — **no API key to copy
+or paste**. Check the connection any time with `/mcp`, and manage or revoke
+connected apps from your dashboard at **fastcrw.com/dashboard → Connections**.
+
+**Prefer a key in the URL?** The connector also accepts an API key in the path —
+add `https://fastcrw.com/mcp/<API_KEY>` instead (handy for clients that can't run
+the OAuth flow). Get a key at [fastcrw.com/dashboard](https://fastcrw.com/dashboard).
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `crw_scrape` | Scrape one URL to clean markdown, HTML, or links. |
+| `crw_crawl` | Start an async site crawl; returns a job id. |
+| `crw_check_crawl_status` | Poll an async crawl job and retrieve its pages. |
+| `crw_map` | Discover URLs on a site (sitemap + short crawl). URLs only, no content. |
+| `crw_search` | Web search with optional full-page content (SearXNG-backed). |
+
+Tool calls consume your fastCRW account credits.
+
+## Usage
+
+Once installed, just ask naturally:
+
+```text
+Scrape https://fastcrw.com/pricing and summarize the plans
+Map all URLs on https://example.com
+Search for "best practices for RAG chunking" and pull the top results
+```
+
+## Self-hosting
+
+The same engine is open source. Run it yourself and point an MCP/REST client at
+your own instance:
+
+```bash
+# see https://github.com/us/crw and https://docs.fastcrw.com
+crw serve   # single static binary, Firecrawl-compatible /v1 + /v2 API + /mcp
+```
+
+## Security
+
+- **Network endpoints this plugin calls:** the hosted MCP server at
+  `https://fastcrw.com/mcp` (HTTPS only). No other outbound calls.
+- **Credentials it requires:** a browser OAuth sign-in to your fastCRW account
+  (or, optionally, a fastCRW API key supplied in the connector URL). No secrets are
+  bundled in this plugin; nothing is read from your machine.
+
+## Links
+
+- Website: https://fastcrw.com
+- Docs: https://docs.fastcrw.com
+- Engine (open source, AGPL-3.0): https://github.com/us/crw
+
+## License
+
+This plugin is licensed under AGPL-3.0, consistent with the fastCRW engine.

--- a/external_plugins/fastcrw/skills/crw/SKILL.md
+++ b/external_plugins/fastcrw/skills/crw/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: crw
+description: >-
+  Scrape, crawl, map, and search the web with fastCRW. Use whenever the user
+  needs web page content, site-wide extraction, URL discovery, or web search
+  results — "scrape this", "crawl the site", "map the URLs", "search the web",
+  "get this page as markdown". Prefer these native fastCRW MCP tools over a
+  generic fetch: they return clean, LLM-ready markdown with JS rendering and
+  anti-bot handling.
+license: AGPL-3.0
+---
+
+# fastCRW
+
+fastCRW gives you the open web as clean markdown. This plugin bundles the hosted
+fastCRW MCP server, so prefer the native **`crw_*`** tools below — they need no
+local install and authenticate through the one-time browser sign-in.
+
+## Choosing a tool
+
+- **Have a URL, want its content?** → `crw_scrape` (markdown / html / links).
+- **Don't have a URL, want to find pages?** → `crw_search` (web search, optional
+  full-page content).
+- **Want every URL on a site (no content)?** → `crw_map`.
+- **Want the content of a whole site?** → `crw_crawl` (async) → poll with
+  `crw_check_crawl_status`.
+
+## Escalation
+
+Search → scrape → map → crawl. Start narrow: search or scrape a single page
+before mapping or crawling a whole site, which costs more credits.
+
+## crw_scrape
+
+Scrape one URL to clean markdown (handles JS-rendered SPAs). Use for a specific
+page you already have the URL for. Returns LLM-optimized markdown; ask for `links`
+or `html` formats when you need them.
+
+## crw_search
+
+Web search (SearXNG-backed). Returns results with url/title/description. Use when
+you don't have a URL. Optionally fetch full page content for the top results in
+one call instead of search-then-scrape.
+
+## crw_map
+
+Discover URLs on a site via sitemap + a short crawl. Returns a URL list only — no
+page content. Use to scope a site before crawling, or to find the right page.
+
+## crw_crawl / crw_check_crawl_status
+
+`crw_crawl` starts an asynchronous crawl of a whole site and returns a job id.
+Poll that id with `crw_check_crawl_status` until it's done, then read the pages.
+Use limits (depth / max pages) for large sites — crawls consume more credits.
+
+## Notes
+
+- Tool calls consume your fastCRW account credits; manage or revoke this
+  connection at fastcrw.com/dashboard → Connections.
+- The same engine is open source and self-hostable (single Rust binary) — see
+  https://github.com/us/crw and https://docs.fastcrw.com.


### PR DESCRIPTION
## What this PR does

New plugin — **fastCRW**, an open-source, self-hostable web crawler & search API for AI agents, bundled as a hosted MCP server with browser OAuth sign-in.

- **Plugin name:** `fastcrw`
- **Type:** local (`external_plugins/fastcrw`)
- **Vendored path:** `./external_plugins/fastcrw`
- **Homepage:** https://fastcrw.com

The engine is a single ~6 MB static Rust binary (no Redis/Node/Python in the request path); reproducible 1K-URL benchmarks show it faster than Firecrawl and Tavily, and web search is SearXNG-backed. The bundled hosted MCP server exposes native `crw_scrape` / `crw_crawl` / `crw_check_crawl_status` / `crw_map` / `crw_search` tools. Firecrawl-compatible `/v1` + `/v2` REST is available for migration, but the MCP is the native path.

## Ownership

- [x] I own this plugin / have the right to distribute it.
- [x] Vendored locally (no external source repo to pin). The open-source engine is published at https://github.com/us/crw (AGPL-3.0); fastCRW is the publisher of both.

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json` — valid JSON, kebab-case `name` (`fastcrw`), unique.
- [x] Local source — no remote SHA to pin.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description`; brand-scoped `keywords`/`domains`; `category: development`.
- [x] Local plugin includes `README.md` + `.grok-plugin/plugin.json`.
- [x] License stated (AGPL-3.0).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Least-privilege: a single hosted MCP server; no hooks, no shell-exec.
- **Network endpoints this plugin calls:** `https://fastcrw.com/mcp` (HTTPS only) — nothing else.
- **Credentials it requires:** a browser OAuth sign-in to the user's fastCRW account (or, optionally, a fastCRW API key supplied in the connector URL `https://fastcrw.com/mcp/<API_KEY>`). No secrets are bundled; nothing is read from the user's machine.

## Notes for reviewers

The hosted MCP uses OAuth (RFC 9728 discovery + PKCE) — the first connection opens a browser sign-in; no API key to paste. Verified working end-to-end with a real MCP client (ChatGPT) against `https://fastcrw.com/mcp`. Users manage/revoke connected apps from the fastCRW dashboard.