### PR TITLE
Add oh-my-grok-build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "d41356cdbd0a8ddf01c0788626612ddaaa1ef9ba",
+        "sha": "dc5c6f5c87b0190666db30db53f64cb6b8aaaeb6",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "d4ff002fdf2aef24419e7616fb145d8546a90608",
+        "sha": "e590fd6b0b97de96d14c626e66896e3570ac3018",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "3dcbd5c4b48e02263fbf4a3c01e3fe4f81d584d9"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -142,8 +199,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -155,8 +220,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -169,8 +243,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -183,12 +264,22 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -197,8 +288,17 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
     },
     {
       "name": "oh-my-grok-build",
@@ -207,7 +307,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "339610fdb5af4014a23978f3628b28fe747e3d39",
+        "sha": "4967ef1f159a6cabeefcf8eb953a16a59d3947bc",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "059722011b099fecfa07daee5ea9a0b152cabc61",
+        "sha": "3314e2efde6586c10d4ad2ff15a932a9fce2642a",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -185,6 +185,19 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "oh-my-grok-build",
+      "description": "Consensus planning, bounded parallel execution, and evidence-based verification for Grok Build. Adds /ogb-plan, /ogb-start, /ogb-ultrawork, /ogb-verify, /ogb-workflow, and /ogb-doctor on top of native plan mode, subagents, worktrees, and workflows. Content-only: no hooks, MCP servers, binaries, or runtime dependencies.",
+      "category": "workflows",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
+        "sha": "d4ff002fdf2aef24419e7616fb145d8546a90608",
+        "path": "plugins/oh-my-grok-build"
+      },
+      "homepage": "https://github.com/duarbdhks/oh-my-grok-build",
+      "keywords": ["oh-my-grok-build", "ogb", "ogb-plan", "ogb-start", "ogb-verify"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -284,7 +284,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "a8c07bd460c95e3a779767f1dc3d1b7291c4a702",
+        "sha": "fab0af9bc60afc287b73163ee386dda5b341c162",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "e590fd6b0b97de96d14c626e66896e3570ac3018",
+        "sha": "bed1100eac229e9e373637d8351416afeb837906",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "3dcbd5c4b48e02263fbf4a3c01e3fe4f81d584d9"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -142,8 +199,16 @@
         "sha": "7d1f84071ac57ea22536e9937e699122f2f8ae91"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -155,8 +220,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -169,8 +243,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -183,8 +264,18 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "oh-my-grok-build",
@@ -193,11 +284,21 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "dc5c6f5c87b0190666db30db53f64cb6b8aaaeb6",
+        "sha": "d3987a662affaf07b0f987bceceabeb0edc35889",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",
-      "keywords": ["oh-my-grok-build", "ogb", "ogb-plan", "ogb-start", "ogb-verify", "ogb-interview", "ogb-ultrawork", "ogb-doctor", "ogb-workflow"]
+      "keywords": [
+        "oh-my-grok-build",
+        "ogb",
+        "ogb-plan",
+        "ogb-start",
+        "ogb-verify",
+        "ogb-interview",
+        "ogb-ultrawork",
+        "ogb-doctor",
+        "ogb-workflow"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -188,16 +188,16 @@
     },
     {
       "name": "oh-my-grok-build",
-      "description": "Consensus planning, bounded parallel execution, and evidence-based verification for Grok Build. Adds /ogb-plan, /ogb-start, /ogb-ultrawork, /ogb-verify, /ogb-workflow, and /ogb-doctor on top of native plan mode, subagents, worktrees, and workflows. Content-only: no hooks, MCP servers, binaries, or runtime dependencies.",
+      "description": "Consensus planning, bounded parallel execution, and evidence-based verification for Grok Build. Adds /ogb-interview, /ogb-plan, /ogb-start, /ogb-ultrawork, /ogb-verify, /ogb-workflow, and /ogb-doctor on top of native plan mode, subagents, worktrees, and workflows. Content-only: no hooks, MCP servers, binaries, or runtime dependencies.",
       "category": "workflows",
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "35331b4ef8f4619b07d2e333533b3d7052784d22",
+        "sha": "059722011b099fecfa07daee5ea9a0b152cabc61",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",
-      "keywords": ["oh-my-grok-build", "ogb", "ogb-plan", "ogb-start", "ogb-verify"]
+      "keywords": ["oh-my-grok-build", "ogb", "ogb-plan", "ogb-start", "ogb-verify", "ogb-interview", "ogb-ultrawork", "ogb-doctor", "ogb-workflow"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "3314e2efde6586c10d4ad2ff15a932a9fce2642a",
+        "sha": "d41356cdbd0a8ddf01c0788626612ddaaa1ef9ba",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -193,7 +193,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "bed1100eac229e9e373637d8351416afeb837906",
+        "sha": "35331b4ef8f4619b07d2e333533b3d7052784d22",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -284,7 +284,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "d3987a662affaf07b0f987bceceabeb0edc35889",
+        "sha": "a8c07bd460c95e3a779767f1dc3d1b7291c4a702",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -207,7 +207,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/duarbdhks/oh-my-grok-build.git",
-        "sha": "fab0af9bc60afc287b73163ee386dda5b341c162",
+        "sha": "339610fdb5af4014a23978f3628b28fe747e3d39",
         "path": "plugins/oh-my-grok-build"
       },
       "homepage": "https://github.com/duarbdhks/oh-my-grok-build",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "059722011b099fecfa07daee5ea9a0b152cabc61",
+      "sha": "3314e2efde6586c10d4ad2ff15a932a9fce2642a",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "d41356cdbd0a8ddf01c0788626612ddaaa1ef9ba",
+      "sha": "dc5c6f5c87b0190666db30db53f64cb6b8aaaeb6",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "e590fd6b0b97de96d14c626e66896e3570ac3018",
+      "sha": "bed1100eac229e9e373637d8351416afeb837906",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "d3987a662affaf07b0f987bceceabeb0edc35889",
+      "sha": "a8c07bd460c95e3a779767f1dc3d1b7291c4a702",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -360,6 +360,63 @@
         ]
       }
     },
+    "oh-my-grok-build": {
+      "sha": "d4ff002fdf2aef24419e7616fb145d8546a90608",
+      "components": {
+        "agents": [
+          {
+            "name": "ogb-architect",
+            "description": "Reviews implementation plans and designs for architectural soundness, compatibility, maintainability, operational risk,…"
+          },
+          {
+            "name": "ogb-critic",
+            "description": "Enforces plan completeness, internal consistency, fair alternatives, testable acceptance criteria, verification feasibi…"
+          },
+          {
+            "name": "ogb-executor",
+            "description": "Implements one bounded engineering task in an isolated worktree, preserves unrelated changes, and reports fresh validat…"
+          },
+          {
+            "name": "ogb-explorer",
+            "description": "Performs read-only codebase investigation and returns concise evidence with file paths, symbols, commands, and uncertai…"
+          },
+          {
+            "name": "ogb-planner",
+            "description": "Creates evidence-backed implementation plans with explicit scope, alternatives, dependency waves, acceptance criteria,…"
+          },
+          {
+            "name": "ogb-verifier",
+            "description": "Independently verifies final changes against acceptance criteria by inspecting the diff and reproducing high-signal che…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ogb-doctor",
+            "description": "Diagnose oh-my-grok-build installation, skill and agent discovery, Grok native capability availability, git worktree re…"
+          },
+          {
+            "name": "ogb-plan",
+            "description": "Build a Grok-native consensus implementation plan before code changes. Use when the user asks for planning, architectur…"
+          },
+          {
+            "name": "ogb-start",
+            "description": "Execute an approved Grok Build plan with dependency-aware subagents, isolated worktrees, integration checks, and final…"
+          },
+          {
+            "name": "ogb-ultrawork",
+            "description": "Run multiple independent engineering tasks in parallel with bounded Grok subagent or workflow budgets. Use for explicit…"
+          },
+          {
+            "name": "ogb-verify",
+            "description": "Verify a feature, fix, refactor, or plan result with fresh tests, builds, direct evidence, an independent verifier, and…"
+          },
+          {
+            "name": "ogb-workflow",
+            "description": "Design, create, and smoke-validate a reusable native Grok Build Rhai workflow for bounded fan-out or staged verificatio…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
       "version": "1.3.6",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "d4ff002fdf2aef24419e7616fb145d8546a90608",
+      "sha": "e590fd6b0b97de96d14c626e66896e3570ac3018",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -367,7 +367,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "339610fdb5af4014a23978f3628b28fe747e3d39",
+      "sha": "4967ef1f159a6cabeefcf8eb953a16a59d3947bc",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "3314e2efde6586c10d4ad2ff15a932a9fce2642a",
+      "sha": "d41356cdbd0a8ddf01c0788626612ddaaa1ef9ba",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "bed1100eac229e9e373637d8351416afeb837906",
+      "sha": "35331b4ef8f4619b07d2e333533b3d7052784d22",
       "components": {
         "agents": [
           {
@@ -393,6 +393,10 @@
           {
             "name": "ogb-doctor",
             "description": "Diagnose oh-my-grok-build installation, skill and agent discovery, Grok native capability availability, git worktree re…"
+          },
+          {
+            "name": "ogb-interview",
+            "description": "Interview the user one question at a time until a vague idea becomes a decision-ready direction brief. Use when the req…"
           },
           {
             "name": "ogb-plan",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,31 +361,31 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "35331b4ef8f4619b07d2e333533b3d7052784d22",
+      "sha": "059722011b099fecfa07daee5ea9a0b152cabc61",
       "components": {
         "agents": [
           {
-            "name": "ogb-architect",
+            "name": "architect",
             "description": "Reviews implementation plans and designs for architectural soundness, compatibility, maintainability, operational risk,…"
           },
           {
-            "name": "ogb-critic",
+            "name": "critic",
             "description": "Enforces plan completeness, internal consistency, fair alternatives, testable acceptance criteria, verification feasibi…"
           },
           {
-            "name": "ogb-executor",
+            "name": "executor",
             "description": "Implements one bounded engineering task in an isolated worktree, preserves unrelated changes, and reports fresh validat…"
           },
           {
-            "name": "ogb-explorer",
+            "name": "explorer",
             "description": "Performs read-only codebase investigation and returns concise evidence with file paths, symbols, commands, and uncertai…"
           },
           {
-            "name": "ogb-planner",
+            "name": "planner",
             "description": "Creates evidence-backed implementation plans with explicit scope, alternatives, dependency waves, acceptance criteria,…"
           },
           {
-            "name": "ogb-verifier",
+            "name": "verifier",
             "description": "Independently verifies final changes against acceptance criteria by inspecting the diff and reproducing high-signal che…"
           }
         ],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -367,7 +367,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "fab0af9bc60afc287b73163ee386dda5b341c162",
+      "sha": "339610fdb5af4014a23978f3628b28fe747e3d39",
       "components": {
         "agents": [
           {
@@ -418,7 +418,7 @@
           },
           {
             "name": "ogb-ultrawork",
-            "description": "Run multiple independent engineering tasks in parallel with bounded Grok subagent or workflow budgets. Use for explicit…"
+            "description": "Run multiple independent engineering tasks in parallel with max-safe concurrency scoring, role lenses, and bounded Grok…"
           },
           {
             "name": "ogb-verify",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,7 +361,7 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "a8c07bd460c95e3a779767f1dc3d1b7291c4a702",
+      "sha": "fab0af9bc60afc287b73163ee386dda5b341c162",
       "components": {
         "agents": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,9 +361,13 @@
       }
     },
     "oh-my-grok-build": {
-      "sha": "dc5c6f5c87b0190666db30db53f64cb6b8aaaeb6",
+      "sha": "d3987a662affaf07b0f987bceceabeb0edc35889",
       "components": {
         "agents": [
+          {
+            "name": "AGENTS",
+            "description": "<!-- Parent: ../AGENTS.md -->"
+          },
           {
             "name": "architect",
             "description": "Reviews implementation plans and designs for architectural soundness, compatibility, maintainability, operational risk,…"


### PR DESCRIPTION
## What this PR does

Adds one new remote-source entry for `oh-my-grok-build`, a content-only plugin that layers a plan → execute → independently-verify discipline on top of Grok Build's native plan mode, subagents, worktrees, and workflows. It ships eight skills (`/ogb-interview`, `/ogb-plan`, `/ogb-start`, `/ogb-ultrawork`, `/ogb-graph`, `/ogb-verify`, `/ogb-workflow`, `/ogb-doctor`) and six role agents.

- Plugin name: `oh-my-grok-build`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/duarbdhks/oh-my-grok-build.git` @ `017463494068a3596aa15a470864fee57a42ed9e` (subdirectory `plugins/oh-my-grok-build`)
- Homepage: https://github.com/duarbdhks/oh-my-grok-build

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

This is an independent community plugin, not a branded product, so there is no official org behind it. See "Notes for reviewers".

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, `LICENSE` at the repo root).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

- Network endpoints this plugin calls (and why): none. The plugin is Markdown only.
- Credentials/permissions it requires (and why): none.

The plugin ships no hooks, no `.mcp.json`, no `.lsp.json`, no binaries, and no npm runtime dependencies. Its own CI asserts those absences on every commit, and its `AGENTS.md` forbids adding them without an accepted architecture decision. The only executable in the repo is a dependency-free Node validator under `scripts/`, which is never installed or run by the plugin — it is repository tooling.

`ogb-doctor` reads configuration to report readiness and is explicitly instructed never to print secret values. All skills default to read-only and never commit, push, or open PRs without an explicit user request.

## Notes for reviewers

**Why a personal-account source.** `oh-my-grok-build` is an independent community plugin in the `oh-my-*` tradition, not a branded product from a company, so there is no official org to publish it under. It claims no affiliation with xAI; `NOTICE.md` states this and the README repeats it. If sourcing from a personal account is disqualifying, I'm happy to close this and keep it as a third-party marketplace.

**Pin history.** Latest bump: `0174634` — adds `/ogb-graph`, a one-shot DAG orchestrator (dependency audit, batched fan-out, layered fan-in, targeted retry, human gate). Skill inventory is now eight. Preceding pins: `4967ef1` (open-source landing overhaul), `339610f` (ultrawork max-safe concurrency / ROLE_LENS), `fab0af9` (native workflow lifecycle UX), `a8c07bd` (upstream naming reduction), `d3987a6` (brand assets / README hero).

**Verification performed.** Every skill except `/ogb-graph` was exercised in a live Grok Build 0.2.112 session:

| Skill | Evidence |
|---|---|
| `/ogb-doctor` | Full readiness table; all skills and six agents resolved |
| `/ogb-plan` | Planner → Architect (REVISE) → Critic (APPROVE) consensus loop |
| `/ogb-ultrawork` | Scenario C: 3 parallel explorers; A: 3 independent worktree executors; D: two passing shared-database/port tests serialized with timestamp proof; E: 6 isolated worktree executors launched in one wave and integrated; F: native workflow selected instead of direct 8-agent fan-out, `validate_only` passed, and 8/8 logical agents completed with `agent_budget=8` |
| `/ogb-start` | Two worktree executors; runtime acceptance evidence; no commit or push |
| `/ogb-verify` | Independent verifier plus bundled `check-work`; zero files modified |
| `/ogb-workflow` | Minimal Rhai workflow live-ran successfully (`complete`, `agents_used=1`, `OGB_LIVE_OK`) and its missing `args.target` branch blocked before dispatch (`agents_used=0`) with an actionable pause message |
| `/ogb-interview` | Two headless runs against a throwaway Express app; explored the repo before asking, one question per turn, working tree untouched |
| `/ogb-graph` | Static only: `npm test` (248 checks) and `grok plugin validate` pass on `0174634`. Live DAG scenarios remain unverified (`docs/validation.md`). |

The chain from `/ogb-interview` through `/ogb-verify` was also run continuously inside one session, which covers the handoffs between skills rather than each skill alone.

Still unverified (recorded in `docs/validation.md`): worktree merge *conflict* handling, session-boundary plan restore messaging, saved workflow loading through `script_path`, budget-exhaustion and parallel-slot workflow branches, scheduling scenarios B/B2, a command-level non-blocking shell primitive, and live `/ogb-graph` DAG runs (layered fan-in completeness, hidden shared-file edge, targeted redo, human deploy gate, linear skip).

Static checks: `npm test` (248 checks) and `grok plugin validate` both pass on the pinned SHA. CI runs the repository validator on every push.

**Prior art.** Independent clean-room implementation for Grok Build's native extension interfaces. Workflow discipline draws on public MIT-licensed upstream inspiration named only in `NOTICE.md`. No upstream runtime, hooks, state engine, or prompts were vendored.
