### PR TITLE
Add AxioRank plugin (Zero-Trust security for the Grok coding agent)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "axiorank",
+      "description": "Zero-Trust security for your Grok coding agent. Block destructive commands, secret exfiltration, and prompt-injected tool results locally and offline, then govern outbound tool calls through the AxioRank MCP server.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/AxioRank/grok-plugin.git",
+        "sha": "08fe4b8616c8b11a56d23c3cf1d68f12f25665de"
+      },
+      "homepage": "https://www.axiorank.com/coding-agent-security",
+      "keywords": ["axiorank", "security", "guardrails", "prompt injection", "secret scanning", "agent security", "mcp"],
+      "domains": ["axiorank.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,6 +43,45 @@
         ]
       }
     },
+    "axiorank": {
+      "sha": "08fe4b8616c8b11a56d23c3cf1d68f12f25665de",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "governance",
+            "description": "Show how AxioRank is governing this Grok session."
+          },
+          {
+            "name": "verify-seal",
+            "description": "Verify this repo's AxioRank Coding Session Seal offline."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse"
+          },
+          {
+            "name": "PreToolUse"
+          },
+          {
+            "name": "Stop"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "axiorank",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "AxioRank coding guard",
+            "description": "How AxioRank governs this Grok session, what it blocks, the env vars that turn on central reporting, and how to verify…"
+          }
+        ]
+      }
+    },
     "base44": {
       "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
       "version": "1.0.0-beta.1",


### PR DESCRIPTION
## What this PR does

Adds the **AxioRank** plugin: Zero-Trust security for the Grok coding agent. It blocks destructive commands, secret exfiltration, and prompt-injected tool results locally and offline (no account, no key), and registers the AxioRank remote MCP server for governing outbound tool calls.

- Plugin name: `axiorank`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/AxioRank/grok-plugin.git` @ `08fe4b8616c8b11a56d23c3cf1d68f12f25665de`
- Homepage: https://www.axiorank.com/coding-agent-security

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (github.com/AxioRank).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The guard is a single vendored zero-dependency ESM file (`bin/guard.mjs`) built from the published `@axiorank/coding-guard`; there is no install step.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. The guard inspects the tool call the agent is about to run so it can block a leak, and it redacts secret material before recording anything.
- [x] Hooks and MCP scope are least-privilege. Hooks are `PreToolUse`/`PostToolUse`/`Stop` only; the MCP server is opt-in and reached only when Grok invokes it.
- Network endpoints this plugin calls (and why): none by default. The guard runs fully offline. Only if `AXIORANK_API_KEY` is set does it send redacted call metadata to the workspace's AxioRank endpoint (`app.axiorank.com`) for the audit trail and Coding Session Seal. The registered MCP server (`app.axiorank.com/api/mcp-server/mcp`) is reached only when the agent invokes an AxioRank tool.
- Credentials/permissions it requires (and why): none for local blocking. `AXIORANK_API_KEY` (optional) enables central audit and sealing.

## Notes for reviewers

AxioRank ships the same governance plugin for Claude Code, Codex, and Cursor ([AxioRank/claude-plugin](https://github.com/AxioRank/claude-plugin), [/codex-plugin](https://github.com/AxioRank/codex-plugin), [/cursor-plugin](https://github.com/AxioRank/cursor-plugin)). The source repo `AxioRank/grok-plugin` is under our official org and pinned to a commit SHA. Local blocking is free and offline; the engine is the published `@axiorank/coding-guard`.
