### PR TITLE
Add intellihelper-ui plugin (Liquid Glass React components)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "railway",
@@ -143,8 +200,38 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
+    },
+    {
+      "name": "intellihelper-ui",
+      "description": "Official IntelliHelper UI agent plugin (MCP Server + Skills). Liquid Glass React components for Next.js and Tailwind \u2014 browse the registry, install components with the CLI, apply design-system rules, and compose production UI from coding agents.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/IntelliHelper/agent-skills.git",
+        "sha": "133835c7e2229a9f56ea0bc8ee11de8962fcdb56"
+      },
+      "homepage": "https://ui.intellihelper.in",
+      "keywords": [
+        "intellihelper",
+        "intellihelper ui",
+        "intelli ui",
+        "liquid glass",
+        "intelli glass",
+        "intellihelper-ui"
+      ],
+      "domains": [
+        "ui.intellihelper.in",
+        "intellihelper.in"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -266,6 +266,63 @@
         ]
       }
     },
+    "intellihelper-ui": {
+      "sha": "133835c7e2229a9f56ea0bc8ee11de8962fcdb56",
+      "components": {
+        "agents": [
+          {
+            "name": "ui-builder",
+            "description": "Specialized IntelliHelper UI builder. Use for multi-component screens, Liquid Glass layouts, design-system-faithful Rea…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "add",
+            "description": "Install one or more IntelliHelper UI components into the current project"
+          },
+          {
+            "name": "audit",
+            "description": "Audit the project for correct IntelliHelper UI setup and usage"
+          },
+          {
+            "name": "list",
+            "description": "List IntelliHelper UI registry components (optionally by category)"
+          },
+          {
+            "name": "search",
+            "description": "Search the IntelliHelper UI registry for components"
+          },
+          {
+            "name": "themes",
+            "description": "List IntelliHelper Liquid Glass themes and when to use them"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "intellihelper-ui",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "add-component",
+            "description": "Install IntelliHelper UI components into a project correctly: init components.json, resolve dependencies, run CLI add,…"
+          },
+          {
+            "name": "compose-ui",
+            "description": "Compose production pages with IntelliHelper UI components — settings, dashboards, auth, CRUD tables, empty/loading/erro…"
+          },
+          {
+            "name": "intellihelper-ui",
+            "description": "Official IntelliHelper UI skill for Liquid Glass React/Next.js components. Use when the user asks for IntelliHelper UI,…"
+          },
+          {
+            "name": "liquid-glass",
+            "description": "IntelliHelper Liquid Glass design system — chrome vs content layers, frosted surfaces, themes (mono, aurora, sunset, fr…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: **intellihelper-ui**
- Type: remote source
- Source URL + pinned SHA: `https://github.com/IntelliHelper/agent-skills.git` @ `133835c7e2229a9f56ea0bc8ee11de8962fcdb56`
- Homepage: https://ui.intellihelper.in

Adds the official IntelliHelper UI agent plugin to the xAI catalog: MCP registry tools, design-system skills, slash commands, and a `ui-builder` agent for Liquid Glass React/Next.js components.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`IntelliHelper/agent-skills`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT on the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; MCP is stdio CLI only).
- Network endpoints this plugin calls (and why):
  - `npx` → npm registry to run `@intellihelper/cli@latest mcp` (stdio MCP server)
  - Registry/docs at `https://ui.intellihelper.in` (component registry JSON used by the CLI/MCP)
- Credentials/permissions it requires (and why):
  - None. No API keys or auth. Node.js 18+ required for `npx`.

## Components (from generated index)

| Type | Items |
| --- | --- |
| Skills | `intellihelper-ui`, `liquid-glass`, `add-component`, `compose-ui` |
| Commands | `add`, `search`, `list`, `audit`, `themes` |
| Agents | `ui-builder` |
| MCP | `intellihelper-ui` (stdio via `@intellihelper/cli`) |

## Notes for reviewers

- Official org: [IntelliHelper](https://github.com/IntelliHelper)
- Plugin source: [IntelliHelper/agent-skills](https://github.com/IntelliHelper/agent-skills)
- Product docs: [ui.intellihelper.in/getting-started#plugin](https://ui.intellihelper.in/getting-started#plugin)
- Keywords/domains are brand-scoped (`intellihelper*`, `liquid glass`, `ui.intellihelper.in`) to avoid generic CTA misfires.