### PR TITLE
Add TinyFish plugin — web search, content extraction, and browser automation

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -185,6 +185,20 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "tinyfish",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
+        "sha": "89457fba3fa44c7b2227807948628011983ab668",
+        "path": "grok"
+      },
+      "homepage": "https://www.tinyfish.ai",
+      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
+      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -614,6 +614,40 @@
         ]
       }
     },
+    "tinyfish": {
+      "sha": "89457fba3fa44c7b2227807948628011983ab668",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "tinyfish",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "tinyfish-authenticated",
+            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta…"
+          },
+          {
+            "name": "tinyfish-automation",
+            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site — clicking, filling…"
+          },
+          {
+            "name": "tinyfish-browser",
+            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow…"
+          },
+          {
+            "name": "tinyfish-research",
+            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r…"
+          },
+          {
+            "name": "tinyfish-web",
+            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97",
       "version": "0.45.1",


### PR DESCRIPTION
## What this PR does

Adds the **TinyFish** plugin to the marketplace: web search, content extraction, and goal-driven browser automation (including authenticated sites via Browser Context Profiles + Vault credentials) through TinyFish's hosted MCP server. Sign-in on first connection; no API key required.

- Plugin name: `tinyfish`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git` @ `89457fba3fa44c7b2227807948628011983ab668` (path: `grok`)
- Homepage: https://www.tinyfish.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`tinyfish-io`, matching the `tinyfish` brand).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable (`refs/heads/main` HEAD).
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (see upstream repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege — the plugin ships a single hosted MCP server (`http`) plus 5 skills, no lifecycle hooks.
- Network endpoints this plugin calls (and why): TinyFish hosted MCP server (`agent.tinyfish.ai`) for search, content fetch, and browser automation.
- Credentials/permissions it requires (and why): TinyFish account sign-in on first connection (OAuth-style); no API key. Authenticated automation optionally uses user-configured Browser Context Profiles / Vault credentials.

## Notes for reviewers

Source is published under our official `tinyfish-io` org, path-scoped to `grok/`. Ships 1 MCP server + 5 skills (`tinyfish-web`, `tinyfish-research`, `tinyfish-automation`, `tinyfish-authenticated`, `tinyfish-browser`). `keywords`/`domains` are brand-scoped to TinyFish/AgentQL and domains we own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
