### PR TITLE
Add authorityprompt plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "authorityprompt",
+      "description": "Manage your company's official AI identity from Grok with AuthorityPrompt. Read verified company facts with their sources, provenance and confidence; run AIO readiness audits; check what LLMs say about the company and where it diverges from the truth; and publish or repair facts with confirmation. Sign in \u2014 each account sees only its own data.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/authorityprompt/grok-authorityprompt-mcp.git",
+        "sha": "f8511546be57d034390c51bba59f62edf0d8464a"
+      },
+      "homepage": "https://authorityprompt.com",
+      "keywords": ["authorityprompt", "ai visibility", "llm trust", "company facts", "aio audit"],
+      "domains": ["authorityprompt.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "authorityprompt": {
+      "sha": "f8511546be57d034390c51bba59f62edf0d8464a",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "authorityprompt",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds one new third-party plugin, **authorityprompt**, as a remote source. Nothing is vendored here — the entry references our public repo, pinned to a full commit SHA.

**Plugin:** `authorityprompt` · category `development`
**Source:** https://github.com/authorityprompt/grok-authorityprompt-mcp.git
**Pinned SHA:** `f8511546be57d034390c51bba59f62edf0d8464a`

AuthorityPrompt lets a Grok user manage their own company's official AI identity: read verified company facts with sources, provenance and confidence, run AIO readiness audits, check what LLMs say about the company, and publish or repair facts with confirmation. It is a remote MCP server over OAuth 2.0 (dynamic client registration + PKCE), so each account only ever reaches its own companies.

## Checklist

One entry added to `.grok-plugin/marketplace.json` — valid JSON, name kebab-case and unique. Remote source pins a full 40-char lowercase commit SHA; the commit is public and reachable. `.grok-plugin/plugin-index.json` regenerated with `scripts/generate-plugin-index.py`, not hand-edited, and `scripts/validate-catalog.py` passes. Homepage, description, brand-scoped keywords/domains and category are set. Only the two catalog files changed — no other entries touched.