### PR TITLE
Add supabase-battle-tested plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -69,6 +69,18 @@
       "keywords": ["superpowers"]
     },
     {
+      "name": "supabase-battle-tested",
+      "description": "Production Supabase and Postgres patterns learned from real incidents: generated-column write traps, migrations-vs-live-DB drift, SECURITY DEFINER audit gaps, and RLS performance fixes.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/YoungAlgy/supabase-battle-tested.git",
+        "sha": "c8f08e7621ba58bcacd393c01e6eb74068152498"
+      },
+      "homepage": "https://github.com/YoungAlgy/supabase-battle-tested",
+      "keywords": ["supabase", "supabase rls", "supabase migrations", "supabase security definer"]
+    },
+    {
       "name": "mongodb",
       "description": "Official plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
       "category": "database",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -505,6 +505,17 @@
         ]
       }
     },
+    "supabase-battle-tested": {
+      "sha": "c8f08e7621ba58bcacd393c01e6eb74068152498",
+      "components": {
+        "skills": [
+          {
+            "name": "supabase-production-patterns",
+            "description": "Production Supabase/Postgres patterns and traps learned from real incidents — generated columns, migrations vs. live DB…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: supabase-battle-tested
- Type: remote source
- Source URL + pinned SHA (remote): https://github.com/YoungAlgy/supabase-battle-tested.git @ c8f08e7621ba58bcacd393c01e6eb74068152498
- Homepage: https://github.com/YoungAlgy/supabase-battle-tested

A single skill (`supabase-production-patterns`) covering four production Supabase/Postgres patterns learned from real incidents, not paraphrased docs: the generated-column write trap (Postgres error `428C9`), migrations-vs-live-DB schema drift and how to get ground truth, a manual `SECURITY DEFINER` audit methodology including a `service_role`-vs-`auth.uid()` gate trap, and the `(select auth.uid())` RLS performance fix for the `auth_rls_initplan` advisory.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none. It's a static markdown skill (guidance only), no scripts, no hooks, no MCP server.
- Credentials/permissions it requires (and why): none.

## Notes for reviewers

Personal-account source, not an official org, because this isn't a branded product plugin — it's original written guidance distilled from my own hands-on Supabase production experience (not Supabase's docs, not affiliated with Supabase Inc.). No impersonation intended; description and repo name make the "community lessons" framing explicit.