### PR TITLE
Add Keenable plugin (keyless web search + page extraction)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,19 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "keenable",
+      "description": "Keyless web search and page-content extraction via Keenable's hosted MCP server \u2014 no signup or API key needed (rate-limited public path; set KEENABLE_API_KEY to raise limits). search_web_pages returns ranked results with snippets; fetch_page_content reads any URL as clean markdown. Includes web-research and deep-research skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/keenableai/keenable-grok-plugin.git",
+        "sha": "350fd05a76a3e7bc6b6dbef616f30c9d08ce6c90"
+      },
+      "homepage": "https://keenable.ai",
+      "keywords": ["keenable", "keenable search", "keenable ai"],
+      "domains": ["keenable.ai", "docs.keenable.ai", "api.keenable.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,28 @@
         ]
       }
     },
+    "keenable": {
+      "sha": "350fd05a76a3e7bc6b6dbef616f30c9d08ce6c90",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "keenable",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "keenable-deep-research",
+            "description": "Run comprehensive multi-source web research with Keenable and synthesize a cited answer. Use for literature reviews, ma…"
+          },
+          {
+            "name": "keenable-web",
+            "description": "Search and read the web with Keenable. Use for current information, source discovery, and extracting clean content from…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds **Keenable** — a keyless web search + page-content extraction plugin backed by Keenable's hosted MCP server.

- Plugin name: `keenable`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/keenableai/keenable-grok-plugin.git` @ `350fd05a76a3e7bc6b6dbef616f30c9d08ce6c90`
- Homepage: https://keenable.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`keenableai/keenable-grok-plugin`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege — the plugin ships no hooks and a single scoped HTTP MCP server (two tools: `search_web_pages`, `fetch_page_content`).
- Network endpoints this plugin calls (and why): only `https://api.keenable.ai/mcp` — Keenable's hosted MCP server, for web search and page extraction.
- Credentials/permissions it requires (and why): none. Keyless by default. The server optionally reads a `KEENABLE_API_KEY` env var to raise rate limits; a key is never required and none is bundled.

## Notes for reviewers

Follows the same shape as the existing `tavily`, `exa`, and `firecrawl` entries: a thin remote-source repo (`.mcp.json` + `.grok-plugin/plugin.json` + skills) wrapping a hosted MCP endpoint. Like `firecrawl`, Keenable is **keyless by default** (public rate-limited path, no signup); an optional API key only lifts limits. Source is published under our official `keenableai` org.
