### PR TITLE
Add jerrysniffs.online web and social search plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,19 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "jerrysniffs",
+      "description": "No-subscriptions online and social search via the JerrySniffs MCP server. Provides web search, Reddit post search, Twitter/X search, tweet lookup, and URL-to-Markdown conversion for public HTML pages, PDFs, DOC files, and DOCX files.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/freakynit/jerrysniffs-grok-plugin.git",
+        "sha": "ca2b5beba3ff2121db4841ff5711af260db6d95b"
+      },
+      "homepage": "https://github.com/freakynit/jerrysniffs-grok-plugin",
+      "keywords": ["reddit", "twitter", "X", "serp", "serp=api", "jerrysniffs", "jerry sniffs"],
+      "domains": ["jerrysniffs.online"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -716,6 +716,23 @@
           }
         ]
       }
+    },
+    "jerrysniffs": {
+      "sha": "ca2b5beba3ff2121db4841ff5711af260db6d95b",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "jerrysniffs",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "jerrysniffs-search",
+            "description": "No-subscriptions online and social search via JerrySniffs. Use this skill whenever the user asks to search the web, look up current information, find recent articles or docs, search Reddit posts, search Twitter/X posts, look up a specific tweet by ID, or fetch a public URL and convert it to Markdown."
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
No-subscriptions online and social search via the JerrySniffs MCP server. Source pinned to freakynit/jerrysniffs-grok-plugin@ca2b5be.

## What this PR does

- Plugin name: jerrysniffs
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/freakynit/jerrysniffs-grok-plugin @ ca2b5beba3ff2121db4841ff5711af260db6d95b
- Homepage: https://jerrysniffs.online

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under my GitHub account; the product homepage is https://jerrysniffs.online.

## Checklist

- [x] Added/updated exactly one entry in .grok-plugin/marketplace.json (valid JSON, kebab-case name).
- [x] Remote source pins a full 40-char lowercase commit sha, and that commit is public + reachable.
- [x] Regenerated .grok-plugin/plugin-index.json (python3 scripts/generate-plugin-index.py).
- [x] python3 scripts/validate-catalog.py passes locally.
- [x] python3 scripts/generate-plugin-index.py --check passes locally.
- [x] homepage + clear description set; local plugins include README.md + .grok-plugin/plugin.json.
- [x] License is stated.

## Security

- [x] No curl | bash, remote-code download/exec, or postinstall RCE.
- [x] No reading/exfiltration of secrets, tokens, .env, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://jerrysniffs.online — used by `jerrysniffs-mcp` to execute web search, Reddit search, Twitter/X search, tweet lookup, and usage tracking for URL-to-Markdown conversions.
- Credentials/permissions it requires (and why): JERRYSNIFFS_API_KEY, user supplied. The plugin passes it to the MCP server as API_KEY so `jerrysniffs-mcp` can authenticate requests to JerrySniffs. No other secrets or local file/env access.

## Notes for reviewers

Repo is under my GitHub account at freakynit/jerrysniffs-grok-plugin, matching the JerrySniffs product homepage in .grok-plugin/plugin.json. Bundles one MCP server (stdio via `npx -y jerrysniffs-mcp`) and one skill (`jerrysniffs-search`) with no hooks or install scripts. The MCP package is published on npm as `jerrysniffs-mcp`.