### PR TITLE
Add gipity plugin (GipityAI/skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,33 @@
         "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
+    },
+    {
+      "name": "gipity",
+      "description": "Gipity cloud for coding agents - hosting, Postgres databases, serverless functions, auth, file storage, realtime, and AI services (image, speech, LLM), driven by the gipity CLI. Skills cover the build-deploy-verify loop plus web apps, 2D/3D games, computer vision, and realtime; hooks auto-sync project files to the cloud.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/GipityAI/skills.git",
+        "sha": "90fd54797da9dc4e2ab435dc801eba743f6a538c"
+      },
+      "homepage": "https://gipity.ai",
+      "keywords": [
+        "gipity",
+        "gip",
+        "gipity deploy"
+      ],
+      "domains": [
+        "gipity.ai"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,83 @@
         ]
       }
     },
+    "gipity": {
+      "sha": "90fd54797da9dc4e2ab435dc801eba743f6a538c",
+      "components": {
+        "commands": [
+          {
+            "name": "setup",
+            "description": "Install the Gipity CLI, log in, and link this directory to a Gipity cloud project"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Write|Edit"
+          },
+          {
+            "name": "PreCompact"
+          },
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "SubagentStop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "2d-game",
+            "description": "Use when the user wants to build a 2D browser game - platformer, side-scroller, arcade, puzzle, endless runner - and sh…"
+          },
+          {
+            "name": "3d-world",
+            "description": "Use when the user wants a 3D browser game or a multiplayer game - obby, tycoon, simulator, PvP arena, shooter, racing -…"
+          },
+          {
+            "name": "agent-deploy",
+            "description": "Use when an AI agent, script, or CI job needs to deploy to or operate Gipity WITHOUT a human present to complete an int…"
+          },
+          {
+            "name": "app-realtime",
+            "description": "Use when the user wants realtime multiplayer, live presence, chat, or shared live state in a web app - rooms, lobbies,…"
+          },
+          {
+            "name": "chatbot",
+            "description": "Use when the user wants to add a configurable AI chatbot/assistant to a web app - a help bubble in the corner, a suppor…"
+          },
+          {
+            "name": "gipity",
+            "description": "Use when the user mentions Gipity, or when they want to put something built in this session on the internet - deploy/ho…"
+          },
+          {
+            "name": "plans",
+            "description": "Use when a user hits a plan limit or runs low on credits, asks what Gipity costs / which plan to pick / how to upgrade,…"
+          },
+          {
+            "name": "web-app-basics",
+            "description": "Use when the user wants to build and put online a full-stack web app - a site or tool with a real backend: database, AP…"
+          },
+          {
+            "name": "web-vision-detect",
+            "description": "Use when the user wants real-time object detection in a web app - boxing, labeling, or counting things from the camera…"
+          },
+          {
+            "name": "web-vision-mediapipe",
+            "description": "Use when the user wants an app that sees through the camera - gesture recognition, body/pose tracking, object detection…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## What this PR does

New plugin: adds the Gipity plugin to the catalog as a remote source.

- Plugin name: `gipity`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/GipityAI/skills.git` @ `90fd54797da9dc4e2ab435dc801eba743f6a538c`
- Homepage: https://gipity.ai

Gipity is a full-stack cloud platform for coding agents - hosting, Postgres databases, serverless functions, auth, file storage, realtime, and AI services, all driven by the `gipity` CLI. The plugin's skills cover onboarding plus the most common builds (full-stack web apps, 2D/3D games, computer vision, realtime), and its hooks keep a linked project's files auto-synced to the cloud. Verified against Grok Build 0.2.99: `grok plugin install GipityAI/skills --trust` discovers all 10 skills, the `/gipity:setup` command, and the hooks (`grok plugin validate` passes).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (GipityAI).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the source repo's `plugin.json` and `LICENSE`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): the hooks run the user-installed `gipity` CLI, which calls `*.gipity.ai` (Gipity's own API - file sync, deploys). Every hook checks for a `.gipity.json` project marker in the working directory first and exits immediately outside Gipity projects; nothing runs or phones home in other repos.
- Credentials/permissions it requires (and why): the user's own Gipity account session, created interactively via `gipity login` (email + 6-digit code). The plugin stores no secrets and requires no API keys.

## Notes for reviewers

The skills are generated from the same documentation source that powers Gipity's hosted agent and docs site (single source of truth), and the repo doubles as the plugin's Claude Code marketplace - it's the canonical distribution point. Session-capture hooks explicitly no-op under Grok (guarded on `GROK_HOOK_EVENT`); only file-sync hooks are active. The `gipity` CLI on the machine is installed by the user (`npm install -g gipity`), not by this plugin.