### PR TITLE
Add conventional-commits plugin to marketplace

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "d884ae04edebef577e82ff7c4e143debd0bbec99"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,8 +139,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -142,8 +199,16 @@
         "sha": "7d1f84071ac57ea22536e9937e699122f2f8ae91"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -155,8 +220,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -169,8 +243,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -183,8 +264,35 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
+    },
+    {
+      "name": "conventional-commits",
+      "description": "Write clean Conventional Commits and generate changelog entries from your staged diff, with correct type, scope, and breaking-change footers.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/covisualize/conventional-commits.git",
+        "sha": "07d51e9732e24e03a30b40d29e0088f5054c70ad"
+      },
+      "homepage": "https://github.com/covisualize/conventional-commits",
+      "keywords": [
+        "conventional commits",
+        "conventional commit",
+        "commit convention",
+        "changelog from commits"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -153,6 +153,18 @@
         ]
       }
     },
+    "conventional-commits": {
+      "sha": "07d51e9732e24e03a30b40d29e0088f5054c70ad",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "conventional-commits",
+            "description": "Write commit messages that follow the Conventional Commits 1.0.0 spec and derive changelog entries from history. Use wh…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "7d1f84071ac57ea22536e9937e699122f2f8ae91",
       "version": "1.1.0",


### PR DESCRIPTION
## Add `conventional-commits`

Adds a single catalog entry for **conventional-commits**, a small skills-only plugin that helps Grok Build write [Conventional Commits 1.0.0](https://www.conventionalcommits.org) messages and derive changelogs from a staged diff.

- **Source:** https://github.com/covisualize/conventional-commits (remote, pinned SHA `07d51e97…`)
- **License:** MIT
- **No executable code / MCP / hooks / network** — it ships one `SKILL.md` that only guides commit-message writing, so it requires zero runtime permissions.

### Checklist
- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` kebab-case and unique
- [x] Remote source pins a full 40-char lowercase commit SHA; commit is public and reachable
- [x] `.grok-plugin/plugin-index.json` regenerated (`scripts/generate-plugin-index.py`) and committed
- [x] `homepage`, clear `description`, product-scoped `keywords`, and a `category` (`development`)
- [x] Plugin is licensed (MIT) and the license is stated
- [x] Local validation passes: `validate-catalog.py` → "Catalog OK", `generate-plugin-index.py --check` → "Plugin index OK"
- [x] Read and complies with Security expectations (no RCE, no exfiltration; skill-only)