### PR TITLE
Add anakin plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "anakin",
+      "description": "Official plugin for Anakin (MCP Server + Skills). Turn any website into clean, LLM-ready markdown or structured JSON — scrape, search, map, and crawl, or run multi-source agentic deep research. Execute pre-built Wire actions across hundreds of popular sites to extract listings, prices, and profiles without writing selectors. Also monitors pages for changes on a schedule, compares what AI answer engines say about a topic, and drives a real cloud browser from natural language. Automatic JS rendering, stealth browser, and proxy rotation.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Anakin-Inc/agent-skills.git",
+        "sha": "3bda02903117843795ac81d4c99483eea86d1a96"
+      },
+      "homepage": "https://anakin.io",
+      "keywords": ["anakin", "anakin.io", "anakin scrape", "wire action"],
+      "domains": ["anakin.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,40 @@
 {
   "version": 1,
   "plugins": {
+    "anakin": {
+      "sha": "3bda02903117843795ac81d4c99483eea86d1a96",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "anakin",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "anakin-browser",
+            "description": "Use when a task needs a real browser driven step by step — multi-step flows, clicking and typing, complex navigation th…"
+          },
+          {
+            "name": "anakin-monitoring",
+            "description": "Use when the user wants to watch a web page, site, or Wire action for changes over time rather than fetch it once — pri…"
+          },
+          {
+            "name": "anakin-research",
+            "description": "Use when answering a question from the web with Anakin rather than fetching a known URL — web search for relevant pages…"
+          },
+          {
+            "name": "anakin-web-data",
+            "description": "Use when fetching content from the web with Anakin — reading a page, getting a site's URL structure, or bulk-collecting…"
+          },
+          {
+            "name": "anakin-wire",
+            "description": "Use when a task targets a specific well-known website — extracting products, listings, prices, profiles, reviews or das…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
Adds [Anakin](https://anakin.io) — a web data platform for AI agents — as a third-party plugin.

## What it provides

The plugin bundles the `@anakin-io/mcp` server with five skills:

- **scrape / map / crawl** — any URL to clean markdown or AI-extracted JSON, with optional stealth-browser rendering
- **search / agentic_search** — web search, and multi-source deep research that scrapes its own citations
- **wire_\*** — pre-built, vetted actions across hundreds of popular sites, returning structured data without hand-written selectors
- **monitor_\*** — scheduled change detection with webhook or email alerts
- **browser_task / session_\*** — natural-language automation in a real cloud browser, with saved login sessions

The skills exist because the tool schemas alone don't convey when to prefer one over another — most notably that Wire has read actions needing no auth, which agents otherwise skip.

## Checklist

- [x] `source` pins a full 40-character lowercase commit SHA
- [x] Public repository owned by Anakin-Inc, Apache-2.0
- [x] `keywords` and `domains` scoped to the brand, not generic terms
- [x] `category` set to `development`
- [x] No duplicate entry in the catalog
- [x] `python3 scripts/generate-plugin-index.py` run and committed
- [x] `python3 scripts/validate-catalog.py` passes — `Catalog OK`

## Notes

The generated index resolves the stdio MCP server and all five skills at the pinned SHA.

The server requires an `ANAKIN_API_KEY` environment variable (free tier available, no card). The plugin intentionally ships no `env` block: clients that don't expand `${VAR}` would pass the literal through, and the server would then start and advertise every tool while all calls fail. Without one, a missing key stops the server immediately with a message naming the variable and where to get it.

The MCP server version is pinned exactly rather than tracking `@latest`, so the reviewed SHA cannot execute unreviewed code.