### PR TITLE
Add vesper-forge plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "d884ae04edebef577e82ff7c4e143debd0bbec99"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,8 +139,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "railway",
@@ -143,8 +200,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -157,8 +221,34 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
+    },
+    {
+      "name": "vesper-forge",
+      "description": "VesperForge is a localhost web UI for managing Grok Build sessions: search, pin, rename, open in tmux, and sync notes/transcripts to Obsidian. Built for solo Linux workflows—simple toolbar, no cloud multi-user hosting.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/TX-220/vesper-forge.git",
+        "sha": "7f93404e860eb029b09331e30e82d2ff327c6258"
+      },
+      "homepage": "https://github.com/TX-220/vesper-forge",
+      "keywords": [
+        "vesperforge",
+        "vesper-forge",
+        "vesper forge"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -718,6 +718,18 @@
           }
         ]
       }
+    },
+    "vesper-forge": {
+      "sha": "7f93404e860eb029b09331e30e82d2ff327c6258",
+      "version": "1.1.1",
+      "components": {
+        "skills": [
+          {
+            "name": "vesper-forge",
+            "description": "Manage local Grok Build sessions with VesperForge — a localhost web UI for browsing, pinning, renaming, opening session…"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Add **vesper-forge** (VesperForge) to the official Grok Build plugin marketplace catalog.

- **Homepage / source:** https://github.com/TX-220/vesper-forge
- **Pinned SHA:** `7f93404e860eb029b09331e30e82d2ff327c6258`
- **Category:** development
- **What it provides:** skill `vesper-forge` — guides Grok on running the local VesperForge session browser (Grok Build session list/search/pin, open in tmux, one-click Obsidian sync). The app itself is a localhost FastAPI UI bundled in the same repo.

### Description (listing)

VesperForge is a localhost web UI for managing Grok Build sessions: search, pin, rename, open in tmux, and sync notes/transcripts to Obsidian. Built for solo Linux workflows—simple toolbar, no cloud multi-user hosting.

VesperForge - Local Grok Build session browser with Obsidian sync
What it does:

Browse, search, pin, and rename local Grok Build sessions
Open sessions in tmux
One-click sync of session summaries and transcripts to Obsidian vault
Simple localhost web UI (127.0.0.1:7420)

Target users: Solo developers using Grok Build on Linux who use Obsidian for notes.
Tech stack: Python + FastAPI + local filesystem integration.
Why useful: Makes managing long Grok Build sessions much more convenient without leaving your terminal workflow.

### Keywords

`vesperforge`, `vesper-forge`, `vesper forge` (brand-scoped for CTA)

## Checklist

- [x] One entry in `.grok-plugin/marketplace.json` (kebab-case unique name)
- [x] Remote `url` source with full 40-char lowercase `sha`
- [x] `plugin-index.json` regenerated (`generate-plugin-index.py`)
- [x] Local validation: `validate-catalog.py` + `generate-plugin-index.py --check`
- [x] Source public and reachable; MIT licensed
- [x] Plugin owns a `.grok-plugin/plugin.json` and skill under `skills/vesper-forge/`

## Note on pin SHA

Product freeze note `4b0edb6…` was specified earlier; marketplace install requires a plugin package (`plugin.json` + skill), so the pin is the follow-up commit that adds those files on top of the reviewed product tree.

## Test plan

- [ ] CI: catalog validation + plugin-index check
- [ ] Install from marketplace / source URL and confirm skill `vesper-forge` is listed
- [ ] Optional: run `python3 server.py` from the pinned tree and open `http://127.0.0.1:7420/`