### PR TITLE
feat: add apify plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "homepage": "https://github.com/stripe/ai",
       "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
       "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "apify",
+      "description": "Extract data from any website with thousands of trusted scrapers, crawlers, and automations from Apify Store. Integrate ready-made Actors to access all popular social media, video, e-commerce, search engines, maps, and travel sites. Build, debug, publish, and monetize new Actors on Apify.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/apify/apify-grok-build-plugin.git",
+        "sha": "a90e598fb28a9c0e1a30f0c649d528bd3d27f600"
+      },
+      "homepage": "https://apify.com",
+      "keywords": ["apify", "apify actors", "apify store", "apify scraper"],
+      "domains": ["apify.com", "docs.apify.com", "console.apify.com", "mcp.apify.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,46 @@
 {
   "version": 1,
   "plugins": {
+    "apify": {
+      "sha": "a90e598fb28a9c0e1a30f0c649d528bd3d27f600",
+      "version": "1.0.0",
+      "components": {
+        "agents": [
+          {
+            "name": "apify",
+            "description": "Apify agent for web scraping, automation, and Actor development. Routes user requests to the appropriate skill or MCP t…"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "apify",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "apify-actor-development",
+            "description": "Develop, debug, and deploy Apify Actors - serverless cloud programs for web scraping, automation, and data processing.…"
+          },
+          {
+            "name": "apify-actorization",
+            "description": "Convert existing projects into Apify Actors - serverless cloud programs. Actorize JavaScript/TypeScript (SDK with Actor…"
+          },
+          {
+            "name": "apify-generate-output-schema",
+            "description": "Generate output schemas (dataset_schema.json, output_schema.json, key_value_store_schema.json) for an Apify Actor by an…"
+          },
+          {
+            "name": "apify-sdk-integration",
+            "description": "Integrate Apify into an existing JavaScript/TypeScript or Python application using the apify-client package. Use when a…"
+          },
+          {
+            "name": "apify-ultimate-scraper",
+            "description": "Universal AI-powered web scraper for any platform. Scrape data from Instagram, Facebook, TikTok, YouTube, LinkedIn, X/T…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

This PR adds new Apify plugin (Apify MCP config, 5 skills and 1 agent) that allows users to extract data from any website with thousands of trusted scrapers, crawlers, and automations from Apify Store. It also allows user to  build, debug, publish, and monetize new Actors on Apify. I tested the plugin locally + through remote marketplace and it works well (MCP tested with OAuth flow).

- Plugin name: Apify
- Type: remote source
- Source URL: https://github.com/apify/apify-grok-build-plugin  a90e598fb28a9c0e1a30f0c649d528bd3d27f600 
- Homepage: https://apify.com

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls: only Apify API is used through Apify MCP
- Credentials/permissions it requires: User needs Apify account (Apify has actually usable free plan) to use run the actors. There are no special permissions required.

## Notes for reviewers

Let me know if anything is missing or incorrect, I will address it ASAP :) 
