### PR TITLE
feat: add Octen Grok Build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
     },
     {
+      "name": "octen",
+      "description": "Live web and news search, broad multi-angle search, clean URL extraction, and Beta image/video search via Octen MCP for Grok Build.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Octen-Team/octen-grok-plugin.git",
+        "sha": "f707f44c0f011392ea6e563b8c9a150289525367"
+      },
+      "homepage": "https://octen.ai",
+      "keywords": ["octen", "octen search", "octen ai"],
+      "domains": ["octen.ai", "www.octen.ai", "docs.octen.ai"]
+    },
+    {
       "name": "railway",
       "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -366,6 +366,24 @@
         ]
       }
     },
+    "octen": {
+      "sha": "f707f44c0f011392ea6e563b8c9a150289525367",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "octen",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "octen-web",
+            "description": "Search the live web, news, images, and Beta video results; broaden research; or extract clean content from known URLs w…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
       "version": "1.3.6",


### PR DESCRIPTION
## Summary
- Adds the official Octen Grok Build plugin from the Octen-Team/octen-grok-plugin repository.
- Provides live web search, news search, broad search, URL extraction, and Beta image/video search through the octen-mcp package.
- Pins the source to commit SHA f707f44c0f011392ea6e563b8c9a150289525367 and regenerates the plugin index.

## Validation
- Plugin static validation passed.
- Grok Build plugin manifest validation passed.
- Grok Build MCP doctor, in a clean temporary environment, completed a successful handshake and discovered 6 tools.
- Marketplace catalog validation passed.
- Marketplace generated-index check passed.
- Git whitespace check passed.

## Security
- Source is published from the official Octen-Team organization.
- The plugin uses one stdio MCP server, no hooks, and reads OCTEN_API_KEY only from the user's local environment.
- Image Search (Octen Design) and Video Search are Beta capabilities.