### PR TITLE
Add beast-dev-guard plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,26 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "beast-dev-guard",
+      "description": "Verification-first agentic development from The Beast, the self-improving AGI software company. Docs-only skills and commands: verify-before-claim launch gates, primary-source preflight, evidence-labeled research, a 7-point security audit for installing third-party skills, and deterministic QA with checksums and pinned SHAs.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/thebeastagi/beast-dev-guard.git",
+        "sha": "df33477dfa730a660851f3243f42d943a36486e2"
+      },
+      "homepage": "https://github.com/thebeastagi/beast-dev-guard",
+      "keywords": [
+        "beast",
+        "thebeastagi",
+        "beast dev guard",
+        "the beast agi"
+      ],
+      "domains": [
+        "thebeastagi.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,6 +43,52 @@
         ]
       }
     },
+    "beast-dev-guard": {
+      "sha": "df33477dfa730a660851f3243f42d943a36486e2",
+      "version": "1.0.0",
+      "components": {
+        "commands": [
+          {
+            "name": "evidence-label",
+            "description": "Label every factual claim in a document or research output by evidence strength (✅ verified / ⚠️ vendor-claimed / ❓ unv…"
+          },
+          {
+            "name": "preflight",
+            "description": "Run the primary-source preflight checklist over a claim, repo, API, or task premise before building on it — verify repo…"
+          },
+          {
+            "name": "skill-audit",
+            "description": "Run the 7-point static security audit on a third-party skill, plugin, hook, or MCP config before installing it — RCE, e…"
+          },
+          {
+            "name": "verify-claims",
+            "description": "Audit the completion claims in the current work (or a given summary/diff) against actual evidence, and produce the veri…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "deterministic-qa",
+            "description": "Make deliverables reproducible and tamper-evident — SHA-256 manifests for every artifact, two-run byte-determinism chec…"
+          },
+          {
+            "name": "evidence-labeled-research",
+            "description": "Label every factual claim in research output by evidence strength — ✅ independently verified (primary source fetched),…"
+          },
+          {
+            "name": "primary-source-preflight",
+            "description": "A 1-5 minute checklist to verify primary sources before building on any claim — repo identity, live API probes, existen…"
+          },
+          {
+            "name": "safe-skill-install",
+            "description": "Static security audit checklist for third-party agent skills, plugins, prompts, and MCP configs BEFORE installing them.…"
+          },
+          {
+            "name": "verify-before-claim",
+            "description": "Never claim \"done\", \"live\", \"fixed\", or \"delivered\" without end-to-end evidence. Use before announcing a launch, closin…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c",
       "version": "1.6.0",


### PR DESCRIPTION
## What this PR does

Adds `beast-dev-guard`, a docs-only plugin for verification-first agentic development.

- Plugin name: `beast-dev-guard`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): `https://github.com/thebeastagi/beast-dev-guard.git` at `df33477dfa730a660851f3243f42d943a36486e2`
- Homepage: https://github.com/thebeastagi/beast-dev-guard

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The plugin is original content from The Beast (`@thebeastagi`) and is published under the MIT License.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): None.
- Credentials/permissions it requires (and why): None.

Docs-only plugin — no scripts, hooks, MCP/LSP servers; calls no network endpoints; requires no credentials or permissions.

## Notes for reviewers

The source is published from our official organization and all plugin content is original. The remote commit is immutable-pinned, publicly reachable, and the catalog/index validation commands pass locally.
