### PR TITLE
Add Tako plugin — licensed market, macro, and web-traffic data as citation-backed charts

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -199,6 +199,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "tako",
+      "description": "Live market, macro, and web-traffic data via Tako's hosted MCP server (MCP server + skills). Query licensed datasets the open web does not have — company financials and analyst estimates, CPI/GDP/policy rates, SimilarWeb site and app traffic, sports, US government spending — and get back citation-backed interactive charts plus grounded prose answers. Works with no API key on the free tier; sign in with OAuth for the full toolset.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/TakoData/tako-mcp.git",
+        "sha": "51c736210f6fbcb0ca789156b666a41a2a700729"
+      },
+      "homepage": "https://docs.tako.com/documentation/integrations/mcp-server",
+      "keywords": ["tako", "tako search", "tako mcp", "tako data"],
+      "domains": ["tako.com", "docs.tako.com", "mcp.tako.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -202,7 +202,7 @@
     },
     {
       "name": "tako",
-      "description": "Live market, macro, and web-traffic data via Tako's hosted MCP server (MCP server + skills). Query licensed datasets the open web does not have — company financials and analyst estimates, CPI/GDP/policy rates, SimilarWeb site and app traffic, sports, US government spending — and get back citation-backed interactive charts plus grounded prose answers. Works with no API key on the free tier; sign in with OAuth for the full toolset.",
+      "description": "Live market, macro, and web-traffic data via Tako's hosted MCP server (MCP server + skills). Query licensed datasets the open web does not have — company financials and analyst estimates, CPI/GDP/policy rates, SimilarWeb site and app traffic, sports, US government spending — and get back citation-backed interactive charts plus grounded prose answers. Sign in with your Tako account on first connection — OAuth in the browser, no API key to paste.",
       "category": "development",
       "source": {
         "source": "url",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -568,6 +568,32 @@
         ]
       }
     },
+    "tako": {
+      "sha": "51c736210f6fbcb0ca789156b666a41a2a700729",
+      "version": "0.15.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "tako",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "tako-financial-research",
+            "description": "Company financials and markets via Tako (sources vary by metric — S&P Global, Fiscal.ai, Visible Alpha, Xignite, and ot…"
+          },
+          {
+            "name": "tako-macroeconomics",
+            "description": "Macroeconomic and demographic indicators via Tako (sources vary — FRED, BLS, OECD, BIS, IMF, World Bank, Census). Infla…"
+          },
+          {
+            "name": "tako-web-traffic",
+            "description": "Website and app traffic via Tako (source: SimilarWeb). Monthly visits, app active users, traffic trends, and top-sites…"
+          }
+        ]
+      }
+    },
     "tavily": {
       "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds Tako as a new third-party plugin. Tako is a data-native search API: a hosted MCP server that answers questions from licensed datasets the open web doesn't carry — company financials and analyst estimates, macroeconomic indicators, SimilarWeb site/app traffic, sports, US government spending — and returns citation-backed interactive charts alongside grounded prose. The plugin bundles the hosted MCP server plus three research skills.

Auth is a browser OAuth flow on first connection — there is no API key to paste. Grok's proactive OAuth discovery (RFC 8414/9728) picks the flow up automatically from the server's well-known metadata. (The server also serves an anonymous free tier, but Grok authenticates before `initialize`, so Grok users land on their own account and limits.)

- Plugin name: `tako`
- Type: remote source (url)
- Source URL + pinned SHA: `https://github.com/TakoData/tako-mcp.git` @ `51c736210f6fbcb0ca789156b666a41a2a700729` (v0.15.1, on `main`, public)
- Homepage: https://docs.tako.com/documentation/integrations/mcp-server

Components the index picks up at that SHA:

| Component | Value |
|---|---|
| MCP server | `tako` (http) — `https://mcp.tako.com/mcp` |
| Skills | `tako-financial-research`, `tako-macroeconomics`, `tako-web-traffic` |
| Commands / agents / hooks / LSP | none |

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is `TakoData/tako-mcp`, the official Tako org, and I'm a maintainer on that repo. The brand, the source org, the homepage (`docs.tako.com`) and the MCP endpoint (`mcp.tako.com`) all resolve to the same first party.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated — MIT ([LICENSE](https://github.com/TakoData/tako-mcp/blob/main/LICENSE)).

Also verified against the real runtime (`grok` 0.2.117) by adding this branch as a local marketplace and installing from it:

```
Plugins
└ tako (user, enabled)   3 skills

MCP Servers
└ tako (http)   plugin: tako
```

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

- **Network endpoints this plugin calls (and why):** exactly one — `https://mcp.tako.com/mcp`, Tako's hosted MCP server, over streamable HTTP. That is the plugin's entire function. No other host is contacted; the plugin ships no scripts, no binaries, no hooks, and no `postinstall` step.
- **Credentials/permissions it requires (and why):** a Tako account, via browser OAuth on first connection — the server publishes OAuth protected-resource and authorization-server metadata, which Grok discovers on its own. A per-host API key is minted server-side and is revocable at https://tako.com/console/api-keys. The plugin never reads a token from the user's filesystem or environment, and writes nothing to disk beyond the plugin files themselves. Note that in non-interactive mode (`grok agent -p`) Grok fails closed on OAuth servers and skips the connection, which is expected behavior, not a plugin fault.

The three skills are plain instructional `SKILL.md` documents describing when to reach for which Tako tool. They execute nothing and contain no instructions aimed at the installing agent beyond tool selection guidance.

## Notes for reviewers

- **Why the source is the repo root rather than a `grok/` subdirectory:** `TakoData/tako-mcp` is already a valid plugin root — `.claude-plugin/plugin.json` (second in your manifest lookup order) plus `skills/`. The manifest declares its MCP server inline via `mcpServers`, which `plugin_catalog.py` reads and the runtime supports (`normalize_inline_mcp_servers`). I confirmed both paths rather than assuming: the generated index shows `mcpServers: [{name: "tako", description: "http"}]`, and a live install registers the server as shown above. Happy to restructure into a dedicated subdirectory with a `.grok-plugin/plugin.json` + `.mcp.json` if you'd prefer that shape for consistency with other entries — just say the word.
- **Keywords/domains are deliberately brand-scoped** (`tako`, `tako search`, `tako mcp`, `tako data`; `tako.com`, `docs.tako.com`, `mcp.tako.com`) so the CTA doesn't fire on generic finance or search requests.
- **Pin freshness:** the upstream repo bumps `version` in its manifest on every release via release-please, so your daily `bump-plugin-shas` job will track it without manual PRs.
- Tako is already distributed as an MCP server through the [MCP Registry](https://registry.modelcontextprotocol.io), Smithery, and as a Claude Code plugin; this is the same server, listed for Grok Build.
