### PR TITLE
Add SerpApi plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -118,6 +118,19 @@
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
       "keywords": ["firecrawl", "fire crawl"],
       "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "serpapi",
+      "description": "Multi-engine search via SerpApi's hosted MCP server. One search tool spans 130+ engines \u2014 Google (web, images, news, shopping, maps/local, finance, flights, hotels, jobs, scholar), Bing, Yahoo, Yandex, Baidu, Naver, DuckDuckGo, YouTube, eBay, Amazon, Walmart, and more. Returns structured JSON (prices, ratings, addresses, knowledge graph data), not just links and snippets. The serpapi CLI is available as an optional fallback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/serpapi/serpapi-grok-plugin.git",
+        "sha": "8ce1a329567a8e9f9f79741a45ebee67d4bea474"
+      },
+      "homepage": "https://github.com/serpapi/serpapi-grok-plugin",
+      "keywords": ["serpapi", "serp api"],
+      "domains": ["serpapi.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -425,6 +425,23 @@
         ]
       }
     },
+    "serpapi": {
+      "sha": "8ce1a329567a8e9f9f79741a45ebee67d4bea474",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "serpapi",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "serpapi-search",
+            "description": "Multi-engine search via SerpApi — one tool spanning 130+ engines: Google (web, images, news, shopping, maps/local, fina…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {


### PR DESCRIPTION
Multi-engine search via SerpApi's hosted MCP server, with an optional CLI fallback. Source pinned to serpapi/serpapi-grok-plugin@8ce1a32.

## What this PR does

- Plugin name: serpapi
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/serpapi/serpapi-grok-plugin @ 8ce1a329567a8e9f9f79741a45ebee67d4bea474
- Homepage: https://serpapi.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in .grok-plugin/marketplace.json (valid JSON, kebab-case name).
- [x] Remote source pins a full 40-char lowercase commit sha, and that commit is public + reachable.
- [x] Regenerated .grok-plugin/plugin-index.json (python3 scripts/generate-plugin-index.py).
- [x] python3 scripts/validate-catalog.py passes locally.
- [x] python3 scripts/generate-plugin-index.py --check passes locally.
- [x] homepage + clear description set; local plugins include README.md + .grok-plugin/plugin.json.
- [x] License is stated.

## Security

- [x] No curl | bash, remote-code download/exec, or postinstall RCE.
- [x] No reading/exfiltration of secrets, tokens, .env, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://mcp.serpapi.com/mcp — used to execute search queries across 130+ engines (Google, Bing, YouTube,eBay, Maps, News, Shopping, etc.).
- Credentials/permissions it requires (and why): SERPAPI_KEY (user-supplied, vrization: Bearer header to authenticate against the SerpApi MCP server and the
optional serpapi-cli fallback. No other secrets or local file/env access.

## Notes for reviewers

Repo is under the official [SerpApi GitHub org](serpapi/serpapi-grok-plugin), same org as the homepage/repository fields in .grok-plugin/plugin.json. Bundles one MCP server (hosted, HTTP) and one skill (serpapi-search) with no hooks or install scripts. CLI fallback is only used when the MCP isn't connected.
