### PR TITLE
Run plugin SHA bump on ubuntu-latest-m

### DIFF
--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -50,7 +50,8 @@ concurrency:
 
 jobs:
   bump:
-    runs-on: ubuntu-latest
+    # IP-allowlisted org runners (hosted ubuntu-latest cannot push branches).
+    runs-on: ubuntu-latest-m
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary

Point the **Bump plugin SHAs** job at `ubuntu-latest-m` so it can push branches / open PRs under the org IP allow list. Hosted `ubuntu-latest` got a 403 on the first dispatch.

`validate-catalog` stays on `ubuntu-latest` (read-only checks).

## Test

Re-run **Bump plugin SHAs** via workflow_dispatch after merge.