### PR TITLE
Add Octen plugin — web search, multi-query research, and content extraction

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -214,12 +214,12 @@
     },
     {
       "name": "octen",
-      "description": "Live web and news search, broad multi-angle search, and clean URL extraction via Octen MCP for Grok Build.",
+      "description": "Live web and news search, broad multi-angle search, and clean URL extraction via Octen's hosted MCP server. Connects over HTTP and authorizes with OAuth in the browser — nothing to install, no API key to paste.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Octen-Team/octen-grok-plugin.git",
-        "sha": "825363e074f6aa835368ab8358ff6be9fa050f1f"
+        "sha": "9b4196bf8e83de74aa80e97ba295ae91ab65ef39"
       },
       "homepage": "https://octen.ai",
       "keywords": ["octen", "octen search", "octen ai"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -213,6 +213,19 @@
       "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
     },
     {
+      "name": "octen",
+      "description": "Live web and news search, broad multi-angle search, clean URL extraction, and Beta image/video search via Octen MCP for Grok Build.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Octen-Team/octen-grok-plugin.git",
+        "sha": "f707f44c0f011392ea6e563b8c9a150289525367"
+      },
+      "homepage": "https://octen.ai",
+      "keywords": ["octen", "octen search", "octen ai"],
+      "domains": ["octen.ai", "www.octen.ai", "docs.octen.ai"]
+    },
+    {
       "name": "railway",
       "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -223,7 +223,7 @@
       },
       "homepage": "https://octen.ai",
       "keywords": ["octen", "octen search", "octen ai"],
-      "domains": ["octen.ai", "www.octen.ai", "docs.octen.ai"]
+      "domains": ["octen.ai", "docs.octen.ai"]
     },
     {
       "name": "railway",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -219,7 +219,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Octen-Team/octen-grok-plugin.git",
-        "sha": "f707f44c0f011392ea6e563b8c9a150289525367"
+        "sha": "f3cc948f40ddcda9c09064c5e2d8e6cba62d7a4b"
       },
       "homepage": "https://octen.ai",
       "keywords": ["octen", "octen search", "octen ai"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -214,12 +214,12 @@
     },
     {
       "name": "octen",
-      "description": "Live web and news search, broad multi-angle search, clean URL extraction, and Beta image/video search via Octen MCP for Grok Build.",
+      "description": "Live web and news search, broad multi-angle search, and clean URL extraction via Octen MCP for Grok Build.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Octen-Team/octen-grok-plugin.git",
-        "sha": "f3cc948f40ddcda9c09064c5e2d8e6cba62d7a4b"
+        "sha": "825363e074f6aa835368ab8358ff6be9fa050f1f"
       },
       "homepage": "https://octen.ai",
       "keywords": ["octen", "octen search", "octen ai"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -367,7 +367,7 @@
       }
     },
     "octen": {
-      "sha": "f3cc948f40ddcda9c09064c5e2d8e6cba62d7a4b",
+      "sha": "825363e074f6aa835368ab8358ff6be9fa050f1f",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
@@ -379,7 +379,7 @@
         "skills": [
           {
             "name": "octen-web",
-            "description": "Use Octen for web/news search, broad research, URL extraction, and Beta image (Octen Design) and video search."
+            "description": "Use Octen for web/news search, broad research, and clean URL extraction."
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -367,7 +367,7 @@
       }
     },
     "octen": {
-      "sha": "f707f44c0f011392ea6e563b8c9a150289525367",
+      "sha": "f3cc948f40ddcda9c09064c5e2d8e6cba62d7a4b",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
@@ -379,7 +379,7 @@
         "skills": [
           {
             "name": "octen-web",
-            "description": "Search the live web, news, images, and Beta video results; broaden research; or extract clean content from known URLs w…"
+            "description": "Use Octen for web/news search, broad research, URL extraction, and Beta image (Octen Design) and video search."
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,9 +43,55 @@
         ]
       }
     },
+    "base44": {
+      "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
+      "version": "1.0.0-beta.1",
+      "components": {
+        "skills": [
+          {
+            "name": "base44-cli",
+            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
+          },
+          {
+            "name": "base44-remote-dev",
+            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t…"
+          },
+          {
+            "name": "base44-sandbox",
+            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent — no local checkout and no deploy/push…"
+          },
+          {
+            "name": "base44-sdk",
+            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r…"
+          },
+          {
+            "name": "base44-troubleshooter",
+            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls…"
+          }
+        ]
+      }
+    },
+    "browser-use": {
+      "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "browser-use",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "browser-use",
+            "description": "Browser Use — direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
-      "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c",
-      "version": "1.6.0",
+      "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
+      "version": "1.8.0",
       "components": {
         "mcpServers": [
           {
@@ -178,8 +224,8 @@
       }
     },
     "figma": {
-      "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15",
-      "version": "2.2.81",
+      "sha": "ae7e5e5f80da20f1dd7445e0c6ae5ac58a5b0bce",
+      "version": "2.2.107",
       "components": {
         "mcpServers": [
           {
@@ -213,8 +259,16 @@
             "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable…"
           },
           {
+            "name": "figma-generative-plugins",
+            "description": "**MANDATORY prerequisite** — load this skill before calling `create_generative_plugin` or `update_generative_plugin`. U…"
+          },
+          {
             "name": "figma-implement-motion",
             "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f…"
+          },
+          {
+            "name": "figma-shaders",
+            "description": "**MANDATORY prerequisite** — load this skill before calling `create_shader` or `update_shader`. Use when the user asks…"
           },
           {
             "name": "figma-swiftui",
@@ -240,8 +294,8 @@
       }
     },
     "firecrawl": {
-      "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
-      "version": "1.1.0",
+      "sha": "7100b62d09a40673fe1688175431b1baff7ed262",
+      "version": "1.2.0",
       "components": {
         "commands": [
           {
@@ -267,6 +321,10 @@
           {
             "name": "firecrawl-crawl",
             "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac…"
+          },
+          {
+            "name": "firecrawl-developer-search",
+            "description": "Search an index built for coding agents — GitHub issues, merged pull requests, repository READMEs, and curated document…"
           },
           {
             "name": "firecrawl-download",
@@ -300,8 +358,8 @@
       }
     },
     "mongodb": {
-      "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
-      "version": "1.1.0",
+      "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
+      "version": "1.2.1",
       "components": {
         "mcpServers": [
           {
@@ -321,6 +379,44 @@
           {
             "name": "mongodb-mcp-setup",
             "description": "Guide users through configuring key MongoDB MCP server options. Use this skill when a user has the MongoDB MCP server i…"
+          },
+          {
+            "name": "mongodb-natural-language-querying",
+            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
+          },
+          {
+            "name": "mongodb-query-optimizer",
+            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
+          },
+          {
+            "name": "mongodb-schema-design",
+            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
+          },
+          {
+            "name": "mongodb-search-and-ai",
+            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
+          }
+        ]
+      }
+    },
+    "mongodb-atlas": {
+      "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
+      "version": "1.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mongodb-atlas",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mongodb-atlas-stream-processing",
+            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
+          },
+          {
+            "name": "mongodb-connection",
+            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
           },
           {
             "name": "mongodb-natural-language-querying",
@@ -366,14 +462,88 @@
         ]
       }
     },
+    "netlify": {
+      "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c",
+      "version": "1.3.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "netlify",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "netlify-access-control",
+            "description": "Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call \"…"
+          },
+          {
+            "name": "netlify-agent-runner",
+            "description": "Run AI agent tasks remotely on Netlify using Claude, Codex, or Gemini. Use when the user wants to run an AI agent on th…"
+          },
+          {
+            "name": "netlify-ai-gateway",
+            "description": "Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing pr…"
+          },
+          {
+            "name": "netlify-blobs",
+            "description": "Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/val…"
+          },
+          {
+            "name": "netlify-caching",
+            "description": "Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add cachi…"
+          },
+          {
+            "name": "netlify-config",
+            "description": "Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy cont…"
+          },
+          {
+            "name": "netlify-database",
+            "description": "Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing sche…"
+          },
+          {
+            "name": "netlify-deploy",
+            "description": "Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons,…"
+          },
+          {
+            "name": "netlify-edge-functions",
+            "description": "Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use wh…"
+          },
+          {
+            "name": "netlify-forms",
+            "description": "Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam,…"
+          },
+          {
+            "name": "netlify-frameworks",
+            "description": "Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and…"
+          },
+          {
+            "name": "netlify-functions",
+            "description": "Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API…"
+          },
+          {
+            "name": "netlify-identity",
+            "description": "Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social log…"
+          },
+          {
+            "name": "netlify-image-cdn",
+            "description": "Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use…"
+          },
+          {
+            "name": "netlify-mcp-servers",
+            "description": "Build, deploy, and secure Model Context Protocol (MCP) servers on Netlify. Use whenever the task involves creating an M…"
+          }
+        ]
+      }
+    },
     "octen": {
-      "sha": "825363e074f6aa835368ab8358ff6be9fa050f1f",
+      "sha": "9b4196bf8e83de74aa80e97ba295ae91ab65ef39",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
             "name": "octen",
-            "description": "stdio"
+            "description": "http"
           }
         ],
         "skills": [
@@ -384,9 +554,218 @@
         ]
       }
     },
+    "pstack": {
+      "sha": "93b00b89ef425a9c1bac0d0b317dfc49c930ac99",
+      "components": {
+        "agents": [
+          {
+            "name": "Comment Sicko",
+            "description": "A deranged comment-hater that savors deletion and condemns workaround code."
+          },
+          {
+            "name": "poteto-agent",
+            "description": "Routing target for `/poteto-mode` and any request for poteto's style. Resume an existing `poteto-agent` for the convers…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "Make Bot UI",
+            "description": "Use when building a custom UI (page, dashboard, buttons) that should wake a Grok Bot over a webhook, when the user must…"
+          },
+          {
+            "name": "Poteto Mode",
+            "description": "poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified…"
+          },
+          {
+            "name": "architect",
+            "description": "Sketch types, signatures, and module structure before code, then stay in the loop while implementation fills in. Use fo…"
+          },
+          {
+            "name": "arena",
+            "description": "Spawn N parallel candidates at the same task, pick a base, graft the strongest parts of the losers into it. Use for /ar…"
+          },
+          {
+            "name": "automate-me",
+            "description": "Use for \\\"automate me\\\", \\\"create/update/refresh my -mode skill\\\", \\\"turn/capture my preferences or working style into…"
+          },
+          {
+            "name": "blast-radius",
+            "description": "Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe becaus…"
+          },
+          {
+            "name": "bro",
+            "description": "Restate the last message in plain human language, with no jargon."
+          },
+          {
+            "name": "create-verification-skill",
+            "description": "Generate a project-local verification skill that drives your app the way a user does — any language, framework, or plat…"
+          },
+          {
+            "name": "figure-it-out",
+            "description": "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a hu…"
+          },
+          {
+            "name": "how",
+            "description": "Use for \\\"how does X work\\\", code walkthroughs before changing something, and placement / ownership / layering question…"
+          },
+          {
+            "name": "interrogate",
+            "description": "Use for \\\"interrogate\\\", \\\"adversarial review\\\", \\\"multi-model review\\\", \\\"challenge this\\\", \\\"stress test this code\\\",…"
+          },
+          {
+            "name": "maintain-verification-skill",
+            "description": "Periodic pass that keeps a project's verification skill and feature map honest: parallel source readers per feature, on…"
+          },
+          {
+            "name": "no-comments",
+            "description": "Spawn Comment Sicko, fix accepted findings, and offer encodings for claimed constraints."
+          },
+          {
+            "name": "principle-boundary-discipline",
+            "description": "Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, conf…"
+          },
+          {
+            "name": "principle-build-the-lever",
+            "description": "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or…"
+          },
+          {
+            "name": "principle-encode-lessons-in-structure",
+            "description": "Apply when you catch yourself writing the same instruction a second time, or notice a recurring correction. Encode the…"
+          },
+          {
+            "name": "principle-exhaust-the-design-space",
+            "description": "Apply when facing a novel UI interaction or architectural decision with no precedent in the codebase. Build 2-3 competi…"
+          },
+          {
+            "name": "principle-experience-first",
+            "description": "Apply when product, UX, or feature-scope tradeoffs come up. Choose user delight over implementation convenience; ship f…"
+          },
+          {
+            "name": "principle-fix-root-causes",
+            "description": "Apply when debugging. Trace each symptom to its root cause and fix it there; reproduce first, ask why until you reach i…"
+          },
+          {
+            "name": "principle-foundational-thinking",
+            "description": "Apply before writing logic: choosing core types and data structures, sequencing scaffold-vs-feature work, asking what c…"
+          },
+          {
+            "name": "principle-guard-the-context-window",
+            "description": "Apply when context is filling up: large outputs, long files, repeated reads, fan-out planning. Route bulk to subagents;…"
+          },
+          {
+            "name": "principle-laziness-protocol",
+            "description": "Apply when refactoring, evaluating diff size, or tempted to add abstractions, layers, or signal threading. Bias toward…"
+          },
+          {
+            "name": "principle-make-operations-idempotent",
+            "description": "Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Conve…"
+          },
+          {
+            "name": "principle-migrate-callers-then-delete-legacy-apis",
+            "description": "Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the…"
+          },
+          {
+            "name": "principle-minimize-reader-load",
+            "description": "Apply when reviewing or shaping code that's hard to trace. Count layers between question and answer, and hidden state i…"
+          },
+          {
+            "name": "principle-model-the-domain",
+            "description": "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the d…"
+          },
+          {
+            "name": "principle-never-block-on-the-human",
+            "description": "Apply when tempted to ask 'should I do X?' on reversible work. Proceed, present the result, let the human course-correc…"
+          },
+          {
+            "name": "principle-outcome-oriented-execution",
+            "description": "Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't…"
+          },
+          {
+            "name": "principle-prove-it-works",
+            "description": "Apply after completing a task, before declaring done. Verify against the real artifact (run the feature, read the actua…"
+          },
+          {
+            "name": "principle-redesign-from-first-principles",
+            "description": "Apply when integrating a new requirement into an existing design. Redesign as if the requirement had been a foundationa…"
+          },
+          {
+            "name": "principle-separate-before-serializing-shared-state",
+            "description": "Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; s…"
+          },
+          {
+            "name": "principle-sequence-verifiable-units",
+            "description": "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work i…"
+          },
+          {
+            "name": "principle-subtract-before-you-add",
+            "description": "Apply when sequencing an addition, refactor, or rewrite. Remove dead weight, redundant validators, and stub references…"
+          },
+          {
+            "name": "principle-type-system-discipline",
+            "description": "Apply when designing types, reviewing a function signature, or writing code in any statically-typed language. Make ille…"
+          },
+          {
+            "name": "recall",
+            "description": "Reconstruct your recent working context from your own chat history, live state, and the shared record (user reports, pr…"
+          },
+          {
+            "name": "reflect",
+            "description": "Spawn three parallel review subagents over the active transcript, surface learnings, and route each to a concrete edit…"
+          },
+          {
+            "name": "setup-pstack",
+            "description": "Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overr…"
+          },
+          {
+            "name": "show-me-your-work",
+            "description": "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, e…"
+          },
+          {
+            "name": "swarm",
+            "description": "Fan out N parallel workers, drain them, and return one report. Use for /swarm, 'swarm this', or parallel coverage, race…"
+          },
+          {
+            "name": "tdd",
+            "description": "Use only when the user explicitly asks for TDD, a failing test, or a regression test, OR when the bug has an obvious ch…"
+          },
+          {
+            "name": "teach",
+            "description": "Explain a body of work plainly so a person actually understands it. Runs the `how` and `why` skills and weaves what the…"
+          },
+          {
+            "name": "technical-writing",
+            "description": "Layered technical-writing standard: Diátaxis structure, Google developer style sentences, STE instruction rules, Global…"
+          },
+          {
+            "name": "typescript-best-practices",
+            "description": "TypeScript best practices. Use when reading or editing any .ts or .tsx file."
+          },
+          {
+            "name": "unslop",
+            "description": "Cut AI tells from any writing. Must always apply."
+          },
+          {
+            "name": "why",
+            "description": "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thres…"
+          }
+        ]
+      }
+    },
+    "quo": {
+      "sha": "04abd6ef9cd98ffba2105bb7437c13623c26a675",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "quo",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "railway": {
-      "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
-      "version": "1.3.6",
+      "sha": "950acebcef3445f3915ea0709876c3ba9c237a7f",
+      "version": "1.4.0",
       "components": {
         "hooks": [
           {
@@ -403,14 +782,14 @@
         "skills": [
           {
             "name": "use-railway",
-            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
+            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services, datab…"
           }
         ]
       }
     },
     "sentry": {
-      "sha": "f6b4882489b34b5dce8f21648286a570d56110da",
-      "version": "1.2.0",
+      "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
+      "version": "1.4.0",
       "components": {
         "mcpServers": [
           {
@@ -428,8 +807,8 @@
             "description": "Debug and fix a Sentry issue — find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, lo…"
           },
           {
-            "name": "sentry-feature-setup",
-            "description": "Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry…"
+            "name": "sentry-fix-stack-traces",
+            "description": "Make Sentry stack traces readable — upload source maps for JavaScript/TypeScript, or debug files for native and mobile…"
           },
           {
             "name": "sentry-get-started",
@@ -444,27 +823,19 @@
             "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us…"
           },
           {
-            "name": "sentry-sdk-upgrade",
-            "description": "Upgrade the Sentry JavaScript SDK across major versions. Use when asked to upgrade Sentry, migrate to a newer version,…"
-          },
-          {
-            "name": "sentry-setup-ai-monitoring",
-            "description": "Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversati…"
+            "name": "sentry-setup-releases",
+            "description": "Set up Sentry releases and deploy tracking — tag events with a version and environment, create the release in CI with i…"
           },
           {
             "name": "sentry-snapshots-cocoa",
             "description": "Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to \"setup SnapshotPreviews\", \"setup Apple snapshot…"
-          },
-          {
-            "name": "sentry-workflow",
-            "description": "Keep Sentry SDKs up to date. Use when asked to upgrade the Sentry SDK across major versions, migrate SDK versions, or f…"
           }
         ]
       }
     },
     "stripe": {
-      "sha": "84c364c683c58ba8dfbc003d812e6a35f4c97b47",
-      "version": "0.3.1",
+      "sha": "68382523846ea5bfad75ba1ef58dc5db031d0a5a",
+      "version": "0.6.4",
       "components": {
         "agents": [
           {
@@ -494,12 +865,20 @@
             "description": "Use this skill when the user asks about Stripe Connect configuration, charge patterns, Dashboard access, or how to get…"
           },
           {
+            "name": "connect-required-verification-information",
+            "description": "Use this skill when the user asks what information a Stripe Connect connected account must provide for verification, on…"
+          },
+          {
+            "name": "stripe-apps",
+            "description": "Use when building, modifying, or reviewing a Stripe App — or when the user describes something that implies one (e.g. \"…"
+          },
+          {
             "name": "stripe-best-practices",
             "description": "Guides Stripe integration decisions across API selection (Checkout Sessions vs PaymentIntents), Connect platform setup…"
           },
           {
             "name": "stripe-directory",
-            "description": "Use when the user wants to find businesses, software, service providers, or partners for a specific industry, workflow,…"
+            "description": "Identifies external providers, merchants, nonprofits, platforms, APIs, and software services, and resolves the document…"
           },
           {
             "name": "stripe-docs",
@@ -517,8 +896,8 @@
       }
     },
     "superpowers": {
-      "sha": "3dcbd5c4b48e02263fbf4a3c01e3fe4f81d584d9",
-      "version": "6.2.0",
+      "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
+      "version": "6.3.0",
       "components": {
         "hooks": [
           {
@@ -632,9 +1011,43 @@
         ]
       }
     },
+    "tinyfish": {
+      "sha": "89457fba3fa44c7b2227807948628011983ab668",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "tinyfish",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "tinyfish-authenticated",
+            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta…"
+          },
+          {
+            "name": "tinyfish-automation",
+            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site — clicking, filling…"
+          },
+          {
+            "name": "tinyfish-browser",
+            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow…"
+          },
+          {
+            "name": "tinyfish-research",
+            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r…"
+          },
+          {
+            "name": "tinyfish-web",
+            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
+          }
+        ]
+      }
+    },
     "vercel": {
-      "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97",
-      "version": "0.45.1",
+      "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2",
+      "version": "0.48.2",
       "components": {
         "agents": [
           {
@@ -689,8 +1102,12 @@
         ],
         "skills": [
           {
+            "name": "access-protected-vercel-deployment",
+            "description": "Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection. Use when curl, ag…"
+          },
+          {
             "name": "ai-gateway",
-            "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu…"
+            "description": "Vercel AI Gateway guidance for setup, model discovery, authentication, routing, fallbacks, BYOK, budgets, spend reporti…"
           },
           {
             "name": "ai-sdk",
@@ -705,12 +1122,20 @@
             "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ…"
           },
           {
+            "name": "build-agents",
+            "description": "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or imp…"
+          },
+          {
             "name": "cdn-caching",
             "description": "Debug Vercel CDN caching — cache hit rate, stale content, revalidation behavior, ISR + PPR, per-request cache reasons (…"
           },
           {
             "name": "chat-sdk",
             "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots — Slack, Telegram, Microsoft Teams, Discord…"
+          },
+          {
+            "name": "create-a-backend",
+            "description": "Backend architecture guidance. Use when planning, building, or migrating an API or backend; choosing between Functions,…"
           },
           {
             "name": "deployments-cicd",
@@ -722,7 +1147,11 @@
           },
           {
             "name": "eve",
-            "description": "Build durable AI agents and agent-powered applications with the eve framework. Use when creating, editing, or debugging…"
+            "description": "eve framework guidance for durable AI agents and agent-powered applications. Use when creating, editing, or debugging a…"
+          },
+          {
+            "name": "flags-sdk",
+            "description": "Flags SDK and Vercel Flags expert guidance. Use when declaring feature flags with flag(), wiring provider adapters (Ver…"
           },
           {
             "name": "knowledge-update",
@@ -797,8 +1226,12 @@
             "description": "Vercel Sandbox guidance — ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge…"
           },
           {
+            "name": "vercel-services",
+            "description": "Configure and troubleshoot Vercel Services for multiple frontends and backends in one project. Use when composing a pol…"
+          },
+          {
             "name": "vercel-storage",
-            "description": "Vercel storage expert guidance — Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch…"
+            "description": "Vercel storage expert guidance — Blob, Global Config (formerly Edge Config), and Marketplace storage (Neon Postgres, Up…"
           },
           {
             "name": "verification",
@@ -806,7 +1239,61 @@
           },
           {
             "name": "workflow",
-            "description": "Vercel Workflow DevKit (WDK) expert guidance. Use when building durable workflows, long-running tasks, API routes or ag…"
+            "description": "Vercel Workflow SDK expert guidance. Use when building durable workflows, long-running tasks, API routes or agents that…"
+          }
+        ]
+      }
+    },
+    "wix": {
+      "sha": "572357b791a91a5138c050e08eb718b150be21cb",
+      "version": "1.18.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wix-mcp",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "replatform",
+            "description": "Routes RePlatform source-to-Wix migrations to the next workflow step by inspecting migration project artifacts. Use whe…"
+          },
+          {
+            "name": "wix-app",
+            "description": "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Edito…"
+          },
+          {
+            "name": "wix-auth",
+            "description": "Authenticate with Wix to obtain an access token for calling Wix APIs. Use when an agent needs a valid Wix access token…"
+          },
+          {
+            "name": "wix-base44-connector",
+            "description": "Build on and manage the connected Wix site from a Base44 app: discover and call any Wix API (endpoints, request/respons…"
+          },
+          {
+            "name": "wix-design-system",
+            "description": "Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking prop…"
+          },
+          {
+            "name": "wix-docs",
+            "description": "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, o…"
+          },
+          {
+            "name": "wix-headless",
+            "description": "Connect Wix business services (Stores, Bookings, CMS, Blog, Events, Forms, and more) to a Wix Headless frontend — infer…"
+          },
+          {
+            "name": "wix-headless-fast",
+            "description": "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from reci…"
+          },
+          {
+            "name": "wix-manage",
+            "description": "REST recipes to configure and manage a Wix site's business solutions — stores, bookings, payments, CMS, and more. Open…"
+          },
+          {
+            "name": "wix-vibe-headless",
+            "description": "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vi…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,55 +43,9 @@
         ]
       }
     },
-    "base44": {
-      "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
-      "version": "1.0.0-beta.1",
-      "components": {
-        "skills": [
-          {
-            "name": "base44-cli",
-            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
-          },
-          {
-            "name": "base44-remote-dev",
-            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t…"
-          },
-          {
-            "name": "base44-sandbox",
-            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent — no local checkout and no deploy/push…"
-          },
-          {
-            "name": "base44-sdk",
-            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r…"
-          },
-          {
-            "name": "base44-troubleshooter",
-            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls…"
-          }
-        ]
-      }
-    },
-    "browser-use": {
-      "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
-      "version": "0.1.0",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "browser-use",
-            "description": "stdio"
-          }
-        ],
-        "skills": [
-          {
-            "name": "browser-use",
-            "description": "Browser Use — direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/…"
-          }
-        ]
-      }
-    },
     "chrome-devtools": {
-      "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
-      "version": "1.8.0",
+      "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c",
+      "version": "1.6.0",
       "components": {
         "mcpServers": [
           {
@@ -224,8 +178,8 @@
       }
     },
     "figma": {
-      "sha": "ae7e5e5f80da20f1dd7445e0c6ae5ac58a5b0bce",
-      "version": "2.2.107",
+      "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15",
+      "version": "2.2.81",
       "components": {
         "mcpServers": [
           {
@@ -259,16 +213,8 @@
             "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable…"
           },
           {
-            "name": "figma-generative-plugins",
-            "description": "**MANDATORY prerequisite** — load this skill before calling `create_generative_plugin` or `update_generative_plugin`. U…"
-          },
-          {
             "name": "figma-implement-motion",
             "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f…"
-          },
-          {
-            "name": "figma-shaders",
-            "description": "**MANDATORY prerequisite** — load this skill before calling `create_shader` or `update_shader`. Use when the user asks…"
           },
           {
             "name": "figma-swiftui",
@@ -294,8 +240,8 @@
       }
     },
     "firecrawl": {
-      "sha": "7100b62d09a40673fe1688175431b1baff7ed262",
-      "version": "1.2.0",
+      "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
+      "version": "1.1.0",
       "components": {
         "commands": [
           {
@@ -321,10 +267,6 @@
           {
             "name": "firecrawl-crawl",
             "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac…"
-          },
-          {
-            "name": "firecrawl-developer-search",
-            "description": "Search an index built for coding agents — GitHub issues, merged pull requests, repository READMEs, and curated document…"
           },
           {
             "name": "firecrawl-download",
@@ -358,8 +300,8 @@
       }
     },
     "mongodb": {
-      "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
-      "version": "1.2.1",
+      "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
+      "version": "1.1.0",
       "components": {
         "mcpServers": [
           {
@@ -379,44 +321,6 @@
           {
             "name": "mongodb-mcp-setup",
             "description": "Guide users through configuring key MongoDB MCP server options. Use this skill when a user has the MongoDB MCP server i…"
-          },
-          {
-            "name": "mongodb-natural-language-querying",
-            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
-          },
-          {
-            "name": "mongodb-query-optimizer",
-            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
-          },
-          {
-            "name": "mongodb-schema-design",
-            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
-          },
-          {
-            "name": "mongodb-search-and-ai",
-            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
-          }
-        ]
-      }
-    },
-    "mongodb-atlas": {
-      "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
-      "version": "1.2.1",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "mongodb-atlas",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "mongodb-atlas-stream-processing",
-            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
-          },
-          {
-            "name": "mongodb-connection",
-            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
           },
           {
             "name": "mongodb-natural-language-querying",
@@ -462,292 +366,27 @@
         ]
       }
     },
-    "netlify": {
-      "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c",
-      "version": "1.3.0",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "netlify",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "netlify-access-control",
-            "description": "Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call \"…"
-          },
-          {
-            "name": "netlify-agent-runner",
-            "description": "Run AI agent tasks remotely on Netlify using Claude, Codex, or Gemini. Use when the user wants to run an AI agent on th…"
-          },
-          {
-            "name": "netlify-ai-gateway",
-            "description": "Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing pr…"
-          },
-          {
-            "name": "netlify-blobs",
-            "description": "Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/val…"
-          },
-          {
-            "name": "netlify-caching",
-            "description": "Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add cachi…"
-          },
-          {
-            "name": "netlify-config",
-            "description": "Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy cont…"
-          },
-          {
-            "name": "netlify-database",
-            "description": "Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing sche…"
-          },
-          {
-            "name": "netlify-deploy",
-            "description": "Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons,…"
-          },
-          {
-            "name": "netlify-edge-functions",
-            "description": "Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use wh…"
-          },
-          {
-            "name": "netlify-forms",
-            "description": "Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam,…"
-          },
-          {
-            "name": "netlify-frameworks",
-            "description": "Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and…"
-          },
-          {
-            "name": "netlify-functions",
-            "description": "Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API…"
-          },
-          {
-            "name": "netlify-identity",
-            "description": "Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social log…"
-          },
-          {
-            "name": "netlify-image-cdn",
-            "description": "Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use…"
-          },
-          {
-            "name": "netlify-mcp-servers",
-            "description": "Build, deploy, and secure Model Context Protocol (MCP) servers on Netlify. Use whenever the task involves creating an M…"
-          }
-        ]
-      }
-    },
-    "pstack": {
-      "sha": "93b00b89ef425a9c1bac0d0b317dfc49c930ac99",
-      "components": {
-        "agents": [
-          {
-            "name": "Comment Sicko",
-            "description": "A deranged comment-hater that savors deletion and condemns workaround code."
-          },
-          {
-            "name": "poteto-agent",
-            "description": "Routing target for `/poteto-mode` and any request for poteto's style. Resume an existing `poteto-agent` for the convers…"
-          }
-        ],
-        "skills": [
-          {
-            "name": "Make Bot UI",
-            "description": "Use when building a custom UI (page, dashboard, buttons) that should wake a Grok Bot over a webhook, when the user must…"
-          },
-          {
-            "name": "Poteto Mode",
-            "description": "poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified…"
-          },
-          {
-            "name": "architect",
-            "description": "Sketch types, signatures, and module structure before code, then stay in the loop while implementation fills in. Use fo…"
-          },
-          {
-            "name": "arena",
-            "description": "Spawn N parallel candidates at the same task, pick a base, graft the strongest parts of the losers into it. Use for /ar…"
-          },
-          {
-            "name": "automate-me",
-            "description": "Use for \\\"automate me\\\", \\\"create/update/refresh my -mode skill\\\", \\\"turn/capture my preferences or working style into…"
-          },
-          {
-            "name": "blast-radius",
-            "description": "Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe becaus…"
-          },
-          {
-            "name": "bro",
-            "description": "Restate the last message in plain human language, with no jargon."
-          },
-          {
-            "name": "create-verification-skill",
-            "description": "Generate a project-local verification skill that drives your app the way a user does — any language, framework, or plat…"
-          },
-          {
-            "name": "figure-it-out",
-            "description": "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a hu…"
-          },
-          {
-            "name": "how",
-            "description": "Use for \\\"how does X work\\\", code walkthroughs before changing something, and placement / ownership / layering question…"
-          },
-          {
-            "name": "interrogate",
-            "description": "Use for \\\"interrogate\\\", \\\"adversarial review\\\", \\\"multi-model review\\\", \\\"challenge this\\\", \\\"stress test this code\\\",…"
-          },
-          {
-            "name": "maintain-verification-skill",
-            "description": "Periodic pass that keeps a project's verification skill and feature map honest: parallel source readers per feature, on…"
-          },
-          {
-            "name": "no-comments",
-            "description": "Spawn Comment Sicko, fix accepted findings, and offer encodings for claimed constraints."
-          },
-          {
-            "name": "principle-boundary-discipline",
-            "description": "Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, conf…"
-          },
-          {
-            "name": "principle-build-the-lever",
-            "description": "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or…"
-          },
-          {
-            "name": "principle-encode-lessons-in-structure",
-            "description": "Apply when you catch yourself writing the same instruction a second time, or notice a recurring correction. Encode the…"
-          },
-          {
-            "name": "principle-exhaust-the-design-space",
-            "description": "Apply when facing a novel UI interaction or architectural decision with no precedent in the codebase. Build 2-3 competi…"
-          },
-          {
-            "name": "principle-experience-first",
-            "description": "Apply when product, UX, or feature-scope tradeoffs come up. Choose user delight over implementation convenience; ship f…"
-          },
-          {
-            "name": "principle-fix-root-causes",
-            "description": "Apply when debugging. Trace each symptom to its root cause and fix it there; reproduce first, ask why until you reach i…"
-          },
-          {
-            "name": "principle-foundational-thinking",
-            "description": "Apply before writing logic: choosing core types and data structures, sequencing scaffold-vs-feature work, asking what c…"
-          },
-          {
-            "name": "principle-guard-the-context-window",
-            "description": "Apply when context is filling up: large outputs, long files, repeated reads, fan-out planning. Route bulk to subagents;…"
-          },
-          {
-            "name": "principle-laziness-protocol",
-            "description": "Apply when refactoring, evaluating diff size, or tempted to add abstractions, layers, or signal threading. Bias toward…"
-          },
-          {
-            "name": "principle-make-operations-idempotent",
-            "description": "Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Conve…"
-          },
-          {
-            "name": "principle-migrate-callers-then-delete-legacy-apis",
-            "description": "Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the…"
-          },
-          {
-            "name": "principle-minimize-reader-load",
-            "description": "Apply when reviewing or shaping code that's hard to trace. Count layers between question and answer, and hidden state i…"
-          },
-          {
-            "name": "principle-model-the-domain",
-            "description": "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the d…"
-          },
-          {
-            "name": "principle-never-block-on-the-human",
-            "description": "Apply when tempted to ask 'should I do X?' on reversible work. Proceed, present the result, let the human course-correc…"
-          },
-          {
-            "name": "principle-outcome-oriented-execution",
-            "description": "Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't…"
-          },
-          {
-            "name": "principle-prove-it-works",
-            "description": "Apply after completing a task, before declaring done. Verify against the real artifact (run the feature, read the actua…"
-          },
-          {
-            "name": "principle-redesign-from-first-principles",
-            "description": "Apply when integrating a new requirement into an existing design. Redesign as if the requirement had been a foundationa…"
-          },
-          {
-            "name": "principle-separate-before-serializing-shared-state",
-            "description": "Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; s…"
-          },
-          {
-            "name": "principle-sequence-verifiable-units",
-            "description": "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work i…"
-          },
-          {
-            "name": "principle-subtract-before-you-add",
-            "description": "Apply when sequencing an addition, refactor, or rewrite. Remove dead weight, redundant validators, and stub references…"
-          },
-          {
-            "name": "principle-type-system-discipline",
-            "description": "Apply when designing types, reviewing a function signature, or writing code in any statically-typed language. Make ille…"
-          },
-          {
-            "name": "recall",
-            "description": "Reconstruct your recent working context from your own chat history, live state, and the shared record (user reports, pr…"
-          },
-          {
-            "name": "reflect",
-            "description": "Spawn three parallel review subagents over the active transcript, surface learnings, and route each to a concrete edit…"
-          },
-          {
-            "name": "setup-pstack",
-            "description": "Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overr…"
-          },
-          {
-            "name": "show-me-your-work",
-            "description": "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, e…"
-          },
-          {
-            "name": "swarm",
-            "description": "Fan out N parallel workers, drain them, and return one report. Use for /swarm, 'swarm this', or parallel coverage, race…"
-          },
-          {
-            "name": "tdd",
-            "description": "Use only when the user explicitly asks for TDD, a failing test, or a regression test, OR when the bug has an obvious ch…"
-          },
-          {
-            "name": "teach",
-            "description": "Explain a body of work plainly so a person actually understands it. Runs the `how` and `why` skills and weaves what the…"
-          },
-          {
-            "name": "technical-writing",
-            "description": "Layered technical-writing standard: Diátaxis structure, Google developer style sentences, STE instruction rules, Global…"
-          },
-          {
-            "name": "typescript-best-practices",
-            "description": "TypeScript best practices. Use when reading or editing any .ts or .tsx file."
-          },
-          {
-            "name": "unslop",
-            "description": "Cut AI tells from any writing. Must always apply."
-          },
-          {
-            "name": "why",
-            "description": "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thres…"
-          }
-        ]
-      }
-    },
-    "quo": {
-      "sha": "04abd6ef9cd98ffba2105bb7437c13623c26a675",
+    "octen": {
+      "sha": "f707f44c0f011392ea6e563b8c9a150289525367",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
-            "name": "quo",
-            "description": "http"
+            "name": "octen",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "octen-web",
+            "description": "Search the live web, news, images, and Beta video results; broaden research; or extract clean content from known URLs w…"
           }
         ]
       }
     },
     "railway": {
-      "sha": "950acebcef3445f3915ea0709876c3ba9c237a7f",
-      "version": "1.4.0",
+      "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
+      "version": "1.3.6",
       "components": {
         "hooks": [
           {
@@ -764,14 +403,14 @@
         "skills": [
           {
             "name": "use-railway",
-            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services, datab…"
+            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
           }
         ]
       }
     },
     "sentry": {
-      "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
-      "version": "1.4.0",
+      "sha": "f6b4882489b34b5dce8f21648286a570d56110da",
+      "version": "1.2.0",
       "components": {
         "mcpServers": [
           {
@@ -789,8 +428,8 @@
             "description": "Debug and fix a Sentry issue — find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, lo…"
           },
           {
-            "name": "sentry-fix-stack-traces",
-            "description": "Make Sentry stack traces readable — upload source maps for JavaScript/TypeScript, or debug files for native and mobile…"
+            "name": "sentry-feature-setup",
+            "description": "Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry…"
           },
           {
             "name": "sentry-get-started",
@@ -805,19 +444,27 @@
             "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us…"
           },
           {
-            "name": "sentry-setup-releases",
-            "description": "Set up Sentry releases and deploy tracking — tag events with a version and environment, create the release in CI with i…"
+            "name": "sentry-sdk-upgrade",
+            "description": "Upgrade the Sentry JavaScript SDK across major versions. Use when asked to upgrade Sentry, migrate to a newer version,…"
+          },
+          {
+            "name": "sentry-setup-ai-monitoring",
+            "description": "Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversati…"
           },
           {
             "name": "sentry-snapshots-cocoa",
             "description": "Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to \"setup SnapshotPreviews\", \"setup Apple snapshot…"
+          },
+          {
+            "name": "sentry-workflow",
+            "description": "Keep Sentry SDKs up to date. Use when asked to upgrade the Sentry SDK across major versions, migrate SDK versions, or f…"
           }
         ]
       }
     },
     "stripe": {
-      "sha": "68382523846ea5bfad75ba1ef58dc5db031d0a5a",
-      "version": "0.6.4",
+      "sha": "84c364c683c58ba8dfbc003d812e6a35f4c97b47",
+      "version": "0.3.1",
       "components": {
         "agents": [
           {
@@ -847,20 +494,12 @@
             "description": "Use this skill when the user asks about Stripe Connect configuration, charge patterns, Dashboard access, or how to get…"
           },
           {
-            "name": "connect-required-verification-information",
-            "description": "Use this skill when the user asks what information a Stripe Connect connected account must provide for verification, on…"
-          },
-          {
-            "name": "stripe-apps",
-            "description": "Use when building, modifying, or reviewing a Stripe App — or when the user describes something that implies one (e.g. \"…"
-          },
-          {
             "name": "stripe-best-practices",
             "description": "Guides Stripe integration decisions across API selection (Checkout Sessions vs PaymentIntents), Connect platform setup…"
           },
           {
             "name": "stripe-directory",
-            "description": "Identifies external providers, merchants, nonprofits, platforms, APIs, and software services, and resolves the document…"
+            "description": "Use when the user wants to find businesses, software, service providers, or partners for a specific industry, workflow,…"
           },
           {
             "name": "stripe-docs",
@@ -878,8 +517,8 @@
       }
     },
     "superpowers": {
-      "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
-      "version": "6.3.0",
+      "sha": "3dcbd5c4b48e02263fbf4a3c01e3fe4f81d584d9",
+      "version": "6.2.0",
       "components": {
         "hooks": [
           {
@@ -993,43 +632,9 @@
         ]
       }
     },
-    "tinyfish": {
-      "sha": "89457fba3fa44c7b2227807948628011983ab668",
-      "version": "1.0.0",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "tinyfish",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "tinyfish-authenticated",
-            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta…"
-          },
-          {
-            "name": "tinyfish-automation",
-            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site — clicking, filling…"
-          },
-          {
-            "name": "tinyfish-browser",
-            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow…"
-          },
-          {
-            "name": "tinyfish-research",
-            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r…"
-          },
-          {
-            "name": "tinyfish-web",
-            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
-          }
-        ]
-      }
-    },
     "vercel": {
-      "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2",
-      "version": "0.48.2",
+      "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97",
+      "version": "0.45.1",
       "components": {
         "agents": [
           {
@@ -1084,12 +689,8 @@
         ],
         "skills": [
           {
-            "name": "access-protected-vercel-deployment",
-            "description": "Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection. Use when curl, ag…"
-          },
-          {
             "name": "ai-gateway",
-            "description": "Vercel AI Gateway guidance for setup, model discovery, authentication, routing, fallbacks, BYOK, budgets, spend reporti…"
+            "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu…"
           },
           {
             "name": "ai-sdk",
@@ -1104,20 +705,12 @@
             "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ…"
           },
           {
-            "name": "build-agents",
-            "description": "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or imp…"
-          },
-          {
             "name": "cdn-caching",
             "description": "Debug Vercel CDN caching — cache hit rate, stale content, revalidation behavior, ISR + PPR, per-request cache reasons (…"
           },
           {
             "name": "chat-sdk",
             "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots — Slack, Telegram, Microsoft Teams, Discord…"
-          },
-          {
-            "name": "create-a-backend",
-            "description": "Backend architecture guidance. Use when planning, building, or migrating an API or backend; choosing between Functions,…"
           },
           {
             "name": "deployments-cicd",
@@ -1129,11 +722,7 @@
           },
           {
             "name": "eve",
-            "description": "eve framework guidance for durable AI agents and agent-powered applications. Use when creating, editing, or debugging a…"
-          },
-          {
-            "name": "flags-sdk",
-            "description": "Flags SDK and Vercel Flags expert guidance. Use when declaring feature flags with flag(), wiring provider adapters (Ver…"
+            "description": "Build durable AI agents and agent-powered applications with the eve framework. Use when creating, editing, or debugging…"
           },
           {
             "name": "knowledge-update",
@@ -1208,12 +797,8 @@
             "description": "Vercel Sandbox guidance — ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge…"
           },
           {
-            "name": "vercel-services",
-            "description": "Configure and troubleshoot Vercel Services for multiple frontends and backends in one project. Use when composing a pol…"
-          },
-          {
             "name": "vercel-storage",
-            "description": "Vercel storage expert guidance — Blob, Global Config (formerly Edge Config), and Marketplace storage (Neon Postgres, Up…"
+            "description": "Vercel storage expert guidance — Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch…"
           },
           {
             "name": "verification",
@@ -1221,61 +806,7 @@
           },
           {
             "name": "workflow",
-            "description": "Vercel Workflow SDK expert guidance. Use when building durable workflows, long-running tasks, API routes or agents that…"
-          }
-        ]
-      }
-    },
-    "wix": {
-      "sha": "572357b791a91a5138c050e08eb718b150be21cb",
-      "version": "1.18.1",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "wix-mcp",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "replatform",
-            "description": "Routes RePlatform source-to-Wix migrations to the next workflow step by inspecting migration project artifacts. Use whe…"
-          },
-          {
-            "name": "wix-app",
-            "description": "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Edito…"
-          },
-          {
-            "name": "wix-auth",
-            "description": "Authenticate with Wix to obtain an access token for calling Wix APIs. Use when an agent needs a valid Wix access token…"
-          },
-          {
-            "name": "wix-base44-connector",
-            "description": "Build on and manage the connected Wix site from a Base44 app: discover and call any Wix API (endpoints, request/respons…"
-          },
-          {
-            "name": "wix-design-system",
-            "description": "Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking prop…"
-          },
-          {
-            "name": "wix-docs",
-            "description": "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, o…"
-          },
-          {
-            "name": "wix-headless",
-            "description": "Connect Wix business services (Stores, Bookings, CMS, Blog, Events, Forms, and more) to a Wix Headless frontend — infer…"
-          },
-          {
-            "name": "wix-headless-fast",
-            "description": "Build a Wix Headless site fast by wiring SHIPPED, verified @wix/sdk code instead of authoring the integration from reci…"
-          },
-          {
-            "name": "wix-manage",
-            "description": "REST recipes to configure and manage a Wix site's business solutions — stores, bookings, payments, CMS, and more. Open…"
-          },
-          {
-            "name": "wix-vibe-headless",
-            "description": "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vi…"
+            "description": "Vercel Workflow DevKit (WDK) expert guidance. Use when building durable workflows, long-running tasks, API routes or ag…"
           }
         ]
       }


### PR DESCRIPTION
## What this PR does

Adds the official Octen plugin to the Grok Build Plugin Marketplace. Supersedes #149.

- **Plugin name:** `octen`
- **Type:** remote source
- **Source URL + pinned SHA:** `https://github.com/Octen-Team/octen-grok-plugin.git` @ `825363e074f6aa835368ab8358ff6be9fa050f1f`
- **Homepage:** https://octen.ai
- **License:** MIT

### Why another search plugin

The catalog already has good semantic-search and scraping options. Octen is here for a different
axis: **latency and retrieval width**, which is what a coding agent actually spends its budget on.

- **Fast enough to call repeatedly.** Octen serves web search at a **P50 of 62 ms** (measured on SealQA
  Hard) — inside the budget to call search several times within a single agent turn.
- **Retrieval quality is measured, not asserted.** We score it with a public, re-runnable eval harness:
  SimpleQA and FreshQA through the official graders, plus a blind, position-debiased pairwise judge that
  reports the per-competitor gaps, including where competitors beat us. Octen scores 95.2% on SimpleQA
  and 55.8% on FreshQA there; scores and per-set latency all regenerate from run artifacts:
  https://github.com/Octen-Team/search-eval
- **`broad_search` is a server-side primitive, not a client loop.** Give it the user's full question and
  Octen decomposes it into concurrent sub-queries, returning results grouped per sub-query. Every other
  search plugin in this catalog makes the agent plan the fan-out itself, which costs extra turns and
  extra tokens before a single result comes back. One `broad_search` call replaces a
  plan-then-N-searches round trip.
- **Classification on every result.** Each extracted page carries a topical `category` and a
  `page_structure` typology, so a skill can distinguish docs from forum from product page without a
  second model call.

### Tools

| Tool | What it does |
| --- | --- |
| `search` | Search the live web for focused, current information and sources. |
| `news_search` | Search recent events, announcements, and time-sensitive reporting. |
| `broad_search` | Decompose a research question into concurrent sub-queries and return broad, grouped coverage. |
| `extract` | Turn known URLs into clean, LLM-ready content with optional highlights and page labels. |

The plugin includes the `octen-web` skill, which picks the smallest tool that fits the
request and preserves returned source URLs.

### Credentials

Octen uses a **stdio** MCP server with an `OCTEN_API_KEY` read from the user's local environment.
Unlike a hosted MCP server, no request is proxied through a third party — the key and the query go
from the user's machine straight to `api.octen.ai`.

Sign up at https://octen.ai to get an API key; new accounts start with $5 in free credit.

A hosted MCP server with browser OAuth is on our roadmap.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official organization.

The plugin source is maintained at https://github.com/Octen-Team/octen-grok-plugin under the official
`Octen-Team` organization, licensed MIT. I'm an engineer at Octen.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique, kebab-case name.
- [x] Remote source pins a public, reachable, full 40-character lowercase commit SHA.
- [x] Regenerated and committed `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, clear description, and Octen-owned domains are set.
- [x] The plugin has a README and a valid plugin manifest.
- [x] License is stated as MIT.

**Catalog diff is limited to the single `octen` entry** — no formatting or unrelated changes to other
entries in `marketplace.json`, and `plugin-index.json` differs only by the regenerated `octen` block.

**Keywords are brand-scoped** so the plugin CTA doesn't fire on generic search or extract requests:

```json
["octen", "octen search", "octen ai"]
```

## Security

- [x] No `curl | bash`, postinstall hook, remote-binary download/execute, `eval`, obfuscation, or
      minified payload.
- [x] No lifecycle hooks, agents, shell-execution tools, or filesystem access.
- [x] No telemetry or undisclosed network traffic.
- [x] No reading or exfiltration of `.env` files, SSH material, tokens, or unrelated environment
      variables.
- **MCP scope:** one stdio server named `octen`, exposing exactly the four tools listed above
  (Beta `image_search`/`video_search` are disabled via `OCTEN_ENABLE_BETA_TOOLS=false`).
- **Network endpoint:** `https://api.octen.ai` — the only host the plugin contacts.
- **Credentials:** `OCTEN_API_KEY`, supplied by the user from their local environment. No key is
  embedded in the repository, the marketplace entry, or the plugin documentation.

## Validation

```
$ python3 scripts/validate-catalog.py
Catalog OK (.grok-plugin/marketplace.json)

$ python3 scripts/generate-plugin-index.py --check
Plugin index OK (.grok-plugin/plugin-index.json)

$ git ls-remote https://github.com/Octen-Team/octen-grok-plugin.git HEAD refs/heads/main
825363e074f6aa835368ab8358ff6be9fa050f1f	HEAD
825363e074f6aa835368ab8358ff6be9fa050f1f	refs/heads/main
```

## Notes for reviewers

Verified against the pinned build (`825363e`): the plugin's MCP command —
`npx -y octen-mcp@0.3.6` with `OCTEN_ENABLE_BETA_TOOLS=false` — completes the MCP `initialize`
handshake and lists exactly the four tools above; no Beta tool is exposed. Catalog and index
validators pass locally (see Validation).

To verify against this PR directly, point xAI Official at the merge ref in `~/.grok/config.toml`:

```toml
branch = "refs/pull/150/merge"
```

then refresh `/marketplaces` and confirm the `octen` MCP server and the `octen-web` skill
appear and resolve. Happy to rebase or adjust keywords and description on request.

cc @ykeremy
