### PR TITLE
Add Olostep plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,29 @@
   },
   "plugins": [
     {
+      "name": "olostep",
+      "description": "Web scraping, search, crawling, URL discovery, batch extraction, and AI-grounded answers via Olostep's hosted MCP server. Turn any website into clean markdown, HTML, JSON, or text - with JS rendering, geo-targeting, and structured parsers - directly from Grok Build.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/olostep/olostep-grok-plugin.git",
+        "sha": "617ab62b82cdf0c3d5fef1593e33913e5dc35750"
+      },
+      "homepage": "https://github.com/olostep/olostep-grok-plugin",
+      "keywords": [
+        "olostep",
+        "olostep scrape",
+        "olostep search",
+        "web scraping"
+      ],
+      "domains": [
+        "olostep.com",
+        "www.olostep.com",
+        "docs.olostep.com",
+        "mcp.olostep.com"
+      ]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",
@@ -156,7 +179,12 @@
       },
       "homepage": "https://www.tavily.com",
       "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -183,7 +211,13 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
     }
   ]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -360,6 +360,24 @@
         ]
       }
     },
+    "olostep": {
+      "sha": "617ab62b82cdf0c3d5fef1593e33913e5dc35750",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "olostep",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "olostep-web",
+            "description": "Use Olostep to scrape, search, crawl, map, and extract live web data, or to get AI-grounded answers with citations. Tri…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
       "version": "1.3.6",


### PR DESCRIPTION
Adds the Olostep plugin to the marketplace.

Olostep is web scraping, crawling, and search infrastructure. This plugin wires Olostep's hosted MCP server into Grok Build, giving it 10 tools for live web data: scrape, search, crawl, map, URL discovery, batch extraction, and AI-grounded answers.

- Plugin repo: https://github.com/olostep/olostep-grok-plugin
- Pinned SHA: 617ab62b82cdf0c3d5fef1593e33913e5dc35750
- Auth: user provides an Olostep API key via OLOSTEP_API_KEY (sent as Authorization: Bearer). Free tier available.
- Category: development

Tested locally in Grok Build: the plugin installs, the MCP server connects with all 10 tools listed, and scrape_website returns live page content successfully.

Validators run locally (both pass):
- python scripts/generate-plugin-index.py
- python scripts/validate-catalog.py