### PR TITLE
Add update-devlog plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -191,12 +191,12 @@
     },
     {
       "name": "update-devlog",
-      "description": "Append everything done in a Grok Build CLI session (since the last update) into a project chrono-log HTML. First use binds a path or creates a log from a template; later runs only write the session delta.",
+      "description": "Append everything done in a Grok Build CLI session (since the last update) into a project chrono-log HTML. First use binds a path or creates a log from a template; later runs only write the session delta. Path denylist and HTML-escaping rules included.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Fourier18/grok-update-devlog.git",
-        "sha": "6003071f59c190ccb3a7add9b64ab74e06360b19"
+        "sha": "6520eba2e6a71e13e40ac656231967f2751ba1c5"
       },
       "homepage": "https://github.com/Fourier18/grok-update-devlog",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,30 @@
         "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
+    },
+    {
+      "name": "update-devlog",
+      "description": "Append everything done in a Grok Build CLI session (since the last update) into a project chrono-log HTML. First use binds a path or creates a log from a template; later runs only write the session delta.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Fourier18/grok-update-devlog.git",
+        "sha": "a9681983ad8fc7d5031f6565554668e30c9ddc4c"
+      },
+      "homepage": "https://github.com/Fourier18/grok-update-devlog",
+      "keywords": [
+        "update-devlog",
+        "chrono-log",
+        "devlog skill"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -196,7 +196,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Fourier18/grok-update-devlog.git",
-        "sha": "a9681983ad8fc7d5031f6565554668e30c9ddc4c"
+        "sha": "6003071f59c190ccb3a7add9b64ab74e06360b19"
       },
       "homepage": "https://github.com/Fourier18/grok-update-devlog",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -552,7 +552,7 @@
       }
     },
     "update-devlog": {
-      "sha": "6003071f59c190ccb3a7add9b64ab74e06360b19",
+      "sha": "6520eba2e6a71e13e40ac656231967f2751ba1c5",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -552,7 +552,7 @@
       }
     },
     "update-devlog": {
-      "sha": "a9681983ad8fc7d5031f6565554668e30c9ddc4c",
+      "sha": "6003071f59c190ccb3a7add9b64ab74e06360b19",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -551,6 +551,17 @@
         ]
       }
     },
+    "update-devlog": {
+      "sha": "a9681983ad8fc7d5031f6565554668e30c9ddc4c",
+      "components": {
+        "skills": [
+          {
+            "name": "update-devlog",
+            "description": "Append everything done in this Grok Build CLI session (since the last update) into a project chrono-log HTML. First use…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: `update-devlog`
- Type: remote source
- Source URL + pinned SHA: https://github.com/Fourier18/grok-update-devlog.git @ `a9681983ad8fc7d5031f6565554668e30c9ddc4c`
- Homepage: https://github.com/Fourier18/grok-update-devlog

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] Source is published under my GitHub account (personal utility skill, not a brand impersonation).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (none present).
- Network endpoints this plugin calls (and why): none (skill-only, local HTML + bind files).
- Credentials/permissions it requires (and why): local filesystem for project HTML and bind state only.

## Notes for reviewers

Skill-only Grok Build plugin providing `/update-devlog` — appends session work to a project chrono-log HTML (creates from template on first use). No MCP servers, hooks, or network calls.