### PR TITLE
Add E2LLM plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -44,6 +44,19 @@
       "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
     },
     {
+      "name": "e2llm",
+      "description": "E2LLM gives your AI eyes and hands in a real browser -- structured perception (SiFR) plus action, working with the AI you already use.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/e2llm/e2llm-sifr.git",
+        "sha": "aa0ae67a3377df6d82b480bb21c33593d1dcb2f9"
+      },
+      "homepage": "https://e2llm.com",
+      "keywords": ["e2llm", "element to llm", "sifr", "structured browser perception"],
+      "domains": ["e2llm.com", "mcp.e2llm.com", "api.e2llm.com"]
+    },
+    {
       "name": "cloudflare",
       "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,28 @@
         ]
       }
     },
+    "e2llm": {
+      "sha": "aa0ae67a3377df6d82b480bb21c33593d1dcb2f9",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "e2llm",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "e2llm",
+            "description": "Drive the user's own signed-in browser through the e2llm MCP tools (list_tabs, sifr_capture, query, inspect, read_page,…"
+          },
+          {
+            "name": "sifr",
+            "description": "Read and analyze saved SiFR capture files (sifr-v2 / sifr-v3 JSON with ====METADATA==== / ====SUMMARY==== / ====NODES==…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
Add E2LLM to the Grok Build plugin marketplace.

This adds the public E2LLM SiFR repository as the marketplace source and regenerates the plugin index. E2LLM provides structured browser perception through SiFR plus browser action via its hosted MCP endpoint. The generated index includes the E2LLM MCP server and the published SiFR skills.

Source pinned to `e2llm/e2llm-sifr@aa0ae67a3377df6d82b480bb21c33593d1dcb2f9`.

Local validation on the rebased tree:

- `python3 scripts/generate-plugin-index.py --check` passed.
- `python3 scripts/validate-catalog.py` passed.

The GitHub `Validate catalog` workflow for this fork may still require upstream approval before its job can run; `action_required` without a job is not a validator failure.

