### PR TITLE
Add cloud-run plugin (grok-mcp-cloudrun)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,23 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "cloud-run",
+      "description": "Deploy and manage Google Cloud Run services from Grok. MCP tools, /deploy and /logs slash commands, safety hooks. Wraps @google-cloud/cloud-run-mcp (not affiliated with Google).",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/gprot42/grok-mcp-cloudrun.git",
+        "sha": "5a698e39b45fb87ba63983b21fefd46498706bfd"
+      },
+      "homepage": "https://github.com/gprot42/grok-mcp-cloudrun",
+      "keywords": [
+        "cloud run mcp",
+        "grok cloud run",
+        "google cloud run grok"
+      ],
+      "domains": ["cloud.google.com", "console.cloud.google.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -79,6 +79,42 @@
         ]
       }
     },
+    "cloud-run": {
+      "sha": "5a698e39b45fb87ba63983b21fefd46498706bfd",
+      "components": {
+        "commands": [
+          {
+            "name": "deploy",
+            "description": "Deploy the current project folder to Google Cloud Run."
+          },
+          {
+            "name": "logs",
+            "description": "Fetch recent logs and error messages for a Cloud Run service."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PreToolUse",
+            "description": "cloud-run__create-project, cloud-run__deploy-local-folder, cloud-run__deploy-file-contents, cloud-run__deploy-container…"
+          },
+          {
+            "name": "SessionStart"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "cloud-run",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "cloud-run",
+            "description": "Deploy and manage Google Cloud Run services and jobs. Use when the user asks to deploy to Cloud Run, get Cloud Run logs…"
+          }
+        ]
+      }
+    },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
       "components": {


### PR DESCRIPTION
## Summary

Adds the **cloud-run** third-party Grok plugin for deploying and managing Google Cloud Run services.

- **Source:** https://github.com/gprot42/grok-mcp-cloudrun
- **Pinned SHA:** `5a698e39b45fb87ba63983b21fefd46498706bfd` (tag `v0.2.0`)
- **License:** Apache 2.0 with upstream attribution in `NOTICE`
- **Not affiliated with Google** — wraps `@google-cloud/cloud-run-mcp` via `npx`

## Components

| Component | Details |
|-----------|---------|
| MCP server | stdio via `npx @google-cloud/cloud-run-mcp@1.10.0` (pinned) |
| Skills | `cloud-run` — MCP-first workflow with gcloud fallback |
| Commands | `/deploy`, `/logs` |
| Hooks | SessionStart project/ADC warnings; PreToolUse blocks `create-project` and production-like deploys unless explicitly confirmed |

## Security

- No arbitrary code download or `curl | bash`
- Hooks are scoped with matchers (`cloud-run__create-project`, deploy tools)
- Production deploy guard requires `CONFIRM_CLOUD_RUN_PROD_DEPLOY=1` when project ID matches `*prod*` / `*production*`
- `create-project` blocked unless `CONFIRM_CLOUD_RUN_CREATE_PROJECT=1`

## Validation

```bash
python3 scripts/validate-catalog.py
python3 scripts/generate-plugin-index.py --check
```

Both pass on this branch.