### PR TITLE
Add Caplifi open-standard plugins (brandmd, hbi, slopmd, caplifi-approve)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,8 +240,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-agent-plugins.git",
+        "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
         "path": "plugins/brandmd"
       },
       "homepage": "https://caplifi.com/build/brandmd/",
@@ -260,8 +260,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-agent-plugins.git",
+        "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
         "path": "plugins/hbi"
       },
       "homepage": "https://eclecticventures.net/hbi/",
@@ -281,8 +281,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-agent-plugins.git",
+        "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
         "path": "plugins/slopmd"
       },
       "homepage": "https://eclecticventures.net/slopmd/",
@@ -301,8 +301,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-agent-plugins.git",
+        "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
         "path": "plugins/caplifi-approve"
       },
       "homepage": "https://caplifi.com/approve/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "d884ae04edebef577e82ff7c4e143debd0bbec99"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "railway",
@@ -143,8 +200,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -157,8 +221,99 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
+    },
+    {
+      "name": "brandmd",
+      "description": "BRAND.md open brand standard for agents: apply core brand under 600 tokens, load deeper files on demand, audit repo conformance.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
+        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "path": "plugins/brandmd"
+      },
+      "homepage": "https://caplifi.com/build/brandmd/",
+      "keywords": [
+        "brandmd",
+        "brand.md",
+        "caplifi brandmd"
+      ],
+      "domains": [
+        "caplifi.com"
+      ]
+    },
+    {
+      "name": "hbi",
+      "description": "Half-Baked Idea (HBI) open package format: init packages, advisory IP triage, disclosure gate discipline, local conformance validation.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
+        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "path": "plugins/hbi"
+      },
+      "homepage": "https://eclecticventures.net/hbi/",
+      "keywords": [
+        "hbi",
+        "half-baked idea",
+        "hbi-standard"
+      ],
+      "domains": [
+        "eclecticventures.net",
+        "caplifi.com"
+      ]
+    },
+    {
+      "name": "slopmd",
+      "description": "SLOP.md open agent handoff envelopes plus INSTIGATE (execute) vs HANDOFF (discuss) document contracts.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
+        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "path": "plugins/slopmd"
+      },
+      "homepage": "https://eclecticventures.net/slopmd/",
+      "keywords": [
+        "slopmd",
+        "slop.md",
+        "instigate handoff"
+      ],
+      "domains": [
+        "eclecticventures.net"
+      ]
+    },
+    {
+      "name": "caplifi-approve",
+      "description": "Caplifi Approve open contract (headgate.approve.v1): agents propose; humans approve irreversible access and execute work.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
+        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "path": "plugins/caplifi-approve"
+      },
+      "homepage": "https://caplifi.com/approve/",
+      "keywords": [
+        "caplifi-approve",
+        "headgate.approve",
+        "caplifi approve"
+      ],
+      "domains": [
+        "caplifi.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -241,7 +241,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
         "path": "plugins/brandmd"
       },
       "homepage": "https://caplifi.com/build/brandmd/",
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
         "path": "plugins/hbi"
       },
       "homepage": "https://eclecticventures.net/hbi/",
@@ -282,7 +282,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
         "path": "plugins/slopmd"
       },
       "homepage": "https://eclecticventures.net/slopmd/",
@@ -302,7 +302,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CaplifiTechnologies/caplifi-grok-plugins.git",
-        "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+        "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
         "path": "plugins/caplifi-approve"
       },
       "homepage": "https://caplifi.com/approve/",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,6 +43,46 @@
         ]
       }
     },
+    "brandmd": {
+      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "brandmd",
+            "description": "Quick BRAND.md workflow for this session."
+          }
+        ],
+        "skills": [
+          {
+            "name": "brandmd-apply",
+            "description": "Apply the BRAND.md open brand standard when writing copy, choosing colors/type, or producing assets for a brand. Load B…"
+          },
+          {
+            "name": "brandmd-audit",
+            "description": "Audit a repository for BRAND.md conformance and completeness score. Use when the user says brandmd audit, check brand r…"
+          }
+        ]
+      }
+    },
+    "caplifi-approve": {
+      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "approve-spec",
+            "description": "Caplifi Approve open contract helper."
+          }
+        ],
+        "skills": [
+          {
+            "name": "caplifi-approve",
+            "description": "Caplifi Approve / headgate.approve.v1 — format human phone-approval proposals for access and execute queues. Use when u…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c",
       "version": "1.6.0",
@@ -275,6 +315,28 @@
         ]
       }
     },
+    "hbi": {
+      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "hbi",
+            "description": "Half-Baked Idea package helper."
+          }
+        ],
+        "skills": [
+          {
+            "name": "hbi-package",
+            "description": "Create or shape a Half-Baked Idea (HBI) package: MANIFEST, IDEA, HANDOFF, IP_TRIAGE, DISCLOSURE. Use when the user says…"
+          },
+          {
+            "name": "hbi-validate",
+            "description": "Validate an HBI package for structural conformance using the reference validator. Use when the user says hbi validate,…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",
@@ -416,6 +478,28 @@
           {
             "name": "sentry-workflow",
             "description": "Keep Sentry SDKs up to date. Use when asked to upgrade the Sentry SDK across major versions, migrate SDK versions, or f…"
+          }
+        ]
+      }
+    },
+    "slopmd": {
+      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "slop",
+            "description": "SLOP + INSTIGATE/HANDOFF helper."
+          }
+        ],
+        "skills": [
+          {
+            "name": "instigate-handoff",
+            "description": "Write INSTIGATE (execute on receipt) or HANDOFF (absorb then discuss) documents correctly. Use when the user says INSTI…"
+          },
+          {
+            "name": "slop-envelope",
+            "description": "Author or parse SLOP.md agent handoff envelopes (slop.v1). Use for multi-agent inbox/outbox drops, instigate vs handoff…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -44,7 +44,7 @@
       }
     },
     "brandmd": {
-      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -66,7 +66,7 @@
       }
     },
     "caplifi-approve": {
-      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -316,7 +316,7 @@
       }
     },
     "hbi": {
-      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -483,7 +483,7 @@
       }
     },
     "slopmd": {
-      "sha": "adf47574768b491d8f0c0fb2d120dec18b1444bf",
+      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
       "version": "0.1.0",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -44,7 +44,7 @@
       }
     },
     "brandmd": {
-      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+      "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -66,7 +66,7 @@
       }
     },
     "caplifi-approve": {
-      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+      "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -316,7 +316,7 @@
       }
     },
     "hbi": {
-      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+      "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
       "version": "0.1.0",
       "components": {
         "commands": [
@@ -483,7 +483,7 @@
       }
     },
     "slopmd": {
-      "sha": "ea415658636f34f8c7e7d6d45d2c7e30d2be4a6a",
+      "sha": "11e161f8d372723972a5dbeaaef7c70799c48147",
       "version": "0.1.0",
       "components": {
         "commands": [


### PR DESCRIPTION
## Summary

Adds four Caplifi Technologies open-standard plugins for Grok Build:

| Plugin | What |
|--------|------|
| **brandmd** | BRAND.md apply + audit |
| **hbi** | Half-Baked Idea package format + local validator |
| **slopmd** | SLOP.md envelopes + INSTIGATE/HANDOFF |
| **caplifi-approve** | headgate.approve.v1 human phone approval contract |

## Source

- Repo: https://github.com/CaplifiTechnologies/caplifi-agent-plugins (public, Apache-2.0)
- Org: CaplifiTechnologies
- Paths: `plugins/{brandmd,hbi,slopmd,caplifi-approve}`
- SHA pinned in catalog

## Security

- Skills + slash commands only
- HBI ships pure-Python local validator (no network)
- No hooks, no MCP, no postinstall, no secret access
- No house-local paths

## Checklist

- [x] Catalog entry + regenerated plugin-index
- [x] `validate-catalog.py` OK
- [x] Brand-scoped keywords/domains
- [x] Official org source (not personal account)

## Test plan

- [ ] `grok plugin install CaplifiTechnologies/caplifi-agent-plugins#plugins/brandmd --trust`
- [ ] Skills appear after enable
- [ ] No unexpected network or shell from install alone
