### PR TITLE
Add version-gated daily plugin SHA bump automation

### DIFF
--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -25,10 +25,6 @@ on:
     - cron: "0 15 * * *"
   workflow_dispatch:
     inputs:
-      max_bumps:
-        description: Cap on plugins bumped this run
-        required: false
-        default: "10"
       plugin:
         description: Bump only this plugin name (exact catalog name; empty = all stale)
         required: false
@@ -67,7 +63,6 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/bump-plugin-shas.py \
-            --max-bumps "${{ inputs.max_bumps || '10' }}" \
             --only "${{ inputs.plugin }}" \
             --base-branch "${BASE_BRANCH}" \
             --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -72,13 +72,15 @@ jobs:
           # Pass inputs via env so shell never interpolates untrusted text.
           ONLY_PLUGIN: ${{ inputs.plugin }}
           FORCE_BUMP: ${{ inputs.force }}
+          # Avoid scripts/__pycache__ dirtying the worktree (import + index gen).
+          PYTHONDONTWRITEBYTECODE: "1"
         run: |
           set -euo pipefail
           extra=()
           case "${FORCE_BUMP:-}" in
             true|True|TRUE|1|yes|YES|on|ON) extra+=(--force) ;;
           esac
-          python3 scripts/bump-plugin-shas.py \
+          python3 -B scripts/bump-plugin-shas.py \
             --only "${ONLY_PLUGIN}" \
             --base-branch "${BASE_BRANCH}" \
             --github-output "$GITHUB_OUTPUT" \

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -1,7 +1,8 @@
 name: Bump plugin SHAs
 
-# Discover url-source pins whose upstream HEAD has moved, regenerate the
-# plugin index at the new SHA, and open a stacked PR set:
+# Discover url-source pins whose upstream HEAD has moved *and* plugin.json
+# version changed (via shared plugin_catalog extract), regenerate the plugin
+# index at the new SHA, and open a stacked PR set:
 #
 #   main
 #     └── bump/daily-YYYY-MM-DD            (PR → main)

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -60,10 +60,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          # Pass inputs via env so shell never interpolates untrusted text.
+          ONLY_PLUGIN: ${{ inputs.plugin }}
         run: |
           set -euo pipefail
           python3 scripts/bump-plugin-shas.py \
-            --only "${{ inputs.plugin }}" \
+            --only "${ONLY_PLUGIN}" \
             --base-branch "${BASE_BRANCH}" \
             --github-output "$GITHUB_OUTPUT"
 

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -1,0 +1,87 @@
+name: Bump plugin SHAs
+
+# Discover url-source pins whose upstream HEAD has moved, regenerate the
+# plugin index at the new SHA, and open one PR per plugin on branch
+# bump/<name>. Manual review only; no auto-merge.
+#
+# Uses the default GITHUB_TOKEN (contents + pull-requests + actions write).
+# PRs opened with GITHUB_TOKEN do not trigger on:pull_request, so after each
+# bump PR we re-dispatch validate-catalog.yml against the bump branch so the
+# required `validate` check can go green.
+#
+# Runs daily at 7am Pacific (15:00 UTC) and on workflow_dispatch.
+
+on:
+  schedule:
+    # 7am Pacific: 15:00 UTC (7am PST / 8am PDT). GitHub cron is UTC-only.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+    inputs:
+      max_bumps:
+        description: Cap on plugins bumped this run
+        required: false
+        default: "10"
+      plugin:
+        description: Bump only this plugin name (exact catalog name; empty = all stale)
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: bump-plugin-shas
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Default GITHUB_TOKEN is enough to push bump/* and open PRs.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Discover stale pins and open bump PRs
+        id: bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          python3 scripts/bump-plugin-shas.py \
+            --max-bumps "${{ inputs.max_bumps || '10' }}" \
+            --only "${{ inputs.plugin }}" \
+            --base-branch "${BASE_BRANCH}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Dispatch validate-catalog on each bump branch
+        if: steps.bump.outputs.pr-urls != '' && steps.bump.outputs.pr-urls != '[]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URLS: ${{ steps.bump.outputs.pr-urls }}
+        run: |
+          set -euo pipefail
+          failures="$(mktemp)"
+          jq -c '.[]' <<<"$PR_URLS" | while read -r entry; do
+            branch=$(jq -r '.branch' <<<"$entry")
+            name=$(jq -r '.name' <<<"$entry")
+            echo "Dispatching validate-catalog.yml against $branch ($name)"
+            if ! gh workflow run validate-catalog.yml --ref "$branch"; then
+              echo "::error::Failed to dispatch validate-catalog.yml against $branch ($name)"
+              echo "$branch" >> "$failures"
+            fi
+          done
+          if [ -s "$failures" ]; then
+            echo "::error::$(wc -l < "$failures" | tr -d ' ') validate dispatch(es) failed"
+            exit 1
+          fi

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -1,13 +1,20 @@
 name: Bump plugin SHAs
 
 # Discover url-source pins whose upstream HEAD has moved, regenerate the
-# plugin index at the new SHA, and open one PR per plugin on branch
-# bump/<name>. Manual review only; no auto-merge.
+# plugin index at the new SHA, and open a stacked PR set:
+#
+#   main
+#     └── bump/daily-YYYY-MM-DD          (PR → main)
+#           └── bump/YYYY-MM-DD/<plugin> (PR → daily / previous tip)
+#                 └── ...
+#
+# Only the daily PR targets main, so main history stays one landing per day.
+# Manual review only; no auto-merge.
 #
 # Uses the default GITHUB_TOKEN (contents + pull-requests + actions write).
 # PRs opened with GITHUB_TOKEN do not trigger on:pull_request, so after each
-# bump PR we re-dispatch validate-catalog.yml against the bump branch so the
-# required `validate` check can go green.
+# bump branch we re-dispatch validate-catalog.yml so the required `validate`
+# check can go green on the daily → main PR (and on stack tips).
 #
 # Runs daily at 7am Pacific (15:00 UTC) and on workflow_dispatch.
 
@@ -50,7 +57,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Discover stale pins and open bump PRs
+      - name: Discover stale pins and open stacked bump PRs
         id: bump
         env:
           GH_TOKEN: ${{ github.token }}
@@ -64,7 +71,7 @@ jobs:
             --base-branch "${BASE_BRANCH}" \
             --github-output "$GITHUB_OUTPUT"
 
-      - name: Dispatch validate-catalog on each bump branch
+      - name: Dispatch validate-catalog on each stack branch
         if: steps.bump.outputs.pr-urls != '' && steps.bump.outputs.pr-urls != '[]'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -72,7 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           failures="$(mktemp)"
-          jq -c '.[]' <<<"$PR_URLS" | while read -r entry; do
+          # Validate every branch that carries commits (skip pure daily base if
+          # it is only a pointer at main; still dispatch — validate is cheap).
+          jq -c '.[] | select(.skipped != true)' <<<"$PR_URLS" | while read -r entry; do
             branch=$(jq -r '.branch' <<<"$entry")
             name=$(jq -r '.name' <<<"$entry")
             echo "Dispatching validate-catalog.yml against $branch ($name)"

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -4,12 +4,13 @@ name: Bump plugin SHAs
 # plugin index at the new SHA, and open a stacked PR set:
 #
 #   main
-#     └── bump/daily-YYYY-MM-DD          (PR → main)
-#           └── bump/YYYY-MM-DD/<plugin> (PR → daily / previous tip)
-#                 └── ...
+#     └── bump/daily-YYYY-MM-DD            (PR → main)
+#           ├── bump/YYYY-MM-DD/<plugin-a> (PR → daily)
+#           ├── bump/YYYY-MM-DD/<plugin-b> (PR → daily)
+#           └── ...
 #
-# Only the daily PR targets main, so main history stays one landing per day.
-# Manual review only; no auto-merge.
+# All plugin PRs fan out from daily. Only the daily PR targets main, so main
+# history stays one landing per day. Manual review only; no auto-merge.
 #
 # Uses the default GITHUB_TOKEN (contents + pull-requests + actions write).
 # PRs opened with GITHUB_TOKEN do not trigger on:pull_request, so after each

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -12,6 +12,9 @@ name: Bump plugin SHAs
 # All plugin PRs fan out from daily. Only the daily PR targets main, so main
 # history stays one landing per day. Manual review only; no auto-merge.
 #
+# If remote bump/daily-YYYY-MM-DD already exists, the run is a no-op unless
+# workflow_dispatch sets force=true (rebuild from main, force-push stack).
+#
 # Uses the default GITHUB_TOKEN (contents + pull-requests + actions write).
 # PRs opened with GITHUB_TOKEN do not trigger on:pull_request, so after each
 # bump branch we re-dispatch validate-catalog.yml so the required `validate`
@@ -29,6 +32,11 @@ on:
         description: Bump only this plugin name (exact catalog name; empty = all stale)
         required: false
         default: ""
+      force:
+        description: Rebuild today's stack even if bump/daily-* already exists (force-push)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -62,23 +70,29 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           # Pass inputs via env so shell never interpolates untrusted text.
           ONLY_PLUGIN: ${{ inputs.plugin }}
+          FORCE_BUMP: ${{ inputs.force }}
         run: |
           set -euo pipefail
+          extra=()
+          case "${FORCE_BUMP:-}" in
+            true|True|TRUE|1|yes|YES|on|ON) extra+=(--force) ;;
+          esac
           python3 scripts/bump-plugin-shas.py \
             --only "${ONLY_PLUGIN}" \
             --base-branch "${BASE_BRANCH}" \
-            --github-output "$GITHUB_OUTPUT"
+            --github-output "$GITHUB_OUTPUT" \
+            "${extra[@]}"
 
       - name: Dispatch validate-catalog on each stack branch
-        if: steps.bump.outputs.pr-urls != '' && steps.bump.outputs.pr-urls != '[]'
+        # Run even when the bump step exits 1 after partial success so opened
+        # GITHUB_TOKEN PRs still get the required validate check.
+        if: ${{ !cancelled() && steps.bump.outputs.pr-urls != '' && steps.bump.outputs.pr-urls != '[]' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URLS: ${{ steps.bump.outputs.pr-urls }}
         run: |
           set -euo pipefail
           failures="$(mktemp)"
-          # Validate every branch that carries commits (skip pure daily base if
-          # it is only a pointer at main; still dispatch — validate is cheap).
           jq -c '.[] | select(.skipped != true)' <<<"$PR_URLS" | while read -r entry; do
             branch=$(jq -r '.branch' <<<"$entry")
             name=$(jq -r '.name' <<<"$entry")

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Bump-plugin-shas opens PRs with GITHUB_TOKEN, which does not trigger
+  # on:pull_request. That workflow re-dispatches this one against each
+  # bump/* branch so the required `validate` check can still run.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -3,6 +3,7 @@
   "plugins": {
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
+      "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
@@ -44,6 +45,7 @@
     },
     "chrome-devtools": {
       "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
+      "version": "0.22.0",
       "components": {
         "mcpServers": [
           {
@@ -81,6 +83,7 @@
     },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
+      "version": "1.0.0",
       "components": {
         "commands": [
           {
@@ -152,6 +155,7 @@
     },
     "figma": {
       "sha": "bea8bea5f676ab2bf76fa822b82f50b66653c098",
+      "version": "2.2.68",
       "components": {
         "mcpServers": [
           {
@@ -209,6 +213,7 @@
     },
     "firecrawl": {
       "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
+      "version": "1.1.0",
       "components": {
         "commands": [
           {
@@ -268,6 +273,7 @@
     },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
+      "version": "1.1.0",
       "components": {
         "mcpServers": [
           {
@@ -308,6 +314,7 @@
       }
     },
     "neon": {
+      "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
@@ -333,6 +340,7 @@
     },
     "railway": {
       "sha": "2405547f2044071c9d43bf6782edeb5d93e5bb4e",
+      "version": "1.3.5",
       "components": {
         "hooks": [
           {
@@ -356,6 +364,7 @@
     },
     "sentry": {
       "sha": "2c3b6c74b2b830c3ce2836f1fde6d7f21d37d4c4",
+      "version": "1.0.0",
       "components": {
         "commands": [
           {
@@ -507,6 +516,7 @@
     },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
+      "version": "5.1.0",
       "components": {
         "hooks": [
           {
@@ -576,6 +586,7 @@
     },
     "vercel": {
       "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
+      "version": "0.42.1",
       "components": {
         "agents": [
           {

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Discover stale url-source pins and open one bump PR per plugin.
+
+For each entry in `.grok-plugin/marketplace.json` with
+`source: {source: "url", url, sha}`:
+
+  1. Resolve upstream HEAD via `git ls-remote`
+  2. If HEAD != pinned sha, treat as a candidate bump
+  3. Skip if a PR already exists for `bump/<name>`
+  4. Update the pin, regenerate the plugin index, commit, push, open PR
+
+Designed to run under GitHub Actions with GITHUB_TOKEN
+(contents:write + pull-requests:write). Also runnable locally with
+`--dry-run` (no push/PR) or a real `GH_TOKEN`.
+
+Usage:
+  python3 scripts/bump-plugin-shas.py [--dry-run] [--max-bumps N] [--only NAME]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CATALOG_PATH = Path(".grok-plugin/marketplace.json")
+INDEX_PATH = Path(".grok-plugin/plugin-index.json")
+INDEX_SCRIPT = Path("scripts/generate-plugin-index.py")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+BRANCH_PREFIX = "bump/"
+ALLOWED_HOSTS = {"github.com", "gitlab.com", "bitbucket.org"}
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    capture: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    result = subprocess.run(
+        cmd,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+        capture_output=capture,
+        text=True,
+        env=merged,
+    )
+    if check and result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        detail = stderr or stdout or f"exit {result.returncode}"
+        raise RuntimeError(f"`{' '.join(cmd)}` failed: {detail}")
+    return result
+
+
+def load_catalog() -> dict:
+    return json.loads((REPO_ROOT / CATALOG_PATH).read_text(encoding="utf-8"))
+
+
+def url_entries(catalog: dict) -> list[dict]:
+    out = []
+    for entry in catalog.get("plugins", []):
+        if not isinstance(entry, dict):
+            continue
+        source = entry.get("source")
+        if not isinstance(source, dict):
+            continue
+        if source.get("source") != "url" and source.get("type") != "url":
+            continue
+        out.append(entry)
+    return out
+
+
+def host_allowed(url: str) -> bool:
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host in ALLOWED_HOSTS
+
+
+def ls_remote_head(url: str) -> str:
+    result = run(["git", "ls-remote", url, "HEAD"], check=True)
+    lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
+    if not lines:
+        raise RuntimeError(f"empty ls-remote for {url}")
+    sha = lines[0].split()[0].strip().lower()
+    if not SHA_RE.match(sha):
+        raise RuntimeError(f"unexpected ls-remote output for {url}: {lines[0]!r}")
+    return sha
+
+
+def open_pr_for_branch(branch: str) -> str | None:
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    url = (result.stdout or "").strip()
+    return url or None
+
+
+def replace_sha_in_catalog(name: str, old_sha: str, new_sha: str) -> None:
+    path = REPO_ROOT / CATALOG_PATH
+    text = path.read_text(encoding="utf-8")
+    name_json = json.dumps(name)
+    pattern = re.compile(
+        rf'("name"\s*:\s*{re.escape(name_json)}[\s\S]*?"sha"\s*:\s*")'
+        rf"{re.escape(old_sha)}"
+        rf'(")',
+        re.MULTILINE,
+    )
+    new_text, n = pattern.subn(rf"\g<1>{new_sha}\2", text, count=1)
+    if n != 1:
+        needle = f'"sha": "{old_sha}"'
+        if text.count(needle) != 1:
+            raise RuntimeError(
+                f"could not uniquely locate sha for plugin {name!r} "
+                f"(old={old_sha})"
+            )
+        new_text = text.replace(needle, f'"sha": "{new_sha}"', 1)
+    path.write_text(new_text, encoding="utf-8")
+
+
+def regenerate_index() -> None:
+    run([sys.executable, str(REPO_ROOT / INDEX_SCRIPT)], check=True, capture=False)
+
+
+def git_identity() -> None:
+    run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+    run(
+        [
+            "git",
+            "config",
+            "user.email",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        ],
+        check=True,
+    )
+
+
+def ensure_clean_worktree() -> None:
+    result = run(["git", "status", "--porcelain"], check=True)
+    dirty = [
+        line
+        for line in (result.stdout or "").splitlines()
+        if line.strip() and not line.rstrip().endswith(".DS_Store")
+    ]
+    if dirty:
+        raise RuntimeError(
+            "working tree is dirty; commit or stash before bumping:\n"
+            + "\n".join(dirty)
+        )
+
+
+def origin_base(base_branch: str) -> str:
+    run(["git", "fetch", "origin", base_branch, "--depth", "1"], check=False)
+    run(["git", "fetch", "origin", base_branch], check=True)
+    result = run(["git", "rev-parse", f"origin/{base_branch}"], check=True)
+    return (result.stdout or "").strip()
+
+
+def open_bump_pr(
+    *,
+    name: str,
+    old_sha: str,
+    new_sha: str,
+    url: str,
+    branch: str,
+    base_branch: str,
+    run_url: str,
+    dry_run: bool,
+) -> str | None:
+    short_old = old_sha[:7]
+    short_new = new_sha[:7]
+    title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
+    body_lines = [
+        f"Automated pin bump for `{name}`.",
+        "",
+        f"- **source:** {url}",
+        f"- **old:** `{old_sha}`",
+        f"- **new:** `{new_sha}`",
+        "",
+        "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
+        "at the new pin.",
+        "",
+        "Human review still required (no auto-merge). Confirm the upstream "
+        "diff is intentional before merging.",
+    ]
+    if run_url:
+        body_lines.extend(["", f"Triggered by: {run_url}"])
+    body = "\n".join(body_lines) + "\n"
+
+    if dry_run:
+        print(f"[dry-run] would open PR on {branch}: {title}")
+        return None
+
+    head = origin_base(base_branch)
+    git_identity()
+
+    # Fresh branch from origin/base every time so each PR is single-plugin.
+    run(["git", "checkout", "--detach", head], check=True)
+    run(["git", "checkout", "-B", branch], check=True)
+    run(
+        [
+            "git",
+            "checkout",
+            head,
+            "--",
+            str(CATALOG_PATH),
+            str(INDEX_PATH),
+        ],
+        check=True,
+    )
+
+    replace_sha_in_catalog(name, old_sha, new_sha)
+    regenerate_index()
+
+    run(
+        ["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)],
+        check=True,
+    )
+    status = run(["git", "status", "--porcelain"], check=True)
+    if not (status.stdout or "").strip():
+        raise RuntimeError(f"no file changes after bumping {name}")
+
+    run(["git", "commit", "-m", title], check=True)
+    # Bot-owned branch; force is intentional so retries rewrite the same tip.
+    run(["git", "push", "--force", "origin", f"HEAD:refs/heads/{branch}"], check=True)
+
+    existing = open_pr_for_branch(branch)
+    if existing:
+        print(f"PR already open for {branch}: {existing}")
+        return existing
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base_branch,
+            "--head",
+            branch,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        check=True,
+    )
+    pr_url = (result.stdout or "").strip()
+    print(f"Opened {pr_url}")
+    return pr_url
+
+
+def discover_candidates(
+    *,
+    only: str,
+    freeze: set[str],
+    skip_open_pr_check: bool,
+) -> tuple[list[dict], list[dict]]:
+    catalog = load_catalog()
+    candidates: list[dict] = []
+    skipped: list[dict] = []
+
+    for entry in url_entries(catalog):
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            skipped.append({"name": "<unnamed>", "reason": "missing name"})
+            continue
+        if only and name != only:
+            continue
+        if name in freeze:
+            skipped.append({"name": name, "reason": "frozen"})
+            continue
+
+        source = entry["source"]
+        url = source.get("url")
+        old_sha = source.get("sha")
+        if not isinstance(url, str) or not url.startswith("https://"):
+            skipped.append({"name": name, "reason": f"bad url {url!r}"})
+            continue
+        if not host_allowed(url):
+            skipped.append({"name": name, "reason": f"host not allowed: {url}"})
+            continue
+        if not isinstance(old_sha, str) or not SHA_RE.match(old_sha):
+            skipped.append({"name": name, "reason": f"bad pin {old_sha!r}"})
+            continue
+
+        try:
+            new_sha = ls_remote_head(url)
+        except Exception as e:  # noqa: BLE001
+            skipped.append({"name": name, "reason": f"ls-remote failed: {e}"})
+            continue
+
+        if new_sha == old_sha.lower():
+            skipped.append({"name": name, "reason": "up to date"})
+            continue
+
+        branch = f"{BRANCH_PREFIX}{name}"
+        if not skip_open_pr_check:
+            existing = open_pr_for_branch(branch)
+            if existing:
+                skipped.append(
+                    {"name": name, "reason": f"open PR already: {existing}"}
+                )
+                continue
+
+        candidates.append(
+            {
+                "name": name,
+                "url": url,
+                "old_sha": old_sha.lower(),
+                "new_sha": new_sha,
+                "branch": branch,
+            }
+        )
+
+    return candidates, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--max-bumps", type=int, default=10)
+    parser.add_argument("--only", default="", help="Exact plugin name to bump")
+    parser.add_argument(
+        "--base-branch",
+        default=os.environ.get("BASE_BRANCH", "main"),
+    )
+    parser.add_argument(
+        "--freeze",
+        default=os.environ.get("FREEZE_SHAS", ""),
+        help="Space-separated plugin names to never auto-bump",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+        help="Write pr-urls JSON for the Actions workflow",
+    )
+    args = parser.parse_args()
+
+    freeze = {n for n in args.freeze.split() if n}
+    only = args.only.strip()
+    run_url = os.environ.get("RUN_URL", "")
+
+    if not args.dry_run:
+        ensure_clean_worktree()
+
+    start_ref_proc = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True)
+    start_ref = (start_ref_proc.stdout or "").strip()
+    if start_ref == "HEAD":
+        start_ref = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+
+    candidates, skipped = discover_candidates(
+        only=only,
+        freeze=freeze,
+        skip_open_pr_check=args.dry_run,
+    )
+    if args.max_bumps >= 0:
+        candidates = candidates[: args.max_bumps]
+
+    print(f"candidates={len(candidates)} skipped={len(skipped)}")
+    for s in skipped:
+        print(f"  skip {s['name']}: {s['reason']}")
+
+    pr_urls: list[dict] = []
+    errors: list[str] = []
+
+    for c in candidates:
+        print(
+            f"bump {c['name']}: {c['old_sha'][:7]} -> {c['new_sha'][:7]} "
+            f"({c['url']})"
+        )
+        try:
+            pr_url = open_bump_pr(
+                name=c["name"],
+                old_sha=c["old_sha"],
+                new_sha=c["new_sha"],
+                url=c["url"],
+                branch=c["branch"],
+                base_branch=args.base_branch,
+                run_url=run_url,
+                dry_run=args.dry_run,
+            )
+            pr_urls.append(
+                {
+                    "name": c["name"],
+                    "old_sha": c["old_sha"],
+                    "new_sha": c["new_sha"],
+                    "branch": c["branch"],
+                    "pr_url": pr_url or "",
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            msg = f"{c['name']}: {e}"
+            errors.append(msg)
+            print(f"ERROR: {msg}", file=sys.stderr)
+
+    if not args.dry_run:
+        run(["git", "checkout", "-f", start_ref], check=False)
+
+    payload = json.dumps(pr_urls, separators=(",", ":"))
+    print(f"pr-urls={payload}")
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"pr-urls={payload}\n")
+            fh.write(f"bumped_count={len(pr_urls)}\n")
+
+    if errors:
+        print(f"{len(errors)} bump(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -4,21 +4,19 @@
 Stack shape (one run / Pacific day):
 
   main
-    └── bump/daily-YYYY-MM-DD          PR → main
-          └── bump/YYYY-MM-DD/<plugin> PR → daily (then linear on previous tip)
-                └── bump/YYYY-MM-DD/<next>
-                      └── ...
+    └── bump/daily-YYYY-MM-DD            PR → main
+          ├── bump/YYYY-MM-DD/<plugin-a> PR → daily
+          ├── bump/YYYY-MM-DD/<plugin-b> PR → daily
+          └── ...
 
-Only the daily PR targets main, so main's history stays one merge per day
-after the stack is reviewed. Per-plugin PRs are for isolated review of each
-pin bump.
+Every plugin branch is cut from the daily tip and targets daily (fan-out).
+Only the daily PR targets main, so main history stays one landing per day.
 
 For each url-source entry:
 
   1. Resolve upstream HEAD via `git ls-remote`
   2. If HEAD != pinned sha, treat as a candidate
-  3. Apply bumps in a linear stack on top of the daily branch
-  4. Each step: update the pin, regenerate the plugin index, commit, push, open PR
+  3. Branch from daily, update pin + regenerate plugin index, open PR → daily
 
 Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
 Local: `--dry-run` (no push/PR).
@@ -216,7 +214,7 @@ def ensure_pr(
     dry_run: bool,
 ) -> str | None:
     if dry_run:
-        print(f"[dry-run] would open PR {head} → {base}: {title}")
+        print(f"[dry-run] would open PR {head} -> {base}: {title}")
         return None
 
     existing = open_pr_for_branch(head)
@@ -256,15 +254,18 @@ def open_daily_base(
     day: str,
     run_url: str,
     dry_run: bool,
-) -> str | None:
-    """Create daily branch at main tip (no extra commit) and PR it into main."""
+) -> tuple[str | None, str]:
+    """Create daily branch from main (marker commit) and PR it into main.
+
+    Returns (pr_url, daily_tip_sha). dry-run returns (None, fake sha).
+    """
     title = f"chore(plugins): daily pin bumps {day}"
     body_lines = [
-        f"Daily stack base for plugin pin bumps on **{day}** (Pacific).",
+        f"Daily base for plugin pin bumps on **{day}** (Pacific).",
         "",
-        "Per-plugin PRs stack on top of this branch. Review those for each",
-        "upstream diff; merge this PR into `main` only after the stack is",
-        "accepted (keeps main history to one landing per day).",
+        "Per-plugin PRs all target this branch (fan-out from daily). Review",
+        "and merge the ones you want into this branch, then land this PR into",
+        "`main` so history stays one landing per day.",
         "",
         "No auto-merge.",
     ]
@@ -273,15 +274,14 @@ def open_daily_base(
     body = "\n".join(body_lines) + "\n"
 
     if dry_run:
-        print(f"[dry-run] would open daily base {daily_branch} → {main_branch}")
-        return None
+        print(f"[dry-run] would open daily base {daily_branch} -> {main_branch}")
+        return None, "0" * 40
 
     head = origin_base(main_branch)
     git_identity()
     run(["git", "checkout", "--detach", head], check=True)
     run(["git", "checkout", "-B", daily_branch], check=True)
-    # Empty marker commit so the daily → main PR can open (GitHub rejects
-    # empty branch diffs). Plugin commits stack on top of this.
+    # Marker commit so the daily -> main PR can open (GitHub rejects empty diffs).
     run(
         [
             "git",
@@ -292,14 +292,16 @@ def open_daily_base(
         ],
         check=True,
     )
+    tip = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
     push_branch(daily_branch)
-    return ensure_pr(
+    pr_url = ensure_pr(
         head=daily_branch,
         base=main_branch,
         title=title,
         body=body,
         dry_run=False,
     )
+    return pr_url, tip
 
 
 def apply_plugin_bump(
@@ -309,15 +311,12 @@ def apply_plugin_bump(
     new_sha: str,
     url: str,
     branch: str,
-    parent_branch: str,
-    parent_sha: str,
+    daily_branch: str,
+    daily_sha: str,
     run_url: str,
     dry_run: bool,
-) -> tuple[str | None, str]:
-    """Create plugin branch from parent tip, commit bump, open PR → parent.
-
-    Returns (pr_url, new_tip_sha).
-    """
+) -> str | None:
+    """Branch from daily tip, commit one plugin bump, open PR -> daily."""
     short_old = old_sha[:7]
     short_new = new_sha[:7]
     title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
@@ -327,13 +326,13 @@ def apply_plugin_bump(
         f"- **source:** {url}",
         f"- **old:** `{old_sha}`",
         f"- **new:** `{new_sha}`",
-        f"- **stacks on:** `{parent_branch}`",
+        f"- **base:** `{daily_branch}`",
         "",
         "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
         "at the new pin.",
         "",
-        "Part of the daily stack; do not merge this into `main` directly. "
-        "Merge up into the daily base, then land the daily PR.",
+        "Targets the daily base, not `main`. Merge into the daily branch "
+        "(or close to drop this bump), then land the daily PR.",
         "",
         "Human review still required (no auto-merge).",
     ]
@@ -343,13 +342,14 @@ def apply_plugin_bump(
 
     if dry_run:
         print(
-            f"[dry-run] would open PR {branch} → {parent_branch}: {title} "
-            f"(parent={parent_sha[:7]})"
+            f"[dry-run] would open PR {branch} -> {daily_branch}: {title} "
+            f"(from daily {daily_sha[:7]})"
         )
-        return None, parent_sha
+        return None
 
     git_identity()
-    run(["git", "checkout", "--detach", parent_sha], check=True)
+    # Always cut from the daily tip so siblings are independent.
+    run(["git", "checkout", "--detach", daily_sha], check=True)
     run(["git", "checkout", "-B", branch], check=True)
 
     replace_sha_in_catalog(name, old_sha, new_sha)
@@ -361,17 +361,15 @@ def apply_plugin_bump(
         raise RuntimeError(f"no file changes after bumping {name}")
 
     run(["git", "commit", "-m", title], check=True)
-    tip = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
     push_branch(branch)
 
-    pr_url = ensure_pr(
+    return ensure_pr(
         head=branch,
-        base=parent_branch,
+        base=daily_branch,
         title=title,
         body=body,
         dry_run=False,
     )
-    return pr_url, tip
 
 
 def discover_candidates(
@@ -437,7 +435,7 @@ def main() -> int:
     parser.add_argument(
         "--base-branch",
         default=os.environ.get("BASE_BRANCH", "main"),
-        help="Default branch (stack root). Daily PR targets this.",
+        help="Default branch. Daily PR targets this.",
     )
     parser.add_argument(
         "--day",
@@ -520,7 +518,7 @@ def main() -> int:
             return 0
 
     try:
-        daily_pr = open_daily_base(
+        daily_pr, daily_sha = open_daily_base(
             daily_branch=daily_branch,
             main_branch=args.base_branch,
             day=day,
@@ -536,31 +534,21 @@ def main() -> int:
             }
         )
 
-        if args.dry_run:
-            parent_branch = daily_branch
-            parent_sha = "dry-run"
-        else:
-            parent_branch = daily_branch
-            parent_sha = run(
-                ["git", "rev-parse", f"refs/heads/{daily_branch}"],
-                check=True,
-            ).stdout.strip()
-
         for c in candidates:
             plugin_branch = f"bump/{day}/{c['name']}"
             print(
                 f"bump {c['name']}: {c['old_sha'][:7]} -> {c['new_sha'][:7]} "
-                f"({c['url']}) on {plugin_branch} → {parent_branch}"
+                f"({c['url']}) on {plugin_branch} -> {daily_branch}"
             )
             try:
-                pr_url, parent_sha = apply_plugin_bump(
+                pr_url = apply_plugin_bump(
                     name=c["name"],
                     old_sha=c["old_sha"],
                     new_sha=c["new_sha"],
                     url=c["url"],
                     branch=plugin_branch,
-                    parent_branch=parent_branch,
-                    parent_sha=parent_sha if parent_sha != "dry-run" else "0" * 40,
+                    daily_branch=daily_branch,
+                    daily_sha=daily_sha,
                     run_url=run_url,
                     dry_run=args.dry_run,
                 )
@@ -570,53 +558,48 @@ def main() -> int:
                         "old_sha": c["old_sha"],
                         "new_sha": c["new_sha"],
                         "branch": plugin_branch,
-                        "base": parent_branch,
+                        "base": daily_branch,
                         "pr_url": pr_url or "",
                     }
                 )
-                parent_branch = plugin_branch
             except Exception as e:  # noqa: BLE001
                 msg = f"{c['name']}: {e}"
                 errors.append(msg)
                 print(f"ERROR: {msg}", file=sys.stderr)
-                # Stop the stack here; later plugins would base on a failed tip.
-                break
     finally:
         if not args.dry_run:
             run(["git", "checkout", "-f", start_ref], check=False)
 
-    # Point daily PR body at children once we know them (best-effort).
     if not args.dry_run and daily_pr and len(pr_urls) > 1:
         child_lines = [
             f"- `{e['branch']}` ({e['name']}): {e['pr_url'] or 'opened'}"
             for e in pr_urls
             if e.get("name") != "_daily"
         ]
-        try:
-            run(
-                [
-                    "gh",
-                    "pr",
-                    "edit",
-                    daily_branch,
-                    "--body",
-                    "\n".join(
-                        [
-                            f"Daily stack base for plugin pin bumps on **{day}** (Pacific).",
-                            "",
-                            "Stacked plugin PRs (merge upward into this branch, then land this PR):",
-                            *child_lines,
-                            "",
-                            "No auto-merge.",
-                            *(["", f"Triggered by: {run_url}"] if run_url else []),
-                        ]
-                    )
-                    + "\n",
-                ],
-                check=False,
-            )
-        except Exception:  # noqa: BLE001
-            pass
+        run(
+            [
+                "gh",
+                "pr",
+                "edit",
+                daily_branch,
+                "--body",
+                "\n".join(
+                    [
+                        f"Daily base for plugin pin bumps on **{day}** (Pacific).",
+                        "",
+                        "Plugin PRs (all target this branch; merge or close independently):",
+                        *child_lines,
+                        "",
+                        "Land this PR into `main` after the desired plugins are merged here.",
+                        "",
+                        "No auto-merge.",
+                        *(["", f"Triggered by: {run_url}"] if run_url else []),
+                    ]
+                )
+                + "\n",
+            ],
+            check=False,
+        )
 
     payload = json.dumps(pr_urls, separators=(",", ":"))
     print(f"pr-urls={payload}")

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -12,17 +12,15 @@ Stack shape (one run / Pacific day):
 Every plugin branch is cut from the daily tip and targets daily (fan-out).
 Only the daily PR targets main, so main history stays one landing per day.
 
-For each url-source entry:
-
-  1. Resolve upstream HEAD via `git ls-remote`
-  2. If HEAD != pinned sha, treat as a candidate
-  3. Branch from daily, update pin + regenerate plugin index, open PR → daily
+Default: if remote `bump/daily-YYYY-MM-DD` already exists, the run is a
+no-op (open, merged, or abandoned). Pass `--force` to rebuild that day's
+stack from current main and force-push daily + plugin branches.
 
 Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
 Local: `--dry-run` (no push/PR).
 
 Usage:
-  python3 scripts/bump-plugin-shas.py [--dry-run] [--only NAME]
+  python3 scripts/bump-plugin-shas.py [--dry-run] [--force] [--only NAME]
 """
 
 from __future__ import annotations
@@ -123,7 +121,20 @@ def ls_remote_head(url: str) -> str:
     return sha
 
 
+def remote_branch_exists(branch: str) -> bool:
+    """True if origin has refs/heads/<branch>. Fails hard on git errors."""
+    result = run(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        check=True,
+    )
+    return bool((result.stdout or "").strip())
+
+
 def open_pr_for_branch(branch: str) -> str | None:
+    """Return open PR URL for head branch, or None if none.
+
+    Raises on `gh` failure so we never treat API errors as "no PR".
+    """
     result = run(
         [
             "gh",
@@ -138,10 +149,8 @@ def open_pr_for_branch(branch: str) -> str | None:
             "--jq",
             ".[0].url // empty",
         ],
-        check=False,
+        check=True,
     )
-    if result.returncode != 0:
-        return None
     url = (result.stdout or "").strip()
     return url or None
 
@@ -205,6 +214,13 @@ def origin_base(base_branch: str) -> str:
     return (result.stdout or "").strip()
 
 
+def hard_reset_to(sha: str) -> None:
+    """Detach at sha with a clean tree (isolates failures across plugins)."""
+    run(["git", "checkout", "--detach", sha], check=True)
+    run(["git", "reset", "--hard", sha], check=True)
+    run(["git", "clean", "-fd"], check=True)
+
+
 def ensure_pr(
     *,
     head: str,
@@ -243,8 +259,21 @@ def ensure_pr(
     return pr_url
 
 
-def push_branch(branch: str) -> None:
-    run(["git", "push", "--force", "origin", f"HEAD:refs/heads/{branch}"], check=True)
+def push_branch(branch: str, *, force: bool) -> None:
+    cmd = ["git", "push"]
+    if force:
+        cmd.append("--force")
+    cmd.extend(["origin", f"HEAD:refs/heads/{branch}"])
+    run(cmd, check=True)
+
+
+def write_github_output(path: str, pr_urls: list[dict], bumped_count: int) -> None:
+    payload = json.dumps(pr_urls, separators=(",", ":"))
+    print(f"pr-urls={payload}")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(f"pr-urls={payload}\n")
+            fh.write(f"bumped_count={bumped_count}\n")
 
 
 def open_daily_base(
@@ -253,9 +282,10 @@ def open_daily_base(
     main_branch: str,
     day: str,
     run_url: str,
+    force: bool,
     dry_run: bool,
 ) -> tuple[str | None, str]:
-    """Create daily branch from main (marker commit) and PR it into main.
+    """Create or rebuild daily branch from main; PR it into main.
 
     Returns (pr_url, daily_tip_sha). dry-run returns (None, fake sha).
     """
@@ -269,17 +299,20 @@ def open_daily_base(
         "",
         "No auto-merge.",
     ]
+    if force:
+        body_lines.extend(["", "Rebuilt with `--force` from current main."])
     if run_url:
         body_lines.extend(["", f"Triggered by: {run_url}"])
     body = "\n".join(body_lines) + "\n"
 
     if dry_run:
-        print(f"[dry-run] would open daily base {daily_branch} -> {main_branch}")
+        action = "rebuild (force)" if force else "create"
+        print(f"[dry-run] would {action} daily base {daily_branch} -> {main_branch}")
         return None, "0" * 40
 
     head = origin_base(main_branch)
     git_identity()
-    run(["git", "checkout", "--detach", head], check=True)
+    hard_reset_to(head)
     run(["git", "checkout", "-B", daily_branch], check=True)
     # Marker commit so the daily -> main PR can open (GitHub rejects empty diffs).
     run(
@@ -293,7 +326,8 @@ def open_daily_base(
         check=True,
     )
     tip = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
-    push_branch(daily_branch)
+    # First create: non-force push. Rebuild: force-push over the existing tip.
+    push_branch(daily_branch, force=force)
     pr_url = ensure_pr(
         head=daily_branch,
         base=main_branch,
@@ -314,6 +348,7 @@ def apply_plugin_bump(
     daily_branch: str,
     daily_sha: str,
     run_url: str,
+    force: bool,
     dry_run: bool,
 ) -> str | None:
     """Branch from daily tip, commit one plugin bump, open PR -> daily."""
@@ -343,25 +378,32 @@ def apply_plugin_bump(
     if dry_run:
         print(
             f"[dry-run] would open PR {branch} -> {daily_branch}: {title} "
-            f"(from daily {daily_sha[:7]})"
+            f"(from daily {daily_sha[:7]}, force={force})"
         )
         return None
 
     git_identity()
-    # Always cut from the daily tip so siblings are independent.
-    run(["git", "checkout", "--detach", daily_sha], check=True)
+    # Clean cut from daily tip so a prior plugin failure cannot leak dirty files.
+    hard_reset_to(daily_sha)
     run(["git", "checkout", "-B", branch], check=True)
 
-    replace_sha_in_catalog(name, old_sha, new_sha)
-    regenerate_index()
+    try:
+        replace_sha_in_catalog(name, old_sha, new_sha)
+        regenerate_index()
 
-    run(["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)], check=True)
-    status = run(["git", "status", "--porcelain"], check=True)
-    if not (status.stdout or "").strip():
-        raise RuntimeError(f"no file changes after bumping {name}")
+        run(["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)], check=True)
+        status = run(["git", "status", "--porcelain"], check=True)
+        if not (status.stdout or "").strip():
+            raise RuntimeError(f"no file changes after bumping {name}")
 
-    run(["git", "commit", "-m", title], check=True)
-    push_branch(branch)
+        run(["git", "commit", "-m", title], check=True)
+        # force=True when rebuilding the day; otherwise create-only push.
+        # If the plugin branch already exists without --force, push fails closed.
+        push_branch(branch, force=force)
+    except Exception:
+        # Leave a clean tree for the next candidate even if this one failed.
+        hard_reset_to(daily_sha)
+        raise
 
     return ensure_pr(
         head=branch,
@@ -427,9 +469,22 @@ def discover_candidates(
     return candidates, skipped
 
 
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Rebuild today's stack even if bump/daily-YYYY-MM-DD already exists "
+            "on origin. Force-pushes daily and plugin branches. "
+            "Also set via FORCE_BUMP=true."
+        ),
+    )
     parser.add_argument("--only", default="", help="Exact plugin name to bump")
     parser.add_argument(
         "--base-branch",
@@ -458,6 +513,7 @@ def main() -> int:
     run_url = os.environ.get("RUN_URL", "")
     day = args.day.strip() or pacific_date()
     daily_branch = f"bump/daily-{day}"
+    force = bool(args.force) or env_flag("FORCE_BUMP")
 
     if not args.dry_run:
         ensure_clean_worktree()
@@ -469,50 +525,45 @@ def main() -> int:
 
     candidates, skipped = discover_candidates(only=only, freeze=freeze)
 
-    print(f"day={day} daily_branch={daily_branch}")
+    print(f"day={day} daily_branch={daily_branch} force={force}")
     print(f"candidates={len(candidates)} skipped={len(skipped)}")
     for s in skipped:
         print(f"  skip {s['name']}: {s['reason']}")
 
     pr_urls: list[dict] = []
     errors: list[str] = []
+    daily_pr: str | None = None
 
     if not candidates:
         print("nothing to bump")
-        payload = json.dumps(pr_urls, separators=(",", ":"))
-        print(f"pr-urls={payload}")
-        if args.github_output:
-            with open(args.github_output, "a", encoding="utf-8") as fh:
-                fh.write(f"pr-urls={payload}\n")
-                fh.write("bumped_count=0\n")
+        write_github_output(args.github_output, pr_urls, 0)
         return 0
 
-    # One open daily stack per Pacific day. Re-runs wait for that PR to close.
-    if not args.dry_run:
-        existing_daily = open_pr_for_branch(daily_branch)
-        if existing_daily:
-            print(
-                f"daily stack already open for {day}: {existing_daily}; "
-                "skipping (close it or wait for merge before re-running)"
-            )
-            payload = json.dumps(
-                [
-                    {
-                        "name": "_daily",
-                        "branch": daily_branch,
-                        "base": args.base_branch,
-                        "pr_url": existing_daily,
-                        "skipped": True,
-                    }
-                ],
-                separators=(",", ":"),
-            )
-            print(f"pr-urls={payload}")
-            if args.github_output:
-                with open(args.github_output, "a", encoding="utf-8") as fh:
-                    fh.write(f"pr-urls={payload}\n")
-                    fh.write("bumped_count=0\n")
-            return 0
+    # Gate on remote branch existence (not open PR). Merged/closed daily still
+    # leaves the ref around unless deleted, so same-day re-runs stay no-ops.
+    daily_exists = remote_branch_exists(daily_branch)
+    if daily_exists and not force:
+        print(
+            f"remote branch {daily_branch} already exists; no-op "
+            "(pass --force to rebuild and force-push this day's stack)"
+        )
+        write_github_output(
+            args.github_output,
+            [
+                {
+                    "name": "_daily",
+                    "branch": daily_branch,
+                    "base": args.base_branch,
+                    "pr_url": "",
+                    "skipped": True,
+                }
+            ],
+            0,
+        )
+        return 0
+
+    if daily_exists and force:
+        print(f"remote branch {daily_branch} exists; --force rebuild from main")
 
     try:
         daily_pr, daily_sha = open_daily_base(
@@ -520,8 +571,11 @@ def main() -> int:
             main_branch=args.base_branch,
             day=day,
             run_url=run_url,
+            force=force or daily_exists,
             dry_run=args.dry_run,
         )
+        # First create: force=False for push. But if daily_exists we must force.
+        # open_daily_base already got force=force or daily_exists.
         pr_urls.append(
             {
                 "name": "_daily",
@@ -530,6 +584,10 @@ def main() -> int:
                 "pr_url": daily_pr or "",
             }
         )
+
+        # Plugin pushes: force when rebuilding the day so existing plugin
+        # branches are rewritten onto the new daily tip.
+        plugin_force = force or daily_exists
 
         for c in candidates:
             plugin_branch = f"bump/{day}/{c['name']}"
@@ -547,6 +605,7 @@ def main() -> int:
                     daily_branch=daily_branch,
                     daily_sha=daily_sha,
                     run_url=run_url,
+                    force=plugin_force,
                     dry_run=args.dry_run,
                 )
                 pr_urls.append(
@@ -598,13 +657,8 @@ def main() -> int:
             check=False,
         )
 
-    payload = json.dumps(pr_urls, separators=(",", ":"))
-    print(f"pr-urls={payload}")
-    if args.github_output:
-        with open(args.github_output, "a", encoding="utf-8") as fh:
-            fh.write(f"pr-urls={payload}\n")
-            bumped = sum(1 for e in pr_urls if e.get("name") != "_daily")
-            fh.write(f"bumped_count={bumped}\n")
+    bumped = sum(1 for e in pr_urls if e.get("name") != "_daily")
+    write_github_output(args.github_output, pr_urls, bumped)
 
     if errors:
         print(f"{len(errors)} bump(s) failed", file=sys.stderr)

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Discover version-bumped url-source pins and open a stacked set of PRs.
 
-A pin advances only when upstream HEAD moved *and* plugin.json `version`
-differs from the version at the current pin (extracted via plugin_catalog,
-same path as generate-plugin-index). SHA-only tip movement without a version
-change is ignored so everyone on a given version shares that pin.
+Pin advances when HEAD moved and the version gate passes
+(plugin_catalog extract, same path as generate-plugin-index):
+
+  - both have version, and they differ → bump to HEAD
+  - both lack version → bump to HEAD (SHA is the identity)
+  - same version → skip (commits moved, release did not)
+  - pin has version, HEAD does not → skip (do not un-version)
+  - pin lacks version, HEAD has one → bump (first version appears)
 
 Stack shape (one run / Pacific day):
 
@@ -360,22 +364,37 @@ def apply_plugin_bump(
     """Branch from daily tip, commit one plugin bump, open PR -> daily."""
     short_old = old_sha[:7]
     short_new = new_sha[:7]
-    title = (
-        f"chore(plugins): bump {name} {old_version} -> {new_version} "
-        f"({short_old} -> {short_new})"
-    )
+    ver_old = old_version or "(none)"
+    ver_new = new_version or "(none)"
+    if old_version or new_version:
+        title = (
+            f"chore(plugins): bump {name} {ver_old} -> {ver_new} "
+            f"({short_old} -> {short_new})"
+        )
+        version_line = f"- **version:** `{ver_old}` -> `{ver_new}`"
+        why = (
+            "Catalog SHA updated after an upstream version change (or first "
+            "version appearing). When a version is set, everyone on that "
+            "version shares the same pin."
+        )
+    else:
+        title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
+        version_line = "- **version:** (none at pin or HEAD; pin tracks SHA)"
+        why = (
+            "Catalog SHA updated. Upstream has no plugin.json version on either "
+            "pin or HEAD, so the pin is the release identity."
+        )
     body_lines = [
-        f"Automated pin bump for `{name}` after an upstream version change.",
+        f"Automated pin bump for `{name}`.",
         "",
         f"- **source:** {url}",
-        f"- **version:** `{old_version}` -> `{new_version}`",
+        version_line,
         f"- **old sha:** `{old_sha}`",
-        f"- **new sha:** `{new_sha}` (HEAD when version change was observed)",
+        f"- **new sha:** `{new_sha}` (HEAD when the bump was observed)",
         f"- **base:** `{daily_branch}`",
         "",
         "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
-        "at the new pin. Pins only move when the plugin manifest version changes "
-        "so everyone on a given version shares the same pin.",
+        f"at the new pin. {why}",
         "",
         "Targets the daily base, not `main`. Merge into the daily branch "
         "(or close to drop this bump), then land the daily PR.",
@@ -430,11 +449,17 @@ def discover_candidates(
     only: str,
     freeze: set[str],
 ) -> tuple[list[dict], list[dict]]:
-    """Find url pins where HEAD moved and plugin.json version also changed.
+    """Find url pins where HEAD moved and the version gate allows a bump.
 
     Version extraction uses plugin_catalog.extract_plugin (same path as the
-    index generator). When only the SHA moved, skip so users on a version
-    stay on that pin until the author bumps version.
+    index generator).
+
+    Gate (after SHA moved):
+      - both versions set and equal → skip
+      - pin set, HEAD missing → skip (do not un-version)
+      - both missing → bump (SHA identity)
+      - pin missing, HEAD set → bump (first version)
+      - both set and differ → bump
     """
     catalog = load_catalog()
     candidates: list[dict] = []
@@ -500,20 +525,20 @@ def discover_candidates(
 
         old_version = pin_rec.get("version")
         new_version = head_rec.get("version")
-        if not old_version:
-            skipped.append(
-                {"name": name, "reason": "no version at pin (set plugin.json version)"}
-            )
-            continue
-        if not new_version:
+
+        if old_version and not new_version:
             skipped.append(
                 {
                     "name": name,
-                    "reason": "no version at HEAD (set plugin.json version)",
+                    "reason": (
+                        f"sha moved ({old_sha[:7]}->{new_sha[:7]}) but HEAD "
+                        f"dropped version (pin has {old_version!r}; not "
+                        f"un-versioning)"
+                    ),
                 }
             )
             continue
-        if old_version == new_version:
+        if old_version and new_version and old_version == new_version:
             skipped.append(
                 {
                     "name": name,
@@ -524,6 +549,7 @@ def discover_candidates(
                 }
             )
             continue
+        # bump: both missing | pin missing + HEAD set | both set and differ
 
         candidates.append(
             {
@@ -531,8 +557,8 @@ def discover_candidates(
                 "url": url,
                 "old_sha": old_sha,
                 "new_sha": new_sha,
-                "old_version": old_version,
-                "new_version": new_version,
+                "old_version": old_version or "",
+                "new_version": new_version or "",
                 "path": subdir,
             }
         )

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Discover stale url-source pins and open a stacked set of bump PRs.
+"""Discover version-bumped url-source pins and open a stacked set of PRs.
+
+A pin advances only when upstream HEAD moved *and* plugin.json `version`
+differs from the version at the current pin (extracted via plugin_catalog,
+same path as generate-plugin-index). SHA-only tip movement without a version
+change is ignored so everyone on a given version shares that pin.
 
 Stack shape (one run / Pacific day):
 
@@ -9,12 +14,8 @@ Stack shape (one run / Pacific day):
           ├── bump/YYYY-MM-DD/<plugin-b> PR → daily
           └── ...
 
-Every plugin branch is cut from the daily tip and targets daily (fan-out).
-Only the daily PR targets main, so main history stays one landing per day.
-
 Default: if remote `bump/daily-YYYY-MM-DD` already exists, the run is a
-no-op (open, merged, or abandoned). Pass `--force` to rebuild that day's
-stack from current main and force-push daily + plugin branches.
+no-op. Pass `--force` to rebuild that day's stack from current main.
 
 Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
 Local: `--dry-run` (no push/PR).
@@ -31,9 +32,12 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
+
+import plugin_catalog
 
 try:
     from zoneinfo import ZoneInfo
@@ -44,7 +48,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CATALOG_PATH = Path(".grok-plugin/marketplace.json")
 INDEX_PATH = Path(".grok-plugin/plugin-index.json")
 INDEX_SCRIPT = Path("scripts/generate-plugin-index.py")
-SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA_RE = plugin_catalog.SHA_RE
 ALLOWED_HOSTS = {"github.com", "gitlab.com", "bitbucket.org"}
 
 
@@ -343,6 +347,8 @@ def apply_plugin_bump(
     name: str,
     old_sha: str,
     new_sha: str,
+    old_version: str,
+    new_version: str,
     url: str,
     branch: str,
     daily_branch: str,
@@ -354,17 +360,22 @@ def apply_plugin_bump(
     """Branch from daily tip, commit one plugin bump, open PR -> daily."""
     short_old = old_sha[:7]
     short_new = new_sha[:7]
-    title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
+    title = (
+        f"chore(plugins): bump {name} {old_version} -> {new_version} "
+        f"({short_old} -> {short_new})"
+    )
     body_lines = [
-        f"Automated pin bump for `{name}`.",
+        f"Automated pin bump for `{name}` after an upstream version change.",
         "",
         f"- **source:** {url}",
-        f"- **old:** `{old_sha}`",
-        f"- **new:** `{new_sha}`",
+        f"- **version:** `{old_version}` -> `{new_version}`",
+        f"- **old sha:** `{old_sha}`",
+        f"- **new sha:** `{new_sha}` (HEAD when version change was observed)",
         f"- **base:** `{daily_branch}`",
         "",
         "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
-        "at the new pin.",
+        "at the new pin. Pins only move when the plugin manifest version changes "
+        "so everyone on a given version shares the same pin.",
         "",
         "Targets the daily base, not `main`. Merge into the daily branch "
         "(or close to drop this bump), then land the daily PR.",
@@ -419,6 +430,12 @@ def discover_candidates(
     only: str,
     freeze: set[str],
 ) -> tuple[list[dict], list[dict]]:
+    """Find url pins where HEAD moved and plugin.json version also changed.
+
+    Version extraction uses plugin_catalog.extract_plugin (same path as the
+    index generator). When only the SHA moved, skip so users on a version
+    stay on that pin until the author bumps version.
+    """
     catalog = load_catalog()
     candidates: list[dict] = []
     skipped: list[dict] = []
@@ -437,6 +454,8 @@ def discover_candidates(
         source = entry["source"]
         url = source.get("url")
         old_sha = source.get("sha")
+        path = source.get("path")
+        subdir = path if isinstance(path, str) and path else None
         if not isinstance(url, str) or not url.startswith("https://"):
             skipped.append({"name": name, "reason": f"bad url {url!r}"})
             continue
@@ -453,16 +472,68 @@ def discover_candidates(
             skipped.append({"name": name, "reason": f"ls-remote failed: {e}"})
             continue
 
-        if new_sha == old_sha.lower():
+        old_sha = old_sha.lower()
+        if new_sha == old_sha:
             skipped.append({"name": name, "reason": "up to date"})
+            continue
+
+        try:
+            with tempfile.TemporaryDirectory(prefix=f"bump-{name}-") as tmp:
+                tmp_root = Path(tmp)
+                pin_rec = plugin_catalog.extract_at_sha(
+                    url,
+                    old_sha,
+                    tmp_root / "pin",
+                    subdir=subdir,
+                    name=name,
+                )
+                head_rec = plugin_catalog.extract_at_sha(
+                    url,
+                    new_sha,
+                    tmp_root / "head",
+                    subdir=subdir,
+                    name=name,
+                )
+        except Exception as e:  # noqa: BLE001
+            skipped.append({"name": name, "reason": f"extract failed: {e}"})
+            continue
+
+        old_version = pin_rec.get("version")
+        new_version = head_rec.get("version")
+        if not old_version:
+            skipped.append(
+                {"name": name, "reason": "no version at pin (set plugin.json version)"}
+            )
+            continue
+        if not new_version:
+            skipped.append(
+                {
+                    "name": name,
+                    "reason": "no version at HEAD (set plugin.json version)",
+                }
+            )
+            continue
+        if old_version == new_version:
+            skipped.append(
+                {
+                    "name": name,
+                    "reason": (
+                        f"sha moved ({old_sha[:7]}->{new_sha[:7]}) but "
+                        f"version still {old_version}"
+                    ),
+                }
+            )
             continue
 
         candidates.append(
             {
                 "name": name,
                 "url": url,
-                "old_sha": old_sha.lower(),
+                "old_sha": old_sha,
                 "new_sha": new_sha,
+                "old_version": old_version,
+                "new_version": new_version,
+                "path": subdir,
             }
         )
 
@@ -592,14 +663,17 @@ def main() -> int:
         for c in candidates:
             plugin_branch = f"bump/{day}/{c['name']}"
             print(
-                f"bump {c['name']}: {c['old_sha'][:7]} -> {c['new_sha'][:7]} "
-                f"({c['url']}) on {plugin_branch} -> {daily_branch}"
+                f"bump {c['name']}: {c['old_version']} -> {c['new_version']} "
+                f"({c['old_sha'][:7]} -> {c['new_sha'][:7]}) "
+                f"on {plugin_branch} -> {daily_branch}"
             )
             try:
                 pr_url = apply_plugin_bump(
                     name=c["name"],
                     old_sha=c["old_sha"],
                     new_sha=c["new_sha"],
+                    old_version=c["old_version"],
+                    new_version=c["new_version"],
                     url=c["url"],
                     branch=plugin_branch,
                     daily_branch=daily_branch,
@@ -613,6 +687,8 @@ def main() -> int:
                         "name": c["name"],
                         "old_sha": c["old_sha"],
                         "new_sha": c["new_sha"],
+                        "old_version": c["old_version"],
+                        "new_version": c["new_version"],
                         "branch": plugin_branch,
                         "base": daily_branch,
                         "pr_url": pr_url or "",

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
-"""Discover stale url-source pins and open one bump PR per plugin.
+"""Discover stale url-source pins and open a stacked set of bump PRs.
 
-For each entry in `.grok-plugin/marketplace.json` with
-`source: {source: "url", url, sha}`:
+Stack shape (one run / Pacific day):
+
+  main
+    └── bump/daily-YYYY-MM-DD          PR → main
+          └── bump/YYYY-MM-DD/<plugin> PR → daily (then linear on previous tip)
+                └── bump/YYYY-MM-DD/<next>
+                      └── ...
+
+Only the daily PR targets main, so main's history stays one merge per day
+after the stack is reviewed. Per-plugin PRs are for isolated review of each
+pin bump.
+
+For each url-source entry:
 
   1. Resolve upstream HEAD via `git ls-remote`
-  2. If HEAD != pinned sha, treat as a candidate bump
-  3. Skip if a PR already exists for `bump/<name>`
-  4. Update the pin, regenerate the plugin index, commit, push, open PR
+  2. If HEAD != pinned sha, treat as a candidate
+  3. Apply bumps in a linear stack on top of the daily branch
+  4. Each step: update the pin, regenerate the plugin index, commit, push, open PR
 
-Designed to run under GitHub Actions with GITHUB_TOKEN
-(contents:write + pull-requests:write). Also runnable locally with
-`--dry-run` (no push/PR) or a real `GH_TOKEN`.
+Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
+Local: `--dry-run` (no push/PR).
 
 Usage:
   python3 scripts/bump-plugin-shas.py [--dry-run] [--max-bumps N] [--only NAME]
@@ -25,15 +35,20 @@ import os
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover
+    ZoneInfo = None  # type: ignore[misc, assignment]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CATALOG_PATH = Path(".grok-plugin/marketplace.json")
 INDEX_PATH = Path(".grok-plugin/plugin-index.json")
 INDEX_SCRIPT = Path("scripts/generate-plugin-index.py")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-BRANCH_PREFIX = "bump/"
 ALLOWED_HOSTS = {"github.com", "gitlab.com", "bitbucket.org"}
 
 
@@ -62,6 +77,12 @@ def run(
         detail = stderr or stdout or f"exit {result.returncode}"
         raise RuntimeError(f"`{' '.join(cmd)}` failed: {detail}")
     return result
+
+
+def pacific_date() -> str:
+    if ZoneInfo is not None:
+        return datetime.now(ZoneInfo("America/Los_Angeles")).strftime("%Y-%m-%d")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
 
 def load_catalog() -> dict:
@@ -181,83 +202,26 @@ def ensure_clean_worktree() -> None:
 
 
 def origin_base(base_branch: str) -> str:
-    run(["git", "fetch", "origin", base_branch, "--depth", "1"], check=False)
     run(["git", "fetch", "origin", base_branch], check=True)
     result = run(["git", "rev-parse", f"origin/{base_branch}"], check=True)
     return (result.stdout or "").strip()
 
 
-def open_bump_pr(
+def ensure_pr(
     *,
-    name: str,
-    old_sha: str,
-    new_sha: str,
-    url: str,
-    branch: str,
-    base_branch: str,
-    run_url: str,
+    head: str,
+    base: str,
+    title: str,
+    body: str,
     dry_run: bool,
 ) -> str | None:
-    short_old = old_sha[:7]
-    short_new = new_sha[:7]
-    title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
-    body_lines = [
-        f"Automated pin bump for `{name}`.",
-        "",
-        f"- **source:** {url}",
-        f"- **old:** `{old_sha}`",
-        f"- **new:** `{new_sha}`",
-        "",
-        "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
-        "at the new pin.",
-        "",
-        "Human review still required (no auto-merge). Confirm the upstream "
-        "diff is intentional before merging.",
-    ]
-    if run_url:
-        body_lines.extend(["", f"Triggered by: {run_url}"])
-    body = "\n".join(body_lines) + "\n"
-
     if dry_run:
-        print(f"[dry-run] would open PR on {branch}: {title}")
+        print(f"[dry-run] would open PR {head} → {base}: {title}")
         return None
 
-    head = origin_base(base_branch)
-    git_identity()
-
-    # Fresh branch from origin/base every time so each PR is single-plugin.
-    run(["git", "checkout", "--detach", head], check=True)
-    run(["git", "checkout", "-B", branch], check=True)
-    run(
-        [
-            "git",
-            "checkout",
-            head,
-            "--",
-            str(CATALOG_PATH),
-            str(INDEX_PATH),
-        ],
-        check=True,
-    )
-
-    replace_sha_in_catalog(name, old_sha, new_sha)
-    regenerate_index()
-
-    run(
-        ["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)],
-        check=True,
-    )
-    status = run(["git", "status", "--porcelain"], check=True)
-    if not (status.stdout or "").strip():
-        raise RuntimeError(f"no file changes after bumping {name}")
-
-    run(["git", "commit", "-m", title], check=True)
-    # Bot-owned branch; force is intentional so retries rewrite the same tip.
-    run(["git", "push", "--force", "origin", f"HEAD:refs/heads/{branch}"], check=True)
-
-    existing = open_pr_for_branch(branch)
+    existing = open_pr_for_branch(head)
     if existing:
-        print(f"PR already open for {branch}: {existing}")
+        print(f"PR already open for {head}: {existing}")
         return existing
 
     result = run(
@@ -266,9 +230,9 @@ def open_bump_pr(
             "pr",
             "create",
             "--base",
-            base_branch,
+            base,
             "--head",
-            branch,
+            head,
             "--title",
             title,
             "--body",
@@ -281,11 +245,139 @@ def open_bump_pr(
     return pr_url
 
 
+def push_branch(branch: str) -> None:
+    run(["git", "push", "--force", "origin", f"HEAD:refs/heads/{branch}"], check=True)
+
+
+def open_daily_base(
+    *,
+    daily_branch: str,
+    main_branch: str,
+    day: str,
+    run_url: str,
+    dry_run: bool,
+) -> str | None:
+    """Create daily branch at main tip (no extra commit) and PR it into main."""
+    title = f"chore(plugins): daily pin bumps {day}"
+    body_lines = [
+        f"Daily stack base for plugin pin bumps on **{day}** (Pacific).",
+        "",
+        "Per-plugin PRs stack on top of this branch. Review those for each",
+        "upstream diff; merge this PR into `main` only after the stack is",
+        "accepted (keeps main history to one landing per day).",
+        "",
+        "No auto-merge.",
+    ]
+    if run_url:
+        body_lines.extend(["", f"Triggered by: {run_url}"])
+    body = "\n".join(body_lines) + "\n"
+
+    if dry_run:
+        print(f"[dry-run] would open daily base {daily_branch} → {main_branch}")
+        return None
+
+    head = origin_base(main_branch)
+    git_identity()
+    run(["git", "checkout", "--detach", head], check=True)
+    run(["git", "checkout", "-B", daily_branch], check=True)
+    # Empty marker commit so the daily → main PR can open (GitHub rejects
+    # empty branch diffs). Plugin commits stack on top of this.
+    run(
+        [
+            "git",
+            "commit",
+            "--allow-empty",
+            "-m",
+            f"chore(plugins): daily pin bumps {day}",
+        ],
+        check=True,
+    )
+    push_branch(daily_branch)
+    return ensure_pr(
+        head=daily_branch,
+        base=main_branch,
+        title=title,
+        body=body,
+        dry_run=False,
+    )
+
+
+def apply_plugin_bump(
+    *,
+    name: str,
+    old_sha: str,
+    new_sha: str,
+    url: str,
+    branch: str,
+    parent_branch: str,
+    parent_sha: str,
+    run_url: str,
+    dry_run: bool,
+) -> tuple[str | None, str]:
+    """Create plugin branch from parent tip, commit bump, open PR → parent.
+
+    Returns (pr_url, new_tip_sha).
+    """
+    short_old = old_sha[:7]
+    short_new = new_sha[:7]
+    title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
+    body_lines = [
+        f"Automated pin bump for `{name}`.",
+        "",
+        f"- **source:** {url}",
+        f"- **old:** `{old_sha}`",
+        f"- **new:** `{new_sha}`",
+        f"- **stacks on:** `{parent_branch}`",
+        "",
+        "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
+        "at the new pin.",
+        "",
+        "Part of the daily stack; do not merge this into `main` directly. "
+        "Merge up into the daily base, then land the daily PR.",
+        "",
+        "Human review still required (no auto-merge).",
+    ]
+    if run_url:
+        body_lines.extend(["", f"Triggered by: {run_url}"])
+    body = "\n".join(body_lines) + "\n"
+
+    if dry_run:
+        print(
+            f"[dry-run] would open PR {branch} → {parent_branch}: {title} "
+            f"(parent={parent_sha[:7]})"
+        )
+        return None, parent_sha
+
+    git_identity()
+    run(["git", "checkout", "--detach", parent_sha], check=True)
+    run(["git", "checkout", "-B", branch], check=True)
+
+    replace_sha_in_catalog(name, old_sha, new_sha)
+    regenerate_index()
+
+    run(["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)], check=True)
+    status = run(["git", "status", "--porcelain"], check=True)
+    if not (status.stdout or "").strip():
+        raise RuntimeError(f"no file changes after bumping {name}")
+
+    run(["git", "commit", "-m", title], check=True)
+    tip = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+    push_branch(branch)
+
+    pr_url = ensure_pr(
+        head=branch,
+        base=parent_branch,
+        title=title,
+        body=body,
+        dry_run=False,
+    )
+    return pr_url, tip
+
+
 def discover_candidates(
     *,
     only: str,
     freeze: set[str],
-    skip_open_pr_check: bool,
 ) -> tuple[list[dict], list[dict]]:
     catalog = load_catalog()
     candidates: list[dict] = []
@@ -325,22 +417,12 @@ def discover_candidates(
             skipped.append({"name": name, "reason": "up to date"})
             continue
 
-        branch = f"{BRANCH_PREFIX}{name}"
-        if not skip_open_pr_check:
-            existing = open_pr_for_branch(branch)
-            if existing:
-                skipped.append(
-                    {"name": name, "reason": f"open PR already: {existing}"}
-                )
-                continue
-
         candidates.append(
             {
                 "name": name,
                 "url": url,
                 "old_sha": old_sha.lower(),
                 "new_sha": new_sha,
-                "branch": branch,
             }
         )
 
@@ -355,6 +437,12 @@ def main() -> int:
     parser.add_argument(
         "--base-branch",
         default=os.environ.get("BASE_BRANCH", "main"),
+        help="Default branch (stack root). Daily PR targets this.",
+    )
+    parser.add_argument(
+        "--day",
+        default=os.environ.get("BUMP_DAY", ""),
+        help="Pacific calendar day YYYY-MM-DD (default: today Pacific)",
     )
     parser.add_argument(
         "--freeze",
@@ -371,6 +459,8 @@ def main() -> int:
     freeze = {n for n in args.freeze.split() if n}
     only = args.only.strip()
     run_url = os.environ.get("RUN_URL", "")
+    day = args.day.strip() or pacific_date()
+    daily_branch = f"bump/daily-{day}"
 
     if not args.dry_run:
         ensure_clean_worktree()
@@ -380,14 +470,11 @@ def main() -> int:
     if start_ref == "HEAD":
         start_ref = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
 
-    candidates, skipped = discover_candidates(
-        only=only,
-        freeze=freeze,
-        skip_open_pr_check=args.dry_run,
-    )
+    candidates, skipped = discover_candidates(only=only, freeze=freeze)
     if args.max_bumps >= 0:
         candidates = candidates[: args.max_bumps]
 
+    print(f"day={day} daily_branch={daily_branch}")
     print(f"candidates={len(candidates)} skipped={len(skipped)}")
     for s in skipped:
         print(f"  skip {s['name']}: {s['reason']}")
@@ -395,45 +482,149 @@ def main() -> int:
     pr_urls: list[dict] = []
     errors: list[str] = []
 
-    for c in candidates:
-        print(
-            f"bump {c['name']}: {c['old_sha'][:7]} -> {c['new_sha'][:7]} "
-            f"({c['url']})"
-        )
-        try:
-            pr_url = open_bump_pr(
-                name=c["name"],
-                old_sha=c["old_sha"],
-                new_sha=c["new_sha"],
-                url=c["url"],
-                branch=c["branch"],
-                base_branch=args.base_branch,
-                run_url=run_url,
-                dry_run=args.dry_run,
-            )
-            pr_urls.append(
-                {
-                    "name": c["name"],
-                    "old_sha": c["old_sha"],
-                    "new_sha": c["new_sha"],
-                    "branch": c["branch"],
-                    "pr_url": pr_url or "",
-                }
-            )
-        except Exception as e:  # noqa: BLE001
-            msg = f"{c['name']}: {e}"
-            errors.append(msg)
-            print(f"ERROR: {msg}", file=sys.stderr)
+    if not candidates:
+        print("nothing to bump")
+        payload = json.dumps(pr_urls, separators=(",", ":"))
+        print(f"pr-urls={payload}")
+        if args.github_output:
+            with open(args.github_output, "a", encoding="utf-8") as fh:
+                fh.write(f"pr-urls={payload}\n")
+                fh.write("bumped_count=0\n")
+        return 0
 
+    # One open daily stack per Pacific day. Re-runs wait for that PR to close.
     if not args.dry_run:
-        run(["git", "checkout", "-f", start_ref], check=False)
+        existing_daily = open_pr_for_branch(daily_branch)
+        if existing_daily:
+            print(
+                f"daily stack already open for {day}: {existing_daily}; "
+                "skipping (close it or wait for merge before re-running)"
+            )
+            payload = json.dumps(
+                [
+                    {
+                        "name": "_daily",
+                        "branch": daily_branch,
+                        "base": args.base_branch,
+                        "pr_url": existing_daily,
+                        "skipped": True,
+                    }
+                ],
+                separators=(",", ":"),
+            )
+            print(f"pr-urls={payload}")
+            if args.github_output:
+                with open(args.github_output, "a", encoding="utf-8") as fh:
+                    fh.write(f"pr-urls={payload}\n")
+                    fh.write("bumped_count=0\n")
+            return 0
+
+    try:
+        daily_pr = open_daily_base(
+            daily_branch=daily_branch,
+            main_branch=args.base_branch,
+            day=day,
+            run_url=run_url,
+            dry_run=args.dry_run,
+        )
+        pr_urls.append(
+            {
+                "name": "_daily",
+                "branch": daily_branch,
+                "base": args.base_branch,
+                "pr_url": daily_pr or "",
+            }
+        )
+
+        if args.dry_run:
+            parent_branch = daily_branch
+            parent_sha = "dry-run"
+        else:
+            parent_branch = daily_branch
+            parent_sha = run(
+                ["git", "rev-parse", f"refs/heads/{daily_branch}"],
+                check=True,
+            ).stdout.strip()
+
+        for c in candidates:
+            plugin_branch = f"bump/{day}/{c['name']}"
+            print(
+                f"bump {c['name']}: {c['old_sha'][:7]} -> {c['new_sha'][:7]} "
+                f"({c['url']}) on {plugin_branch} → {parent_branch}"
+            )
+            try:
+                pr_url, parent_sha = apply_plugin_bump(
+                    name=c["name"],
+                    old_sha=c["old_sha"],
+                    new_sha=c["new_sha"],
+                    url=c["url"],
+                    branch=plugin_branch,
+                    parent_branch=parent_branch,
+                    parent_sha=parent_sha if parent_sha != "dry-run" else "0" * 40,
+                    run_url=run_url,
+                    dry_run=args.dry_run,
+                )
+                pr_urls.append(
+                    {
+                        "name": c["name"],
+                        "old_sha": c["old_sha"],
+                        "new_sha": c["new_sha"],
+                        "branch": plugin_branch,
+                        "base": parent_branch,
+                        "pr_url": pr_url or "",
+                    }
+                )
+                parent_branch = plugin_branch
+            except Exception as e:  # noqa: BLE001
+                msg = f"{c['name']}: {e}"
+                errors.append(msg)
+                print(f"ERROR: {msg}", file=sys.stderr)
+                # Stop the stack here; later plugins would base on a failed tip.
+                break
+    finally:
+        if not args.dry_run:
+            run(["git", "checkout", "-f", start_ref], check=False)
+
+    # Point daily PR body at children once we know them (best-effort).
+    if not args.dry_run and daily_pr and len(pr_urls) > 1:
+        child_lines = [
+            f"- `{e['branch']}` ({e['name']}): {e['pr_url'] or 'opened'}"
+            for e in pr_urls
+            if e.get("name") != "_daily"
+        ]
+        try:
+            run(
+                [
+                    "gh",
+                    "pr",
+                    "edit",
+                    daily_branch,
+                    "--body",
+                    "\n".join(
+                        [
+                            f"Daily stack base for plugin pin bumps on **{day}** (Pacific).",
+                            "",
+                            "Stacked plugin PRs (merge upward into this branch, then land this PR):",
+                            *child_lines,
+                            "",
+                            "No auto-merge.",
+                            *(["", f"Triggered by: {run_url}"] if run_url else []),
+                        ]
+                    )
+                    + "\n",
+                ],
+                check=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     payload = json.dumps(pr_urls, separators=(",", ":"))
     print(f"pr-urls={payload}")
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8") as fh:
             fh.write(f"pr-urls={payload}\n")
-            fh.write(f"bumped_count={len(pr_urls)}\n")
+            bumped = sum(1 for e in pr_urls if e.get("name") != "_daily")
+            fh.write(f"bumped_count={bumped}\n")
 
     if errors:
         print(f"{len(errors)} bump(s) failed", file=sys.stderr)

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -22,7 +22,7 @@ Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
 Local: `--dry-run` (no push/PR).
 
 Usage:
-  python3 scripts/bump-plugin-shas.py [--dry-run] [--max-bumps N] [--only NAME]
+  python3 scripts/bump-plugin-shas.py [--dry-run] [--only NAME]
 """
 
 from __future__ import annotations
@@ -430,7 +430,6 @@ def discover_candidates(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--max-bumps", type=int, default=10)
     parser.add_argument("--only", default="", help="Exact plugin name to bump")
     parser.add_argument(
         "--base-branch",
@@ -469,8 +468,6 @@ def main() -> int:
         start_ref = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
 
     candidates, skipped = discover_candidates(only=only, freeze=freeze)
-    if args.max_bumps >= 0:
-        candidates = candidates[: args.max_bumps]
 
     print(f"day={day} daily_branch={daily_branch}")
     print(f"candidates={len(candidates)} skipped={len(skipped)}")

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -186,7 +186,13 @@ def replace_sha_in_catalog(name: str, old_sha: str, new_sha: str) -> None:
 
 
 def regenerate_index() -> None:
-    run([sys.executable, str(REPO_ROOT / INDEX_SCRIPT)], check=True, capture=False)
+    env = {"PYTHONDONTWRITEBYTECODE": "1"}
+    run(
+        [sys.executable, "-B", str(REPO_ROOT / INDEX_SCRIPT)],
+        check=True,
+        capture=False,
+        env=env,
+    )
 
 
 def git_identity() -> None:
@@ -202,13 +208,31 @@ def git_identity() -> None:
     )
 
 
+def _is_ignorable_dirty_path(path: str) -> bool:
+    # Importing scripts/*.py can create bytecode; never treat that as dirty.
+    if path.endswith(".DS_Store"):
+        return True
+    parts = path.replace("\\", "/").split("/")
+    if "__pycache__" in parts:
+        return True
+    if parts and parts[-1].endswith((".pyc", ".pyo")):
+        return True
+    return False
+
+
 def ensure_clean_worktree() -> None:
     result = run(["git", "status", "--porcelain"], check=True)
-    dirty = [
-        line
-        for line in (result.stdout or "").splitlines()
-        if line.strip() and not line.rstrip().endswith(".DS_Store")
-    ]
+    dirty = []
+    for line in (result.stdout or "").splitlines():
+        if not line.strip():
+            continue
+        # porcelain: XY PATH or XY ORIG -> PATH
+        path = line[3:].strip() if len(line) > 3 else line.strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if _is_ignorable_dirty_path(path):
+            continue
+        dirty.append(line)
     if dirty:
         raise RuntimeError(
             "working tree is dirty; commit or stash before bumping:\n"
@@ -220,6 +244,16 @@ def origin_base(base_branch: str) -> str:
     run(["git", "fetch", "origin", base_branch], check=True)
     result = run(["git", "rev-parse", f"origin/{base_branch}"], check=True)
     return (result.stdout or "").strip()
+
+
+def reset_to_origin_base(base_branch: str) -> str:
+    """Fetch and hard-reset to origin/<base> so discovery matches the bump base."""
+    tip = origin_base(base_branch)
+    run(["git", "checkout", "--detach", tip], check=True)
+    run(["git", "reset", "--hard", tip], check=True)
+    run(["git", "clean", "-fd", "-e", ".DS_Store"], check=False)
+    print(f"reset to origin/{base_branch} ({tip[:12]})")
+    return tip
 
 
 def hard_reset_to(sha: str) -> None:
@@ -611,14 +645,44 @@ def main() -> int:
     day = args.day.strip() or pacific_date()
     daily_branch = f"bump/daily-{day}"
     force = bool(args.force) or env_flag("FORCE_BUMP")
-
-    if not args.dry_run:
-        ensure_clean_worktree()
+    base_branch = args.base_branch
 
     start_ref_proc = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True)
     start_ref = (start_ref_proc.stdout or "").strip()
     if start_ref == "HEAD":
         start_ref = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+
+    # Discover and bump from the same revision the stack will cut from.
+    # workflow_dispatch on a non-default ref would otherwise see a different
+    # catalog than origin/<base>.
+    if not args.dry_run:
+        reset_to_origin_base(base_branch)
+        ensure_clean_worktree()
+    else:
+        tip = origin_base(base_branch)
+        head = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+        if head != tip:
+            print(
+                f"[dry-run] worktree HEAD {head[:12]} != origin/{base_branch} "
+                f"{tip[:12]}; discovery uses the worktree catalog "
+                f"(non-dry-run resets to origin/{base_branch})",
+                file=sys.stderr,
+            )
+
+    if only:
+        catalog_names = {
+            e.get("name")
+            for e in load_catalog().get("plugins", [])
+            if isinstance(e, dict) and isinstance(e.get("name"), str)
+        }
+        if only not in catalog_names:
+            print(
+                f"ERROR: --only {only!r} matches no catalog plugin "
+                f"(known: {', '.join(sorted(catalog_names))})",
+                file=sys.stderr,
+            )
+            write_github_output(args.github_output, [], 0)
+            return 1
 
     candidates, skipped = discover_candidates(only=only, freeze=freeze)
 
@@ -650,7 +714,7 @@ def main() -> int:
                 {
                     "name": "_daily",
                     "branch": daily_branch,
-                    "base": args.base_branch,
+                    "base": base_branch,
                     "pr_url": "",
                     "skipped": True,
                 }
@@ -665,7 +729,7 @@ def main() -> int:
     try:
         daily_pr, daily_sha = open_daily_base(
             daily_branch=daily_branch,
-            main_branch=args.base_branch,
+            main_branch=base_branch,
             day=day,
             run_url=run_url,
             force=force or daily_exists,
@@ -677,7 +741,7 @@ def main() -> int:
             {
                 "name": "_daily",
                 "branch": daily_branch,
-                "base": args.base_branch,
+                "base": base_branch,
                 "pr_url": daily_pr or "",
             }
         )

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -3,9 +3,11 @@
 
 For every entry in `.grok-plugin/marketplace.json`, this script resolves the
 plugin's source (local directories are scanned in place; url sources are
-shallow-fetched at their pinned commit sha) and records which components the
-plugin provides: skills, commands, agents, MCP servers, hooks, and LSP
+shallow-fetched at their pinned commit sha) and records version (when set)
+plus components: skills, commands, agents, MCP servers, hooks, and LSP
 servers. Clients use this to show what a plugin contains before installing it.
+
+Extraction is shared with bump-plugin-shas via plugin_catalog.extract_plugin.
 
 The output is deterministic — sorted keys, items sorted by name, no
 timestamps — so CI can regenerate it and fail on any diff.
@@ -17,322 +19,28 @@ Verify (CI):    python3 scripts/generate-plugin-index.py --check
 from __future__ import annotations
 
 import json
-import re
-import subprocess
 import sys
 import tempfile
-import time
 from pathlib import Path
+
+import plugin_catalog
 
 INDEX_PATH = Path(".grok-plugin/plugin-index.json")
 CATALOG_PATH = Path(".grok-plugin/marketplace.json")
 
-MAX_ITEMS_PER_CATEGORY = 50
-MAX_STRING_LEN = 120
-MAX_TEXT_READ_BYTES = 64 * 1024
-MAX_JSON_BYTES = 1 << 20
-FETCH_ATTEMPTS = 3
-
-SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-
-MANIFEST_PATHS = [
-    Path(".grok-plugin/plugin.json"),
-    Path(".claude-plugin/plugin.json"),
-]
-
-CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-
-
-def clean(text: str) -> str:
-    text = re.sub(r"\s+", " ", CONTROL_CHARS_RE.sub("", text)).strip()
-    if len(text) > MAX_STRING_LEN:
-        text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
-    return text
-
-
-def resolve_inside(root: Path, relative) -> Path | None:
-    """Resolve `relative` against `root`, returning None if the result
-    escapes `root` (via `..`, absolute paths, or symlinks). Plugin content
-    is untrusted; nothing outside the plugin tree may be read."""
-    try:
-        candidate = (root / relative).resolve()
-        if candidate.is_relative_to(root.resolve()):
-            return candidate
-    except (OSError, ValueError):
-        return None
-    return None
-
-
-def contained(path: Path, root: Path) -> bool:
-    try:
-        return path.resolve().is_relative_to(root.resolve())
-    except (OSError, ValueError):
-        return False
-
-
-def read_text_limited(path: Path) -> str:
-    with open(path, encoding="utf-8", errors="replace") as f:
-        return f.read(MAX_TEXT_READ_BYTES)
-
-
-def load_json_file(path: Path):
-    try:
-        if path.stat().st_size > MAX_JSON_BYTES:
-            return None
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-
-
-def parse_frontmatter(path: Path) -> dict[str, str]:
-    """Tolerant YAML-ish frontmatter parser: top-level `key: value` lines only."""
-    try:
-        text = read_text_limited(path)
-    except OSError:
-        return {}
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return {}
-    fields: dict[str, str] = {}
-    i = 1
-    while i < len(lines):
-        line = lines[i]
-        if line.strip() in ("---", "..."):
-            break
-        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
-        if not m:
-            i += 1
-            continue
-        key, value = m.group(1), m.group(2).strip()
-        if re.match(r"^[|>][+-]?$", value):
-            block: list[str] = []
-            j = i + 1
-            while j < len(lines) and (lines[j].startswith((" ", "\t")) or not lines[j].strip()):
-                if lines[j].strip():
-                    block.append(lines[j].strip())
-                j += 1
-            value = " ".join(block)
-            i = j
-        else:
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                value = value[1:-1]
-            i += 1
-        fields[key] = value
-    return fields
-
-
-def first_body_line(path: Path) -> str:
-    """First non-empty, non-heading line after any frontmatter block."""
-    try:
-        text = read_text_limited(path)
-    except OSError:
-        return ""
-    lines = text.splitlines()
-    i = 0
-    if lines and lines[0].strip() == "---":
-        for j in range(1, len(lines)):
-            if lines[j].strip() in ("---", "..."):
-                i = j + 1
-                break
-    for line in lines[i:]:
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            return stripped
-    return ""
-
-
-def make_item(name: str, description: str = "") -> dict:
-    item = {"name": clean(name)}
-    description = clean(description)
-    if description:
-        item["description"] = description
-    return item
-
-
-def load_manifest(root: Path) -> dict:
-    for rel in MANIFEST_PATHS:
-        path = resolve_inside(root, rel)
-        if path and path.is_file():
-            data = load_json_file(path)
-            if isinstance(data, dict):
-                return data
-    return {}
-
-
-def as_list(value) -> list:
-    if isinstance(value, list):
-        return value
-    if value is None:
-        return []
-    return [value]
-
-
-def scan_skills(root: Path, manifest: dict) -> list[dict]:
-    skill_dirs: dict[Path, str] = {}
-    for base in [root / "skills"]:
-        if base.is_dir():
-            for child in sorted(base.iterdir()):
-                skill_md = child / "SKILL.md"
-                if skill_md.is_file() and contained(skill_md, root):
-                    skill_dirs[child.resolve()] = child.name
-    for entry in as_list(manifest.get("skills")):
-        if isinstance(entry, str):
-            candidate = resolve_inside(root, entry)
-            if candidate and (candidate / "SKILL.md").is_file() and contained(candidate / "SKILL.md", root):
-                skill_dirs.setdefault(candidate, candidate.name)
-    items = []
-    for skill_dir, dirname in skill_dirs.items():
-        fm = parse_frontmatter(skill_dir / "SKILL.md")
-        items.append(make_item(fm.get("name") or dirname, fm.get("description", "")))
-    return items
-
-
-def scan_markdown_dir(root: Path, dirname: str, manifest_key: str, manifest: dict) -> list[dict]:
-    files: dict[Path, str] = {}
-    base = root / dirname
-    if base.is_dir():
-        for path in sorted(base.rglob("*.md")):
-            if path.is_file() and contained(path, root):
-                files[path.resolve()] = path.stem
-    for entry in as_list(manifest.get(manifest_key)):
-        if isinstance(entry, str):
-            candidate = resolve_inside(root, entry)
-            if candidate and candidate.is_file() and candidate.suffix == ".md":
-                files.setdefault(candidate, candidate.stem)
-    items = []
-    for path, stem in files.items():
-        fm = parse_frontmatter(path)
-        description = fm.get("description") or first_body_line(path)
-        items.append(make_item(fm.get("name") or stem, description))
-    return items
-
-
-def transport_hint(config: dict) -> str:
-    if not isinstance(config, dict):
-        return ""
-    transport = config.get("type") or config.get("transport")
-    if not transport:
-        if config.get("command"):
-            transport = "stdio"
-        elif config.get("url"):
-            transport = "http"
-    return str(transport) if transport else ""
-
-
-def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
-    servers: dict[str, dict] = {}
-    declared = manifest.get("mcpServers")
-    config_rel = declared if isinstance(declared, str) else ".mcp.json"
-    mcp_path = resolve_inside(root, config_rel)
-    if mcp_path and mcp_path.is_file():
-        data = load_json_file(mcp_path)
-        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
-            servers.update(data["mcpServers"])
-    if isinstance(declared, dict):
-        for name, config in declared.items():
-            servers.setdefault(name, config)
-    return [make_item(name, transport_hint(config)) for name, config in servers.items()]
-
-
-def scan_hooks(root: Path, manifest: dict) -> list[dict]:
-    data = None
-    hooks_path = resolve_inside(root, Path("hooks") / "hooks.json")
-    if hooks_path and hooks_path.is_file():
-        data = load_json_file(hooks_path)
-    if data is None:
-        declared = manifest.get("hooks")
-        if isinstance(declared, dict):
-            data = declared
-        elif isinstance(declared, str):
-            declared_path = resolve_inside(root, declared)
-            if declared_path and declared_path.is_file():
-                data = load_json_file(declared_path)
-    if not isinstance(data, dict):
-        return []
-    hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
-    items = []
-    for event, entries in hooks_obj.items():
-        if not isinstance(entries, list):
-            continue
-        matchers = [
-            e["matcher"]
-            for e in entries
-            if isinstance(e, dict) and isinstance(e.get("matcher"), str) and e["matcher"]
-        ]
-        items.append(make_item(event, ", ".join(matchers)))
-    return items
-
-
-def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
-    servers: dict[str, dict] = {}
-    lsp_path = resolve_inside(root, ".lsp.json")
-    if lsp_path and lsp_path.is_file():
-        data = load_json_file(lsp_path)
-        if isinstance(data, dict):
-            servers.update(data.get("lspServers") if isinstance(data.get("lspServers"), dict) else data)
-    declared = manifest.get("lspServers")
-    if isinstance(declared, dict):
-        for name, config in declared.items():
-            servers.setdefault(name, config)
-    return [make_item(name) for name, config in servers.items() if isinstance(config, dict)]
-
-
-def scan_plugin(root: Path) -> dict:
-    manifest = load_manifest(root)
-    categories = {
-        "skills": scan_skills(root, manifest),
-        "commands": scan_markdown_dir(root, "commands", "commands", manifest),
-        "agents": scan_markdown_dir(root, "agents", "agents", manifest),
-        "mcpServers": scan_mcp_servers(root, manifest),
-        "hooks": scan_hooks(root, manifest),
-        "lspServers": scan_lsp_servers(root, manifest),
-    }
-    components = {}
-    for key in sorted(categories):
-        items = sorted(categories[key], key=lambda i: i["name"])[:MAX_ITEMS_PER_CATEGORY]
-        if items:
-            components[key] = items
-    return components
-
-
-def run_git(cmd: list[str], url: str, sha: str) -> None:
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
-            f"{result.returncode}: {result.stderr.strip()}"
-        )
-
-
-def fetch_pinned(url: str, sha: str, dest: Path) -> None:
-    run_git(["git", "init", "--quiet", "--", str(dest)], url, sha)
-    fetch_cmd = [
-        "git", "-C", str(dest), "fetch", "--quiet", "--depth", "1",
-        "--end-of-options", url, sha,
-    ]
-    last_error: RuntimeError | None = None
-    for attempt in range(FETCH_ATTEMPTS):
-        try:
-            run_git(fetch_cmd, url, sha)
-            last_error = None
-            break
-        except RuntimeError as e:
-            last_error = e
-            if attempt < FETCH_ATTEMPTS - 1:
-                time.sleep(2 ** attempt)
-    if last_error is not None:
-        raise last_error
-    run_git(["git", "-C", str(dest), "checkout", "--quiet", "--detach", sha], url, sha)
-
 
 def resolve_local(repo_root: Path, path: str, name: str) -> Path:
-    resolved = resolve_inside(repo_root, path)
+    resolved = plugin_catalog.resolve_inside(repo_root, path)
     if resolved is None:
-        raise RuntimeError(f"plugin '{name}': local source path escapes the repo: {path!r}")
+        raise RuntimeError(
+            f"plugin '{name}': local source path escapes the repo: {path!r}"
+        )
     return resolved
 
 
-def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tuple[Path, str | None]:
+def resolve_source(
+    entry: dict, repo_root: Path, tmp_root: Path, idx: int
+) -> tuple[Path, str | None]:
     """Return (plugin root dir, pinned sha or None for local sources)."""
     name = entry.get("name", "<unnamed>")
     source = entry.get("source")
@@ -343,32 +51,25 @@ def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tu
             url = source.get("url")
             sha = source.get("sha")
             if not isinstance(url, str) or not url.startswith("https://"):
-                raise RuntimeError(f"plugin '{name}': url source must be an https:// url, got {url!r}")
+                raise RuntimeError(
+                    f"plugin '{name}': url source must be an https:// url, got {url!r}"
+                )
             if not sha:
                 raise RuntimeError(
                     f"plugin '{name}': url source has no pinned sha. All url "
                     f"sources must pin a full commit sha (see README)."
                 )
-            if not isinstance(sha, str) or not SHA_RE.match(sha):
+            if not isinstance(sha, str) or not plugin_catalog.SHA_RE.match(sha):
                 raise RuntimeError(
                     f"plugin '{name}': sha {sha!r} is not a 40-character "
                     f"lowercase hex commit sha"
                 )
             dest = tmp_root / f"plugin-{idx}"
-            fetch_pinned(url, sha, dest)
             subdir = source.get("path")
-            if isinstance(subdir, str) and subdir:
-                resolved = resolve_inside(dest, subdir)
-                if resolved is None:
-                    raise RuntimeError(
-                        f"plugin '{name}': url source path escapes the repo: {subdir!r}"
-                    )
-                if not resolved.is_dir():
-                    raise RuntimeError(
-                        f"plugin '{name}': url source path not found: {subdir!r}"
-                    )
-                return resolved, sha
-            return dest, sha
+            subdir_s = subdir if isinstance(subdir, str) and subdir else None
+            plugin_catalog.fetch_at_sha(url, sha, dest)
+            root = plugin_catalog.plugin_root_for_fetch(dest, subdir_s, name)
+            return root, sha
         path = source.get("path")
         if isinstance(path, str):
             return resolve_local(repo_root, path, name), None
@@ -385,12 +86,13 @@ def generate(repo_root: Path) -> dict:
             if not name:
                 raise RuntimeError("catalog entry without a name")
             root, sha = resolve_source(entry, repo_root, tmp_root, idx)
-            if not root.is_dir():
-                raise RuntimeError(f"plugin '{name}': source dir not found: {root}")
+            extracted = plugin_catalog.extract_plugin(root)
             record: dict = {}
             if sha:
                 record["sha"] = sha
-            record["components"] = scan_plugin(root)
+            if "version" in extracted:
+                record["version"] = extracted["version"]
+            record["components"] = extracted["components"]
             plugins_out[name] = record
     return {
         "version": 1,

--- a/scripts/plugin_catalog.py
+++ b/scripts/plugin_catalog.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Shared plugin extraction for marketplace catalog tooling.
+
+One extract path given a plugin root on disk (already resolved at a known
+sha / local path):
+
+  - load manifest (.grok-plugin/plugin.json or .claude-plugin/plugin.json)
+  - read version if present
+  - scan components (skills, commands, agents, mcpServers, hooks, lspServers)
+
+Used by generate-plugin-index.py (full catalog) and bump-plugin-shas.py
+(version gate at HEAD vs pin).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+
+MAX_ITEMS_PER_CATEGORY = 50
+MAX_STRING_LEN = 120
+MAX_TEXT_READ_BYTES = 64 * 1024
+MAX_JSON_BYTES = 1 << 20
+FETCH_ATTEMPTS = 3
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+MANIFEST_PATHS = [
+    Path(".grok-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+]
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def clean(text: str) -> str:
+    text = re.sub(r"\s+", " ", CONTROL_CHARS_RE.sub("", text)).strip()
+    if len(text) > MAX_STRING_LEN:
+        text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
+    return text
+
+
+def resolve_inside(root: Path, relative) -> Path | None:
+    try:
+        candidate = (root / relative).resolve()
+        if candidate.is_relative_to(root.resolve()):
+            return candidate
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def contained(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def read_text_limited(path: Path) -> str:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.read(MAX_TEXT_READ_BYTES)
+
+
+def load_json_file(path: Path):
+    try:
+        if path.stat().st_size > MAX_JSON_BYTES:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    try:
+        text = read_text_limited(path)
+    except OSError:
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: dict[str, str] = {}
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() in ("---", "..."):
+            break
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if re.match(r"^[|>][+-]?$", value):
+            block: list[str] = []
+            j = i + 1
+            while j < len(lines) and (lines[j].startswith((" ", "\t")) or not lines[j].strip()):
+                if lines[j].strip():
+                    block.append(lines[j].strip())
+                j += 1
+            value = " ".join(block)
+            i = j
+        else:
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            i += 1
+        fields[key] = value
+    return fields
+
+
+def first_body_line(path: Path) -> str:
+    try:
+        text = read_text_limited(path)
+    except OSError:
+        return ""
+    lines = text.splitlines()
+    i = 0
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() in ("---", "..."):
+                i = j + 1
+                break
+    for line in lines[i:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def make_item(name: str, description: str = "") -> dict:
+    item = {"name": clean(name)}
+    description = clean(description)
+    if description:
+        item["description"] = description
+    return item
+
+
+def load_manifest(root: Path) -> dict:
+    for rel in MANIFEST_PATHS:
+        path = resolve_inside(root, rel)
+        if path and path.is_file():
+            data = load_json_file(path)
+            if isinstance(data, dict):
+                return data
+    return {}
+
+
+def manifest_version(manifest: dict) -> str | None:
+    """Return a non-empty version string from the manifest, or None."""
+    value = manifest.get("version")
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
+def as_list(value) -> list:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def scan_skills(root: Path, manifest: dict) -> list[dict]:
+    skill_dirs: dict[Path, str] = {}
+    for base in [root / "skills"]:
+        if base.is_dir():
+            for child in sorted(base.iterdir()):
+                skill_md = child / "SKILL.md"
+                if skill_md.is_file() and contained(skill_md, root):
+                    skill_dirs[child.resolve()] = child.name
+    for entry in as_list(manifest.get("skills")):
+        if isinstance(entry, str):
+            candidate = resolve_inside(root, entry)
+            if (
+                candidate
+                and (candidate / "SKILL.md").is_file()
+                and contained(candidate / "SKILL.md", root)
+            ):
+                skill_dirs.setdefault(candidate, candidate.name)
+    items = []
+    for skill_dir, dirname in skill_dirs.items():
+        fm = parse_frontmatter(skill_dir / "SKILL.md")
+        items.append(make_item(fm.get("name") or dirname, fm.get("description", "")))
+    return items
+
+
+def scan_markdown_dir(
+    root: Path, dirname: str, manifest_key: str, manifest: dict
+) -> list[dict]:
+    files: dict[Path, str] = {}
+    base = root / dirname
+    if base.is_dir():
+        for path in sorted(base.rglob("*.md")):
+            if path.is_file() and contained(path, root):
+                files[path.resolve()] = path.stem
+    for entry in as_list(manifest.get(manifest_key)):
+        if isinstance(entry, str):
+            candidate = resolve_inside(root, entry)
+            if candidate and candidate.is_file() and candidate.suffix == ".md":
+                files.setdefault(candidate, candidate.stem)
+    items = []
+    for path, stem in files.items():
+        fm = parse_frontmatter(path)
+        description = fm.get("description") or first_body_line(path)
+        items.append(make_item(fm.get("name") or stem, description))
+    return items
+
+
+def transport_hint(config: dict) -> str:
+    if not isinstance(config, dict):
+        return ""
+    transport = config.get("type") or config.get("transport")
+    if not transport:
+        if config.get("command"):
+            transport = "stdio"
+        elif config.get("url"):
+            transport = "http"
+    return str(transport) if transport else ""
+
+
+def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    declared = manifest.get("mcpServers")
+    config_rel = declared if isinstance(declared, str) else ".mcp.json"
+    mcp_path = resolve_inside(root, config_rel)
+    if mcp_path and mcp_path.is_file():
+        data = load_json_file(mcp_path)
+        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+            servers.update(data["mcpServers"])
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [make_item(name, transport_hint(config)) for name, config in servers.items()]
+
+
+def scan_hooks(root: Path, manifest: dict) -> list[dict]:
+    data = None
+    hooks_path = resolve_inside(root, Path("hooks") / "hooks.json")
+    if hooks_path and hooks_path.is_file():
+        data = load_json_file(hooks_path)
+    if data is None:
+        declared = manifest.get("hooks")
+        if isinstance(declared, dict):
+            data = declared
+        elif isinstance(declared, str):
+            declared_path = resolve_inside(root, declared)
+            if declared_path and declared_path.is_file():
+                data = load_json_file(declared_path)
+    if not isinstance(data, dict):
+        return []
+    hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
+    items = []
+    for event, entries in hooks_obj.items():
+        if not isinstance(entries, list):
+            continue
+        matchers = [
+            e["matcher"]
+            for e in entries
+            if isinstance(e, dict) and isinstance(e.get("matcher"), str) and e["matcher"]
+        ]
+        items.append(make_item(event, ", ".join(matchers)))
+    return items
+
+
+def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    lsp_path = resolve_inside(root, ".lsp.json")
+    if lsp_path and lsp_path.is_file():
+        data = load_json_file(lsp_path)
+        if isinstance(data, dict):
+            servers.update(
+                data.get("lspServers")
+                if isinstance(data.get("lspServers"), dict)
+                else data
+            )
+    declared = manifest.get("lspServers")
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [
+        make_item(name)
+        for name, config in servers.items()
+        if isinstance(config, dict)
+    ]
+
+
+def extract_plugin(root: Path) -> dict:
+    """Extract version + components from a plugin root on disk.
+
+    Returns:
+      {
+        "version": str | omitted when missing,
+        "components": { category: [items...] }
+      }
+    """
+    if not root.is_dir():
+        raise RuntimeError(f"plugin root is not a directory: {root}")
+
+    manifest = load_manifest(root)
+    categories = {
+        "skills": scan_skills(root, manifest),
+        "commands": scan_markdown_dir(root, "commands", "commands", manifest),
+        "agents": scan_markdown_dir(root, "agents", "agents", manifest),
+        "mcpServers": scan_mcp_servers(root, manifest),
+        "hooks": scan_hooks(root, manifest),
+        "lspServers": scan_lsp_servers(root, manifest),
+    }
+    components = {}
+    for key in sorted(categories):
+        items = sorted(categories[key], key=lambda i: i["name"])[
+            :MAX_ITEMS_PER_CATEGORY
+        ]
+        if items:
+            components[key] = items
+
+    record: dict = {"components": components}
+    version = manifest_version(manifest)
+    if version is not None:
+        record["version"] = version
+    return record
+
+
+def run_git(cmd: list[str], url: str, sha: str) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
+            f"{result.returncode}: {result.stderr.strip()}"
+        )
+
+
+def fetch_at_sha(url: str, sha: str, dest: Path) -> None:
+    """Shallow-fetch url at sha into dest and detach checkout."""
+    if not SHA_RE.match(sha):
+        raise RuntimeError(f"sha {sha!r} is not a 40-character lowercase hex commit")
+    run_git(["git", "init", "--quiet", "--", str(dest)], url, sha)
+    fetch_cmd = [
+        "git",
+        "-C",
+        str(dest),
+        "fetch",
+        "--quiet",
+        "--depth",
+        "1",
+        "--end-of-options",
+        url,
+        sha,
+    ]
+    last_error: RuntimeError | None = None
+    for attempt in range(FETCH_ATTEMPTS):
+        try:
+            run_git(fetch_cmd, url, sha)
+            last_error = None
+            break
+        except RuntimeError as e:
+            last_error = e
+            if attempt < FETCH_ATTEMPTS - 1:
+                time.sleep(2 ** attempt)
+    if last_error is not None:
+        raise last_error
+    run_git(
+        ["git", "-C", str(dest), "checkout", "--quiet", "--detach", sha],
+        url,
+        sha,
+    )
+
+
+def plugin_root_for_fetch(dest: Path, subdir: str | None, name: str) -> Path:
+    if not subdir:
+        return dest
+    resolved = resolve_inside(dest, subdir)
+    if resolved is None:
+        raise RuntimeError(
+            f"plugin '{name}': url source path escapes the repo: {subdir!r}"
+        )
+    if not resolved.is_dir():
+        raise RuntimeError(f"plugin '{name}': url source path not found: {subdir!r}")
+    return resolved
+
+
+def extract_at_sha(
+    url: str,
+    sha: str,
+    dest: Path,
+    *,
+    subdir: str | None = None,
+    name: str = "<plugin>",
+) -> dict:
+    """Fetch url@sha into dest and extract_plugin from the resolved root."""
+    fetch_at_sha(url, sha, dest)
+    root = plugin_root_for_fetch(dest, subdir, name)
+    return extract_plugin(root)


### PR DESCRIPTION
## Summary

Daily job that advances url-source pins in `.grok-plugin/marketplace.json` only when it is appropriate, then opens a **fan-out stack** so main gets one landing per day.

```
main
  └── bump/daily-YYYY-MM-DD            PR → main
        ├── bump/YYYY-MM-DD/<plugin-a> PR → daily
        ├── bump/YYYY-MM-DD/<plugin-b> PR → daily
        └── ...
```

### When a pin moves

Uses shared `scripts/plugin_catalog.py` (`extract_plugin` / `extract_at_sha`), same path as index generation:

| pin version | HEAD version | Action |
|---|---|---|
| same string | same string | skip (SHA-only tip noise) |
| set | missing | skip (do not un-version) |
| missing | missing | bump to HEAD (SHA is identity) |
| missing | set | bump (first version) |
| A | B | bump to HEAD |

New pin is **HEAD at discovery time** when the gate passes. Index records `sha` + optional `version` + components.

### Ops

- **Schedule:** `0 15 * * *` (7am PST / 8am PDT; UTC-only cron)
- **Dispatch:** optional `plugin` (exact catalog name; unknown name fails), optional `force`
- **Auth:** default `GITHUB_TOKEN` (contents / pull-requests / actions write)
- **No auto-merge**
- If remote `bump/daily-YYYY-MM-DD` already exists → **no-op** unless `force=true` (rebuild + force-push)
- Non-dry-run resets to `origin/<default-branch>` before discovery so dispatch-from-branch matches the stack base
- Re-dispatches `validate-catalog` on stack branches (`!cancelled()` so partial failures still get checks)
- `PYTHONDONTWRITEBYTECODE` / ignore `__pycache__` so the dirty-tree check does not false-fail

### Merge order

1. Review each plugin PR (single-plugin diff vs daily).
2. Merge the ones you want into daily (or close to drop).
3. Land the daily PR into `main`.

Sibling merges into daily may need update-branch if `plugin-index.json` conflicts.

### Test

After merge: Actions → **Bump plugin SHAs** → Run workflow (`plugin=vercel` is a good first try).

```bash
python3 -B scripts/bump-plugin-shas.py --dry-run --only vercel
python3 scripts/generate-plugin-index.py --check
```