### PR TITLE
Add Zephex plugin (hosted MCP dev tools)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -145,6 +145,19 @@
       "homepage": "https://github.com/railwayapp/railway-skills",
       "keywords": ["railway", "railway deploy", "deploy to railway"],
       "domains": ["railway.com", "railway.app"]
+    },
+    {
+      "name": "zephex",
+      "description": "Zephex hosted MCP — ten read-only developer tools: project context, code search, AST reads, architecture maps, test pulse, package safety, live URL header audits, and project memory. OAuth at zephex.dev/mcp.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/zephexMCP/grok-zephex-plugin.git",
+        "sha": "dc82b08d8b7f03505615cc6faa7bb49df2283a22"
+      },
+      "homepage": "https://zephex.dev",
+      "keywords": ["zephex", "zephex mcp", "zephex dev tools"],
+      "domains": ["zephex.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -739,6 +739,23 @@
           }
         ]
       }
+    },
+    "zephex": {
+      "sha": "dc82b08d8b7f03505615cc6faa7bb49df2283a22",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "zephex",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "zephex-tools",
+            "description": "Zephex MCP — ten hosted dev tools for the user's repository. Use when finding or reading code, mapping architecture, ch…"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds **Zephex** to the xAI Grok Build plugin marketplace.

- **Plugin repo:** https://github.com/zephexMCP/grok-zephex-plugin
- **Pinned SHA:** `dc82b08d8b7f03505615cc6faa7bb49df2283a22`
- **MCP endpoint:** `https://zephex.dev/mcp` (OAuth PKCE on first connect)
- **Components:** `.mcp.json` + `skills/zephex-tools/SKILL.md`

## Checklist

- [x] One entry in `.grok-plugin/marketplace.json` (kebab-case `zephex`, unique)
- [x] Remote source with full 40-char lowercase `sha`
- [x] `.grok-plugin/plugin-index.json` regenerated
- [x] `python3 scripts/validate-catalog.py` passes locally
- [x] Official org source (`zephexMCP/grok-zephex-plugin`)
- [x] `homepage` + description + brand-scoped keywords/domains

## Security

Read-only hosted MCP tools. No shell hooks, no `curl | bash`, no secret exfiltration. OAuth via zephex.dev.

## Note

Separate from **grok.com/connectors Custom MCP** (BYO) — this PR is for Grok Build `/plugin` discovery only.