### PR TITLE
Add grok-peer — Codex + Kimi peer slash commands for Grok Build

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -131,6 +131,19 @@
       "homepage": "https://github.com/figma/mcp-server-guide",
       "keywords": ["figma", "figma mcp"],
       "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "grok-peer",
+      "description": "Peer slash commands for Grok Build: call local Codex for code review and Kimi for bulk codebase analysis (/codex-review, /codex-adversarial, /kimi-analyze, /peer-setup).",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/howardpen9/grok-peer.git",
+        "sha": "19d3c1f3a965d84751d1bb2dfa0d46240b8692f7"
+      },
+      "homepage": "https://github.com/howardpen9/grok-peer",
+      "keywords": ["grok-peer", "codex-review", "kimi-analyze", "peer-review", "grok-build"]
     }
+
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,29 @@
         ]
       }
     },
+    "grok-peer": {
+      "sha": "19d3c1f3a965d84751d1bb2dfa0d46240b8692f7",
+      "components": {
+        "commands": [
+          {
+            "name": "codex-adversarial",
+            "description": "Adversarial peer review via Codex — challenge design, races, security"
+          },
+          {
+            "name": "codex-review",
+            "description": "Peer review via local Codex CLI (read-only) — like Claude's /codex:review"
+          },
+          {
+            "name": "kimi-analyze",
+            "description": "Bulk codebase analysis via local Kimi CLI — cheap long-context reader peer"
+          },
+          {
+            "name": "peer-setup",
+            "description": "Check that peer CLIs (Codex, Kimi) are installed and ready for /codex-* and /kimi-analyze"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## Summary

Adds **grok-peer** to the official catalog: slash commands so Grok Build can call **local Codex** (read-only / adversarial review) and **local Kimi** (bulk analyze) without leaving the session — the same *peer* job Claude users get from OpenAI’s codex-plugin-cc, when **Grok is the conductor**.

## Source

| Field | Value |
| --- | --- |
| Repo | https://github.com/howardpen9/grok-peer |
| Homepage | https://github.com/howardpen9/grok-peer |
| License | MIT |
| Pinned SHA | `19d3c1f3a965d84751d1bb2dfa0d46240b8692f7` |

## What users get

| Slash | Behavior |
| --- | --- |
| `/peer-setup` | Check `codex` / `kimi` on PATH |
| `/codex-review` | `codex review --uncommitted` or `--base` |
| `/codex-adversarial` | Challenge-style Codex review |
| `/kimi-analyze` | `kimi -p` one-shot analyze of cwd |

## Security (self-check)

- Scripts under `scripts/` only resolve and exec **local** `codex` / `kimi` binaries (optional overrides `CODEX_BIN` / `KIMI_BIN`).
- **No** `curl | bash`, remote download, postinstall fetch, or plugin-operated telemetry.
- Network/auth = existing user CLIs only (Codex / Kimi logins). Declared in `SECURITY.md` + README.
- No hooks that shell on every Bash/Write.

## Checklist

- [x] One kebab-case unique `name` in `marketplace.json`
- [x] Remote source + full 40-char lowercase `sha`
- [x] `python3 scripts/generate-plugin-index.py` regenerated
- [x] `python3 scripts/validate-catalog.py` passes
- [x] `python3 scripts/generate-plugin-index.py --check` passes
- [x] Homepage + clear description + product-scoped keywords
- [x] LICENSE + README + SECURITY on source repo
- [x] `grok plugin validate` green on source
- [x] Remote install smoke: `grok plugin install howardpen9/grok-peer --trust`

## Local install smoke

```bash
grok plugin install howardpen9/grok-peer --trust
# /peer-setup
# /codex-review
```

## Author

Howard Peng — https://github.com/howardpen9 · https://howard-peng.xyz

Not affiliated with xAI / OpenAI / Moonshot; interoperability naming only.