### PR TITLE
Add last30days research plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,18 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "last30days",
+      "description": "Research any topic across Reddit, X, YouTube, TikTok, Instagram, Hacker News, Polymarket, GitHub, and 5+ more sources. AI agent scores by upvotes, likes, and real money - not editors.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mvanhorn/last30days-skill.git",
+        "sha": "24c6567731397124d51ac0bccc7c6727d9ca779b"
+      },
+      "homepage": "https://github.com/mvanhorn/last30days-skill",
+      "keywords": ["last30days", "last 30 days"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,22 @@
         ]
       }
     },
+    "last30days": {
+      "sha": "24c6567731397124d51ac0bccc7c6727d9ca779b",
+      "components": {
+        "hooks": [
+          {
+            "name": "SessionStart"
+          }
+        ],
+        "skills": [
+          {
+            "name": "last30days",
+            "description": "Research what people actually say about any topic in the last 30 days. Pulls posts and engagement from Reddit, X, YouTu…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## What this PR does

Add the last30days research plugin as a remote-source catalog entry, pinned to the commit that shipped native `.grok-plugin/` manifests.

- Plugin name: `last30days`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/mvanhorn/last30days-skill.git` @ `24c6567731397124d51ac0bccc7c6727d9ca779b`
- Homepage: https://github.com/mvanhorn/last30days-skill

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is `mvanhorn/last30days-skill` — the project's official public repository (MIT). I'm a maintainer/contributor submitting on behalf of that project.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: MIT (`LICENSE` in the source repo). The pinned commit includes `.grok-plugin/plugin.json` and the `skills/last30days` skill tree.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): optional third-party research APIs the user configures (e.g. ScrapeCreators, OpenAI/xAI/OpenRouter, Brave/Exa/Serper, Polymarket, Reddit/HN public endpoints, GitHub via `gh`). No undisclosed telemetry.
- Credentials/permissions it requires (and why): none required for a basic run (Reddit/HN/Polymarket/GitHub work keyless when available). Optional API keys and browser cookies unlock additional sources; keys are stored only in the user's local `.env` / OS keychain patterns documented in the repo.

## Notes for reviewers

- Brand-scoped keywords only (`last30days`, `last 30 days`) for the plugin CTA.
- Category: `productivity`.
- Components at the pinned SHA (from regenerated index): one skill (`last30days`) + a `SessionStart` hook.
- Direct install already works today via `grok plugin install mvanhorn/last30days-skill`; this PR is the official-catalog listing.
