### PR TITLE
Add security-control + pure hookify (Grok Build)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -302,22 +302,22 @@
     },
     {
       "name": "security-control",
-      "description": "Authorized Ubuntu 24.04 Noble security profile (10 parallel agents), ONE_PRODUCT LoRA honesty gates, and GitHub MCP for Grok Build.",
+      "description": "Authorized Ubuntu 24.04 Noble security profile (10 parallel agents) and GitHub MCP for Grok Build. Self-recon only.",
       "category": "security",
       "source": {
         "source": "url",
-        "url": "https://github.com/Jadon-Fox/orch-control-plugin.git",
-        "sha": "190a9ec4674c9f43a3dcdb752e3bd0194fad304f"
+        "url": "https://github.com/Jadon-Fox/security-control-plugin.git",
+        "sha": "f45935761ba4535825f6e6aeb11f965ff51ab02b"
       },
-      "homepage": "https://github.com/Jadon-Fox/orch-control-plugin",
+      "homepage": "https://github.com/Jadon-Fox/security-control-plugin",
       "keywords": [
         "security",
         "security-profile",
         "noble",
-        "one-product",
+        "ufw",
+        "nmap",
         "github",
-        "mcp",
-        "orch"
+        "mcp"
       ],
       "author": "Jadon Fox"
     }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -302,12 +302,12 @@
     },
     {
       "name": "orch-control",
-      "description": "ONE_PRODUCT LoRA honesty gates + security-profile agents (Ubuntu 24.04 Noble, ten parallel avenues) + GitHub MCP control for Grok Build / training_orchestrator workflows.",
+      "description": "ONE_PRODUCT LoRA honesty gates + security-profile agents + GitHub MCP for Grok Build / training_orchestrator workflows.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Jadon-Fox/orch-control-plugin.git",
-        "sha": "1d0a8b4bc9d35e5e9f163427d84b245c36efba04"
+        "sha": "2879eb11c6dcd75ec19345c4bbe958909a594ce2"
       },
       "homepage": "https://github.com/Jadon-Fox/orch-control-plugin",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -320,6 +320,23 @@
         "mcp"
       ],
       "author": "Jadon Fox"
+    },
+    {
+      "name": "hookify",
+      "description": "Easily create hooks to prevent unwanted behaviors (pure upstream Hookify). Install with --trust; add rules after install.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Jadon-Fox/hookify-plugin.git",
+        "sha": "6c3ce9ddb53ac01c6f529f288da1e814de3c94a9"
+      },
+      "homepage": "https://github.com/anthropics/claude-plugins-official/tree/main/plugins/hookify",
+      "keywords": [
+        "hooks",
+        "hookify",
+        "guardrails"
+      ],
+      "author": "Anthropic (mirror for xAI pin)"
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,23 +301,23 @@
       ]
     },
     {
-      "name": "orch-control",
-      "description": "ONE_PRODUCT LoRA honesty gates + security-profile agents + GitHub MCP for Grok Build / training_orchestrator workflows.",
-      "category": "development",
+      "name": "security-control",
+      "description": "Authorized Ubuntu 24.04 Noble security profile (10 parallel agents), ONE_PRODUCT LoRA honesty gates, and GitHub MCP for Grok Build.",
+      "category": "security",
       "source": {
         "source": "url",
         "url": "https://github.com/Jadon-Fox/orch-control-plugin.git",
-        "sha": "2879eb11c6dcd75ec19345c4bbe958909a594ce2"
+        "sha": "190a9ec4674c9f43a3dcdb752e3bd0194fad304f"
       },
       "homepage": "https://github.com/Jadon-Fox/orch-control-plugin",
       "keywords": [
-        "orch",
-        "lora",
-        "one-product",
+        "security",
         "security-profile",
+        "noble",
+        "one-product",
         "github",
         "mcp",
-        "noble"
+        "orch"
       ],
       "author": "Jadon Fox"
     }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "4f867228f69a48c4781ccf1bc5d2741af435cc97"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "f6b4882489b34b5dce8f21648286a570d56110da"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "77e1d3f9616d5b32671da0b9ea094f4929c14a9c"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "3dcbd5c4b48e02263fbf4a3c01e3fe4f81d584d9"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "mongodb",
@@ -78,8 +100,17 @@
         "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb",
+        "mongo",
+        "mongosh",
+        "mongodb atlas",
+        "mongoose"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -91,8 +122,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -103,12 +139,21 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -116,8 +161,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -129,8 +180,14 @@
         "sha": "07316dd2920d61303ca0e52812b31f5f341e7b15"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -142,8 +199,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -155,8 +220,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -169,8 +243,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -183,12 +264,22 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -197,8 +288,38 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
+    },
+    {
+      "name": "orch-control",
+      "description": "ONE_PRODUCT LoRA honesty gates + security-profile agents (Ubuntu 24.04 Noble, ten parallel avenues) + GitHub MCP control for Grok Build / training_orchestrator workflows.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Jadon-Fox/orch-control-plugin.git",
+        "sha": "1d0a8b4bc9d35e5e9f163427d84b245c36efba04"
+      },
+      "homepage": "https://github.com/Jadon-Fox/orch-control-plugin",
+      "keywords": [
+        "orch",
+        "lora",
+        "one-product",
+        "security-profile",
+        "github",
+        "mcp",
+        "noble"
+      ],
+      "author": "Jadon Fox"
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -366,6 +366,37 @@
         ]
       }
     },
+    "orch-control": {
+      "sha": "1d0a8b4bc9d35e5e9f163427d84b245c36efba04",
+      "components": {
+        "commands": [
+          {
+            "name": "security-profile",
+            "description": "Run the ten-agent security profile skill guidance"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "github",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "github-control",
+            "description": "GitHub control for Security Command Center and orch second-look reviews: PR/body templates, honesty-gate comments, tip…"
+          },
+          {
+            "name": "one-product-lock",
+            "description": "ONE_PRODUCT combined A+B LoRA lock for training_orchestrator product path: HARD_BLOCK product_lora without B, board one…"
+          },
+          {
+            "name": "security-profile",
+            "description": "Hyper-advanced security profile for Grok Build apps and Ubuntu 24.04 Noble hosts: breadth-and-depth assessment, network…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
       "version": "1.3.6",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -299,6 +299,55 @@
         ]
       }
     },
+    "hookify": {
+      "sha": "6c3ce9ddb53ac01c6f529f288da1e814de3c94a9",
+      "components": {
+        "agents": [
+          {
+            "name": "conversation-analyzer",
+            "description": "Use this agent when analyzing conversation transcripts to find behaviors worth preventing with hooks. Typical triggers…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "configure",
+            "description": "Enable or disable hookify rules interactively"
+          },
+          {
+            "name": "help",
+            "description": "Get help with the hookify plugin"
+          },
+          {
+            "name": "hookify",
+            "description": "Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions"
+          },
+          {
+            "name": "list",
+            "description": "List all configured hookify rules"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse"
+          },
+          {
+            "name": "PreToolUse"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "writing-hookify-rules",
+            "description": "This skill should be used when the user asks to \"create a hookify rule\", \"write a hook rule\", \"configure hookify\", \"add…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -366,8 +366,32 @@
         ]
       }
     },
-    "orch-control": {
-      "sha": "2879eb11c6dcd75ec19345c4bbe958909a594ce2",
+    "railway": {
+      "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
+      "version": "1.3.6",
+      "components": {
+        "hooks": [
+          {
+            "name": "PreToolUse",
+            "description": "Bash"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "railway",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "use-railway",
+            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
+          }
+        ]
+      }
+    },
+    "security-control": {
+      "sha": "190a9ec4674c9f43a3dcdb752e3bd0194fad304f",
       "components": {
         "commands": [
           {
@@ -393,30 +417,6 @@
           {
             "name": "security-profile",
             "description": "Hyper-advanced security profile for Grok Build apps and Ubuntu 24.04 Noble hosts: breadth-and-depth assessment, network…"
-          }
-        ]
-      }
-    },
-    "railway": {
-      "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
-      "version": "1.3.6",
-      "components": {
-        "hooks": [
-          {
-            "name": "PreToolUse",
-            "description": "Bash"
-          }
-        ],
-        "mcpServers": [
-          {
-            "name": "railway",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "use-railway",
-            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -391,7 +391,7 @@
       }
     },
     "security-control": {
-      "sha": "190a9ec4674c9f43a3dcdb752e3bd0194fad304f",
+      "sha": "f45935761ba4535825f6e6aeb11f965ff51ab02b",
       "components": {
         "commands": [
           {
@@ -408,11 +408,7 @@
         "skills": [
           {
             "name": "github-control",
-            "description": "GitHub control for Security Command Center and orch second-look reviews: PR/body templates, honesty-gate comments, tip…"
-          },
-          {
-            "name": "one-product-lock",
-            "description": "ONE_PRODUCT combined A+B LoRA lock for training_orchestrator product path: HARD_BLOCK product_lora without B, board one…"
+            "description": "GitHub control for Security Command Center and security review PRs: PR/body templates, tip SHA packaging. Uses GitHub M…"
           },
           {
             "name": "security-profile",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -367,7 +367,7 @@
       }
     },
     "orch-control": {
-      "sha": "1d0a8b4bc9d35e5e9f163427d84b245c36efba04",
+      "sha": "2879eb11c6dcd75ec19345c4bbe958909a594ce2",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
## Summary

### security-control
- https://github.com/Jadon-Fox/security-control-plugin.git
- Pin `f45935761ba4535825f6e6aeb11f965ff51ab02b`
- Skills: security-profile, github-control only (no orch/ONE_PRODUCT)

### hookify (pure upstream)
- Mirror of `anthropics/claude-plugins-official` → `plugins/hookify`
- https://github.com/Jadon-Fox/hookify-plugin.git
- Pin `6c3ce9ddb53ac01c6f529f288da1e814de3c94a9`
- **No host absolute-load bake-in** — stock Hookify; add rules after install
- Requires `--trust` so hooks run

## Test plan
- [ ] validate-catalog
- [ ] `grok plugin install hookify --trust`
- [ ] create rule via `/hookify` or `.claude/hookify.*.local.md`