### PR TITLE
Add noshell plugin (shell-free exec MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,18 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "noshell",
+      "description": "Shell-free exec MCP. Run programs with explicit argv and stdin — never through a shell. Safer multi-line stdin, paths with spaces, and untrusted strings; pairs with (does not replace) the agent shell tool. Tools: exec, pipeline.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dongray2/noshell.git",
+        "sha": "0c76c42d66efaeccf9bb168bbc7da9592adf164d"
+      },
+      "homepage": "https://github.com/dongray2/noshell",
+      "keywords": ["noshell", "noshell-mcp", "shell-free exec"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -331,6 +331,17 @@
         ]
       }
     },
+    "noshell": {
+      "sha": "0c76c42d66efaeccf9bb168bbc7da9592adf164d",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "noshell",
+            "description": "stdio"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4",
       "components": {


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they are exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

- Plugin name: `noshell`
- Type: remote source
- Source URL + pinned SHA: https://github.com/dongray2/noshell.git @ `0c76c42d66efaeccf9bb168bbc7da9592adf164d`
- Homepage: https://github.com/dongray2/noshell

Adds the noshell Grok Build plugin: a shell-free exec MCP server (`noshell-mcp` on npm). Runs programs with an explicit argv array and explicit stdin via `spawn({ shell: false })` — never through bash/sh/PowerShell. Tools: `exec`, `pipeline`.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official account (`dongray2/noshell` — independent MIT project; author is the repo owner).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; plugin includes `.mcp.json` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; two scoped tools only).
- Network endpoints this plugin calls (and why): none from the server itself. Install path uses `npx -y noshell-mcp` to fetch the published npm package.
- Credentials/permissions it requires (and why): none. Local process spawn only.

### Security notes for reviewers

- **Not a general shell.** One spawn site uses `spawn(..., { shell: false })`. Args are an explicit argv array; stdin is an explicit string. No word-splitting, globs, or `$VAR` expansion.
- Keywords are brand-scoped (`noshell`, `noshell-mcp`, `shell-free exec`) to avoid generic CTA misfires.
- Timeouts kill the process tree; server shutdown reaps in-flight children.
- Windows `.cmd`/`.bat` are unsupported by design (consequence of `shell: false`).

## Notes for reviewers

- npm package: https://www.npmjs.com/package/noshell-mcp
- Direct install (without marketplace): `grok plugin install dongray2/noshell --trust`
- Plugin layout at pinned commit: `.mcp.json`, `.grok-plugin/plugin.json`