### PR TITLE
Add focus-audio third-party plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,18 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "focus-audio",
+      "description": "Spoken focus briefs for Grok Build turns using your own xAI API key. Optional mid-turn live speech, play/pause/skip, master on/off, and /audio slash commands. macOS primary; no third-party analytics.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vbusnita/focus-audio.git",
+        "sha": "98185c8d733477aa117e99a91fd6a097541d611b"
+      },
+      "homepage": "https://github.com/vbusnita/focus-audio",
+      "keywords": ["focus-audio", "focus audio"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -167,7 +167,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/vbusnita/focus-audio.git",
-        "sha": "98185c8d733477aa117e99a91fd6a097541d611b"
+        "sha": "91fea499dc35389ef5854cf150b78b0dbf426949"
       },
       "homepage": "https://github.com/vbusnita/focus-audio",
       "keywords": ["focus-audio", "focus audio"]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -275,6 +275,109 @@
         ]
       }
     },
+    "focus-audio": {
+      "sha": "98185c8d733477aa117e99a91fd6a097541d611b",
+      "components": {
+        "commands": [
+          {
+            "name": "audio",
+            "description": "audio: Focus Audio help + hotkeys (Ctrl+Shift+Space play/pause, R restart, . skip, B rebrief, M mode). /audio"
+          },
+          {
+            "name": "audio-live",
+            "description": "audio: toggle live mid-turn speech (live_verbatim). /audio-live"
+          },
+          {
+            "name": "audio-mode",
+            "description": "audio: toggle brief/verbatim mode (Ctrl+Shift+M). /audio-mode"
+          },
+          {
+            "name": "audio-off",
+            "description": "audio: master OFF — silence live + brief + verbatim. /audio-off"
+          },
+          {
+            "name": "audio-on",
+            "description": "audio: master ON — re-enable Focus Audio after /audio-off. /audio-on"
+          },
+          {
+            "name": "audio-rebrief",
+            "description": "audio: re-brief last turn (Ctrl+Shift+B). /audio-rebrief"
+          },
+          {
+            "name": "audio-restart",
+            "description": "audio: restart Focus Audio clip (Ctrl+Shift+R). /audio-restart"
+          },
+          {
+            "name": "audio-skip",
+            "description": "audio: skip/stop Focus Audio (Ctrl+Shift+.). /audio-skip"
+          },
+          {
+            "name": "audio-toggle",
+            "description": "audio: play/pause Focus Audio (Ctrl+Shift+Space). /audio-toggle"
+          },
+          {
+            "name": "listen",
+            "description": "audio: speak last assistant turn as Focus Audio brief. /listen. Hotkeys: Ctrl+Shift+Space"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "audio",
+            "description": "audio: Focus Audio help + hotkeys (Ctrl+Shift+Space play/pause, R restart, . skip, B rebrief, M mode). /audio"
+          },
+          {
+            "name": "audio-live",
+            "description": "audio: toggle live mid-turn speech (live_verbatim). /audio-live"
+          },
+          {
+            "name": "audio-mode",
+            "description": "audio: toggle brief/verbatim mode (Ctrl+Shift+M). /audio-mode"
+          },
+          {
+            "name": "audio-off",
+            "description": "audio: master OFF — silence live + brief + verbatim. /audio-off"
+          },
+          {
+            "name": "audio-on",
+            "description": "audio: master ON — re-enable Focus Audio after /audio-off. /audio-on"
+          },
+          {
+            "name": "audio-rebrief",
+            "description": "audio: re-brief last turn (Ctrl+Shift+B). /audio-rebrief"
+          },
+          {
+            "name": "audio-restart",
+            "description": "audio: restart Focus Audio clip (Ctrl+Shift+R). /audio-restart"
+          },
+          {
+            "name": "audio-skip",
+            "description": "audio: skip/stop Focus Audio (Ctrl+Shift+.). /audio-skip"
+          },
+          {
+            "name": "audio-toggle",
+            "description": "audio: play/pause Focus Audio (Ctrl+Shift+Space). /audio-toggle"
+          },
+          {
+            "name": "listen",
+            "description": "audio: speak last assistant turn as Focus Audio brief. /listen. Hotkeys: Ctrl+Shift+Space"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -276,7 +276,7 @@
       }
     },
     "focus-audio": {
-      "sha": "98185c8d733477aa117e99a91fd6a097541d611b",
+      "sha": "91fea499dc35389ef5854cf150b78b0dbf426949",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

New third-party plugin listing for Focus Audio (spoken briefs for Grok Build).

- Plugin name: `focus-audio`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/vbusnita/focus-audio.git` @ `91fea499dc35389ef5854cf150b78b0dbf426949`
- Homepage: https://github.com/vbusnita/focus-audio

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

**Why personal account:** Focus Audio is a personal open-source project (MIT), not a company product. Source lives at `vbusnita/focus-audio`, which I own and maintain. There is no separate product org to publish under.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json` (N/A — remote source; upstream has README + root `plugin.json`).
- [x] License is stated. (MIT in upstream repo)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - Default `https://api.x.ai/v1` only (user-configurable API base): **chat** completions for optional brief rewrite, and **`/v1/tts`** for speech synthesis. No author telemetry or third-party analytics endpoints.
- Credentials/permissions it requires (and why):
  - **User’s own xAI API key** via macOS Keychain service `xai-api-key` or env `XAI_API_KEY` (never written to plugin config/cache/logs).
  - **Session lifecycle hooks only** (`SessionStart`, `UserPromptSubmit`, `SessionEnd`, `Stop`) to ensure/release the local daemon and enqueue speech — not all Bash/Write.
  - **Optional** global hotkeys: `pynput` + macOS Accessibility for the host process (not required for auto-speak after turns).
  - Local runtime under `~/.grok/focus-audio/` (cache, logs, Unix socket) — owner-only modes by default.

## Notes for reviewers

- **macOS primary** today (AVAudioPlayer / `afplay`); description states this — not claimed as multi-platform.
- Catalog `keywords` are brand-scoped: `focus-audio`, `focus audio` (no generic `tts` / `voice` / `audio` CTA terms).
- Upstream README documents Console vs Grok login, first-time API key creation, Keychain storage, privacy, and install (marketplace path + git).
- Local validation was re-run after pinning the post-docs `main` commit (`91fea49`).