### PR TITLE
feat(mind-protocol): add MIND Protocol plugin — MCP server + 4 skills, x402 payments on Solana

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,19 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "mind-protocol",
+      "description": "Policy runtime and on-chain proof layer for AI agents that spend money. Real-time Solana asset signals (Pyth), wallet market intelligence (Covalent), concentration risk scoring, and verifiable execution proofs — pay per call in USDC via x402, no subscription.",
+      "category": "payment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/DGuedz/mind-grok-plugin.git",
+        "sha": "8262921e0672ac6df0640ac9cde84f75472f9e2d"
+      },
+      "homepage": "https://mindprotocol.xyz",
+      "keywords": ["mind protocol", "mindprotocol", "mind x402"],
+      "domains": ["mindprotocol.xyz", "api.mindprotocol.xyz"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,35 @@
         ]
       }
     },
+    "mind-protocol": {
+      "sha": "8262921e0672ac6df0640ac9cde84f75472f9e2d",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mind-protocol",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mind-market-intel",
+            "description": "Query on-chain market intelligence for a Solana wallet — token balances, portfolio composition, and asset breakdown via…"
+          },
+          {
+            "name": "mind-risk",
+            "description": "Compute a concentration risk score (0–100) for a Solana wallet via MIND Protocol. Score >= 80 triggers a BLOCK decision…"
+          },
+          {
+            "name": "mind-signals",
+            "description": "Get real-time price signals for Solana assets from the MIND Protocol. Returns live price, momentum indicators, and a ve…"
+          },
+          {
+            "name": "mind-verify-proof",
+            "description": "Verify any MIND Protocol execution proof by its delivery_hash. Free — no payment required. Use after any mind_signals,…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## Plugin: mind-protocol

MIND Protocol is a policy runtime and intelligence layer for AI agents that spend money. This PR adds MIND as plugin #10 in the marketplace.

## What this plugin ships

| Component | Description |
|-----------|-------------|
| **MCP server** | Hosted at `https://api.mindprotocol.xyz/mcp` (StreamableHTTP, no auth required) |
| `mind_signals` | Real-time Solana asset prices and momentum from Pyth oracle |
| `mind_market_intelligence` | On-chain wallet portfolio and token balances via Covalent |
| `mind_risk_scoring` | Concentration risk score (0–100). Score ≥ 80 → BLOCK decision |
| `mind_verify_proof` | Free — verify any MIND execution proof by `delivery_hash` |

## Payment model

Each intelligence call may require a micro-payment in USDC via the [x402 protocol](https://x402.org) on Solana mainnet. `mind_verify_proof` is always free. No subscription.

## Source

- Plugin repo: https://github.com/DGuedz/mind-grok-plugin
- SHA pinned: `8262921e0672ac6df0640ac9cde84f75472f9e2d`
- Homepage: https://mindprotocol.xyz
- Live API: https://api.mindprotocol.xyz/health

## Network endpoints declared

- `api.mindprotocol.xyz` — hosted MCP server
- `hermes.pyth.network` — Solana price feeds
- `api.covalenthq.com` — on-chain market data
- `mainnet.helius-rpc.com` — Solana RPC

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` in kebab-case and unique
- [x] Remote source pins a full 40-char lowercase commit SHA; commit is public and reachable
- [x] `.grok-plugin/plugin-index.json` regenerated (`generate-plugin-index.py` → OK, `--check` → OK)
- [x] `homepage` and clear `description` provided; brand-scoped `keywords` and `domains`
- [x] `category` set (`payment`)
- [x] Plugin repo includes `README.md` and valid `.grok-plugin/plugin.json` manifest
- [x] MIT license stated
- [x] No arbitrary code execution, secret reading, or exfiltration — plugin is pure MCP tools over HTTPS
- [x] Network endpoints declared in README
- [x] `python3 scripts/validate-catalog.py` → `Catalog OK`
- [x] `python3 scripts/generate-plugin-index.py --check` → `Plugin index OK`