### PR TITLE
Add invinoveritas plugin (verification layer for Grok Build agents)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "invinoveritas",
+      "description": "Verify before your agent acts: a neutral, recomputable pre-action verdict (review) and a portable signed proof anyone can re-derive (verify-proof). Gate irreversible actions — posting to X, signing an on-chain transaction, shipping a change — before they fire.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/babyblueviper1/invinoveritas-grok-plugin.git",
+        "sha": "e6f316cc76ad1300bf4531f026e503cc1fddbd3d"
+      },
+      "homepage": "https://api.babyblueviper.com",
+      "keywords": ["verify", "verification", "review", "governance", "pre-action", "proof", "second-opinion", "x-post", "guardrail"],
+      "domains": ["api.babyblueviper.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,29 @@
         ]
       }
     },
+    "invinoveritas": {
+      "sha": "e6f316cc76ad1300bf4531f026e503cc1fddbd3d",
+      "components": {
+        "commands": [
+          {
+            "name": "verify",
+            "description": "Run an invinoveritas pre-action verdict on a draft post, transaction, diff, or plan before committing it — returns appr…"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "invinoveritas",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "verify-before-action",
+            "description": "Get an independent, recomputable verdict BEFORE an agent commits an irreversible action — posting to X, signing or send…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What

Adds **invinoveritas** as a remote-source third-party plugin — a verification layer for Grok Build agents.

A plugin bundling:
- **MCP server** (`https://api.babyblueviper.com/mcp`): `review` (structured pre-action verdict — approve / approve_with_concerns / reject, ranked issues, optional portable signed proof) and `verify-proof` (free, no auth — confirm a signed verdict recomputes against the published key).
- **Skill** `verify-before-action` + **command** `/verify`.

## Why it fits Grok Build

Grok agents increasingly take irreversible actions — notably posting to X via the hosted X MCP (`createPosts`/`likePost`). The X API authenticates *who* may post; it doesn't judge *whether the post should go out*. invinoveritas is the pre-action verdict for exactly that boundary (and for on-chain signs, diffs, plans). The verdict is **recomputable** — a downstream party confirms it without trusting the agent or us.

## Submission checklist
- Remote source, pinned to a full commit SHA (`e6f316c…`); nothing vendored here.
- `python3 scripts/generate-plugin-index.py` + `python3 scripts/validate-catalog.py` → **Catalog OK**.
- Plugin repo: https://github.com/babyblueviper1/invinoveritas-grok-plugin (MIT).
- Developed by invinoveritas, not xAI.
