### PR TITLE
Add Composio plugin — connect Grok to 1,000+ apps with managed auth

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,20 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "composio",
+      "description": "Connect Grok to 1,000+ apps — Slack, GitHub, Gmail, Notion, Linear, and more — with fully managed OAuth. The composio CLI resolves the right tool just-in-time: search a task, then execute it.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ComposioHQ/composio-plugin-cc.git",
+        "sha": "5858b999c96438433a6a4ca1090f5a69a32925b6",
+        "path": "plugins/composio"
+      },
+      "homepage": "https://composio.dev",
+      "keywords": ["composio", "composio cli", "composio toolkits"],
+      "domains": ["composio.dev", "app.composio.dev", "docs.composio.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -150,6 +150,26 @@
         ]
       }
     },
+    "composio": {
+      "sha": "5858b999c96438433a6a4ca1090f5a69a32925b6",
+      "components": {
+        "commands": [
+          {
+            "name": "composio-connect",
+            "description": "Connect an app/toolkit to Composio via managed OAuth (e.g. Slack, GitHub, Gmail)."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "SessionStart",
+            "description": "startup|resume|clear|compact"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the **Composio** plugin to the catalog as a new remote-source entry.

- Plugin name: `composio`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/ComposioHQ/composio-plugin-cc.git` @ `5858b999c96438433a6a4ca1090f5a69a32925b6` (plugin root: `plugins/composio` via `source.path`)
- Homepage: https://composio.dev

Composio connects Grok to 1,000+ apps — Slack, GitHub, Gmail, Notion, Linear, and more — with fully managed OAuth. The plugin is intentionally thin: all logic lives in the `composio` CLI, which resolves the right tool just-in-time (`composio search "<task>"` → `composio execute`) instead of preloading a fixed toolset.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (ComposioHQ).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none directly. The plugin ships two bash hooks and one slash command — no MCP server, no bundled skills. All network activity goes through the separately installed `composio` CLI, which talks to Composio's hosted API (`*.composio.dev`) for tool search, execution, and managed OAuth. The SessionStart hook invokes the CLI (if already installed) to check login status and warm a top-50 toolkit-name cache; the UserPromptSubmit hook is pure bash with no network on the hot path.
- Credentials/permissions it requires (and why): a Composio account (`composio login`). Per-app OAuth grants are created on demand through Composio's managed auth when the user connects an app.

For transparency: when the CLI is not installed, the SessionStart context *suggests* the official install command (`curl -fsSL https://composio.dev/install | bash`) to the user — the plugin itself never downloads or executes remote code.

## Notes for reviewers

- Components indexed: 1 command (`/composio-connect`), 2 hooks (SessionStart on `startup|resume|clear|compact`, UserPromptSubmit). Hooks are short, readable bash with tight timeouts (8s/5s).
- The manifest uses the `.claude-plugin/plugin.json` layout, which this marketplace accepts for Claude-ecosystem plugins; the catalog entry points at the `plugins/composio` subdirectory.
- Submitted by the Composio team (pranav@composio.dev). Happy to adjust keywords/domains scoping if you'd like them tighter.
