### PR TITLE
Add illo plugin (editorial illustration mascot)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,19 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "illo",
+      "description": "Original editorial illustrations where a recurring mascot performs the idea.",
+      "category": "creative",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tmchow/illo-skill.git",
+        "sha": "85bfa576a5cf6d87ade011cb9ee983757961fdc9"
+      },
+      "homepage": "https://illo-skill.com",
+      "keywords": ["illo", "illo skill", "editorial illustration"],
+      "domains": ["illo-skill.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,17 @@
         ]
       }
     },
+    "illo": {
+      "sha": "85bfa576a5cf6d87ade011cb9ee983757961fdc9",
+      "components": {
+        "skills": [
+          {
+            "name": "illo",
+            "description": "Creates original editorial illustrations where a recurring mascot character performs the idea — one caught scene by def…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds **illo** — a Grok plugin that generates original editorial illustrations where a recurring mascot character performs the idea (caught scenes, explainer diagrams, and transparent character cutouts) in a set of bundled looks.

- Plugin name: `illo`
- Type: remote source
- Source URL + pinned SHA (remote): `https://github.com/tmchow/illo-skill.git` @ `85bfa576a5cf6d87ade011cb9ee983757961fdc9`
- Homepage: https://illo-skill.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below). — see Notes: it's a first-party personal-account source.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; source repo carries a `README.md` and `.grok-plugin/plugin.json`.
- [x] License is stated — MIT (`tmchow/illo-skill`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The engine is a single stdlib Python script.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. The optional OpenRouter key is written by `illo.py init` to `~/.config/illo/config.yaml` (mode 600) and read only to call the image backend.
- [x] Hooks and MCP scope are least-privilege. No MCP servers; no hooks.
- Network endpoints this plugin calls (and why): the image backend only — either the user's signed-in **Codex CLI** (no key), or **OpenRouter** (`openrouter.ai`) when the user configures a key, to render images.
- Credentials/permissions it requires (and why): none by default (Codex backend); optionally a user-supplied OpenRouter API key for the OpenRouter backend.

## Notes for reviewers

- **Personal-account source is first-party, not impersonation.** `illo` is an original project authored and maintained by @tmchow; `tmchow/illo-skill` is its canonical home. `illo` is not a company/brand name, so there's no org to source it from — the personal account *is* the official owner.
- **Keywords/domains are brand-scoped** (`illo`, `illo skill`, `editorial illustration`; `illo-skill.com`) so the plugin CTA does not mis-fire on generic "illustrate/draw an image" requests — matching illo's do-not-hijack design.
- illo already installs on Grok via its `.claude-plugin/*` compat fallback and ships a native `.grok-plugin/` pair; this entry makes it discoverable in the official catalog.