### PR TITLE
Add Sprites plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -147,6 +147,19 @@
       "domains": ["railway.com", "railway.app"]
     },
     {
+      "name": "sprites",
+      "description": "Official Sprites integration for Grok Build. Create and operate isolated, persistent Linux environments through the hosted OAuth-authenticated Sprites MCP server; run commands and tests, manage services, checkpoints, and network policy.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/superfly/sprites-grok-plugin.git",
+        "sha": "a696ac338d86529c45f959b8b002e456330d349a"
+      },
+      "homepage": "https://sprites.dev",
+      "keywords": ["sprites", "sprites dev", "fly sprites", "sprites mcp"],
+      "domains": ["sprites.dev", "docs.sprites.dev"]
+    },
+    {
       "name": "stripe",
       "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -420,6 +420,32 @@
         ]
       }
     },
+    "sprites": {
+      "sha": "a696ac338d86529c45f959b8b002e456330d349a",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "sprites",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "sprites",
+            "description": "Use Sprites for isolated remote compute from Grok Build: create sandboxes, run commands and tests, manage long-running…"
+          },
+          {
+            "name": "sprites-smoke",
+            "description": "End-to-end Sprites smoke test via MCP: list, create, exec, optional destroy. Use when the user runs /sprites-smoke or a…"
+          },
+          {
+            "name": "sprites-status",
+            "description": "Check whether the Sprites plugin MCP is loaded and authenticated. Use when the user runs /sprites-status, asks if Sprit…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "61df6113574127536db39738c4aa6fc15d3e2298",
       "version": "0.1.1",


### PR DESCRIPTION
## What this PR does

Adds the official Fly.io Sprites plugin for Grok Build. The plugin connects Grok to the hosted Sprites MCP server and supplies skills for isolated remote compute, first-run authentication, safe command execution, services, checkpoints, network policy, and smoke testing.

- Plugin name: sprites
- Type: remote source
- Source URL + pinned SHA: https://github.com/superfly/sprites-grok-plugin.git at `a696ac338d86529c45f959b8b002e456330d349a`
- Homepage: https://sprites.dev

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The plugin is published by Fly.io under the official `superfly` GitHub organization.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, install-time remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://sprites.dev/mcp`, the Fly.io-operated hosted MCP control plane for Sprites. OAuth discovery and consent remain on the `sprites.dev` host.
- Credentials/permissions it requires (and why): browser OAuth with the Sprites `sprites:read` and `sprites:write` scopes. The recommended/default connector token is restricted by a non-empty Sprite name prefix and a creation cap. Full organization access is optional and explicitly warned about in the README and skill.

## Notes for reviewers

- The repository contains no local server executable, install script, hooks, postinstall behavior, or telemetry. The MCP server is hosted and operated by Fly.io.
- `exec` is an intentional product capability for user-requested commands inside hardware-isolated remote Sprites. It never executes commands on the Grok user's local machine.
- Destructive operations such as destroy, checkpoint restore, and network-policy changes are marked destructive by the MCP server; the bundled skill additionally requires explicit user intent or confirmation.
- The file-writing reference documents base64 as a transparent transport encoding for user/generated file content through the MCP `exec` schema. The plugin contains no encoded or obfuscated payload blobs.
- Local verification found version `0.2.0`, three skills (`sprites`, `sprites-status`, `sprites-smoke`), and one hosted MCP server (`sprites`).
