### PR TITLE
Add Meritocra Engineering Help

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "meritocra-engineering-help",
+      "description": "Provider-neutral software-delivery triage for production incidents, inherited codebases, and delivery blockers, with an explicitly confirmed request path for human engineering help.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Meritocra/meritocra-engineering-help.git",
+        "sha": "db642b1ae9acbfcefda757fc2027c45918e2f573"
+      },
+      "homepage": "https://meritocra.com/mcp.md",
+      "keywords": ["meritocra", "meritocra engineering help", "meritocra mcp"],
+      "domains": ["meritocra.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -167,7 +167,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Meritocra/meritocra-engineering-help.git",
-        "sha": "db642b1ae9acbfcefda757fc2027c45918e2f573"
+        "sha": "792ee7f5dbd3dd9dfe21113490ebe9306acd79ef"
       },
       "homepage": "https://meritocra.com/mcp.md",
       "keywords": ["meritocra", "meritocra engineering help", "meritocra mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,6 +275,18 @@
         ]
       }
     },
+    "meritocra-engineering-help": {
+      "sha": "db642b1ae9acbfcefda757fc2027c45918e2f573",
+      "version": "0.4.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "meritocra-engineering-help",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -276,8 +276,8 @@
       }
     },
     "meritocra-engineering-help": {
-      "sha": "db642b1ae9acbfcefda757fc2027c45918e2f573",
-      "version": "0.4.0",
+      "sha": "792ee7f5dbd3dd9dfe21113490ebe9306acd79ef",
+      "version": "0.5.0",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: Meritocra Engineering Help
- Type: remote source
- Source URL + pinned SHA: https://github.com/Meritocra/meritocra-engineering-help.git @ db642b1ae9acbfcefda757fc2027c45918e2f573
- Homepage: https://meritocra.com/mcp.md

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the official Meritocra organization.

## Checklist

- [x] Added exactly one kebab-case catalog entry in `.grok-plugin/marketplace.json`.
- [x] The remote source pins a full 40-character lowercase SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] The package has a clear description, homepage, README, and Grok manifest.
- [x] The source package is MIT licensed.

## Security

- [x] No scripts, hooks, shell execution, remote-code download/exec, or postinstall behavior.
- [x] No reading or exfiltration of secrets, tokens, environment variables, or local files.
- [x] The plugin exposes one least-privilege remote MCP configuration.
- Network endpoint: https://meritocra.com/api/engineering-help/mcp — connects Grok Build to the public engineering-triage MCP.
- Credentials/permissions: none required to connect. The only write action requires explicit user confirmation in the tool input; users should not submit credentials or private source code.

## Notes for reviewers

The source is an official, source-only Meritocra repository. It contains only a README, MIT license, an explicit Grok manifest, and the remote MCP configuration. The generated index resolves one HTTP MCP server.
