### PR TITLE
Add browser-use plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -199,6 +199,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "browser-use",
+      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/browser-use/plugins.git",
+        "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
+        "path": "grok"
+      },
+      "homepage": "https://browser-use.com",
+      "keywords": ["browser use", "browser-use", "browser use cloud"],
+      "domains": ["browser-use.com", "cloud.browser-use.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,6 +43,24 @@
         ]
       }
     },
+    "browser-use": {
+      "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "browser-use",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "browser-use",
+            "description": "Browser Use — direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c",
       "version": "1.6.0",


### PR DESCRIPTION
## What this PR does

New plugin: **Browser Use**. It gives Grok a real browser — the user's own Chrome, with their existing
logins, or an isolated Browser Use Cloud browser — for browsing, scraping and data extraction, filling
forms, testing sites, screenshots, and automating web workflows. Ships one MCP server
(`browser_exec`, `browser_screenshot`) and one skill.

- Plugin name: `browser-use`
- Type: remote source (nothing vendored in this repo)
- Source URL + pinned SHA (remote), or vendored path (local): `https://github.com/browser-use/plugins.git` @ `4749bcbfe456e5384b98281a8a66119352197f59`, `path: grok`
- Homepage: https://browser-use.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

[Browser Use](https://browser-use.com) is the browser agent for AI
([browser-use/browser-use](https://github.com/browser-use/browser-use), MIT).
[browser-use/plugins](https://github.com/browser-use/plugins) is our official plugin repo.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The pinned commit is on `main` in a public repo. The plugin directory includes a `README.md` and
`.grok-plugin/plugin.json` (`version: 0.1.0`, MIT) even though it's a remote source.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. *(The MCP server is a
  package-registry install — `uvx browser-use@latest` — not a shell pipe or a fetched binary; same
  pattern as the accepted `chrome-devtools` entry's `npx chrome-devtools-mcp@1.6.0`. Detailed below.)*
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. *(One MCP server; no hooks, no LSP servers.)*

- Network endpoints this plugin calls (and why):

  | Endpoint | When | Why |
  |---|---|---|
  | `pypi.org` | On MCP server start, via `uvx` | Fetches the `browser-use` package |
  | `localhost` DevTools endpoint | Driving local Chrome | CDP connection to the user's browser |
  | `api.browser-use.com` | Only if the user opts into a cloud browser | Starts and stops managed cloud browsers |
  | `eu.i.posthog.com` | Anonymous usage telemetry, on by default | Product analytics — see below |
  | Sites the user asks for | During a task | The task itself |

- Credentials/permissions it requires (and why): none for driving local Chrome. Cloud browsers need a
  Browser Use API key, which the user supplies themselves via `browser-use auth login`; the CLI stores
  it outside this plugin. The plugin reads no secret it wasn't explicitly given — it does not scan
  `.env` files, SSH keys, or the environment for credentials. The one environment variable it touches
  is `$BROWSER_USE_API_KEY`, and only in a documented, user-initiated command that pipes the user's own
  key into their own CLI (`printf '%s' "$BROWSER_USE_API_KEY" | browser-use auth login --api-key-stdin`).
  Connection settings (`BU_NAME`, `BU_CDP_URL`, `BU_CDP_WS`) are also read. Nothing is transmitted
  anywhere except the endpoints above. The plugin's own contents are Markdown and JSON only — no
  scripts, binaries, or install steps.

**Telemetry.** The `browser-harness` layer under the MCP server sends anonymous,
**opt-out** usage telemetry. It is keyed to a random install
id, and payloads run through a blocklist that strips `api_key`, `content`, `cookie`, and `email` keys —
page contents, credentials, and cookies are not sent. Users can disable it by setting any of
`BH_TELEMETRY`, `BROWSER_HARNESS_TELEMETRY`, or `ANONYMIZED_TELEMETRY` to `0`/`false`/`no`/`off`. This enables us to track and fix errors as they arise.

## Notes for reviewers

**On `uvx browser-use@latest --cli-mcp`.** It's the published [`browser-use`](https://pypi.org/project/browser-use/)
package run through `uvx` — a package-registry install. One difference: that entry pins an
exact version (`@1.6.0`) where we use `@latest`, so our users always get the newest release rather than
a reviewed one. I'm happy to pin an exact or minimum version instead — say the word and I'll push a
commit upstream and bump the SHA here.

**On what the plugin can do.** Driving local Chrome uses the user's real profile, so the agent acts as
them on sites they're already signed in to. The skill tells the agent to stop for passwords, MFA, consent screens, and
ambiguous account choices. It also tells the agent not to open a browser at all when a plain HTTP
request would do, which keeps it off pages that don't need it.

**Keywords and domains** are brand-scoped (`browser use`, `browser-use`, `browser use cloud`, and our
own two domains) so the plugin CTA doesn't fire on unrelated web requests.

**Verification.** Tested end to end from a clean environment — no `browser-use` CLI on `PATH`, empty
`uv` cache, fresh `GROK_HOME`: the MCP server self-installs via `uvx`, registers in Grok Build with its
skill, and drives a real browser. `validate-catalog.py` and `generate-plugin-index.py --check` both
pass locally.