### PR TITLE
Add figma plugin (MCP server + skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -118,6 +118,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "figma",
+      "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/figma/mcp-server-guide.git",
+        "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098"
+      },
+      "homepage": "https://github.com/figma/mcp-server-guide",
+      "keywords": ["figma", "figma mcp", "code connect"],
+      "domains": ["figma.com", "www.figma.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -129,7 +129,7 @@
         "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp", "code connect"],
+      "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
     }
   ]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -150,6 +150,63 @@
         ]
       }
     },
+    "figma": {
+      "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "figma",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "figma-code-connect",
+            "description": "Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user m…"
+          },
+          {
+            "name": "figma-create-new-file",
+            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `create_new_file` tool call. NEVER call `create_ne…"
+          },
+          {
+            "name": "figma-generate-design",
+            "description": "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layou…"
+          },
+          {
+            "name": "figma-generate-diagram",
+            "description": "MANDATORY prerequisite — load this skill BEFORE every `generate_diagram` tool call. NEVER call `generate_diagram` direc…"
+          },
+          {
+            "name": "figma-generate-library",
+            "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable…"
+          },
+          {
+            "name": "figma-implement-motion",
+            "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f…"
+          },
+          {
+            "name": "figma-swiftui",
+            "description": "SwiftUI ↔ Figma translation. Use whenever the user mentions Swift, SwiftUI, iOS, iPhone, or iPad — in EITHER direction…"
+          },
+          {
+            "name": "figma-use",
+            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` dire…"
+          },
+          {
+            "name": "figma-use-figjam",
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the FigJam context. Can be used alongside figma-use which has…"
+          },
+          {
+            "name": "figma-use-motion",
+            "description": "Motion / animation context for the `use_figma` MCP tool — animating Figma nodes via manual keyframes, animation styles,…"
+          },
+          {
+            "name": "figma-use-slides",
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the Slides context. Can be used alongside figma-use which has…"
+          }
+        ]
+      }
+    },
     "firecrawl": {
       "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official **Figma** plugin from `figma/mcp-server-guide` — hosted Figma MCP server plus skills for design-to-code and write-to-canvas workflows.

- Plugin name: `figma`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/figma/mcp-server-guide.git` @ `bea8bea5f676ab2bf76fa822b82f50b66653c098`
- Homepage: https://github.com/figma/mcp-server-guide

Ships **1 MCP server** (`https://mcp.figma.com/mcp`, HTTP/OAuth) + **11 skills** (`figma-use`, `figma-code-connect`, `figma-generate-design`, `figma-generate-library`, `figma-generate-diagram`, `figma-implement-motion`, `figma-swiftui`, `figma-create-new-file`, `figma-use-figjam`, `figma-use-motion`, `figma-use-slides`).