### PR TITLE
Add openviking plugin (OpenViking MCP for Grok CLI)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -199,6 +199,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "openviking",
+      "description": "OpenViking context database MCP for Grok CLI. Long-term memory, resources, and semantic search via a local stdio proxy that reads ~/.openviking/ovcli.conf (or OPENVIKING_* env vars). Requires a reachable OpenViking server and Node.js 18+.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/shpaw415/openviking-grok-plugin.git",
+        "sha": "90343ff1cb885d303379914f179283c2940c9acb"
+      },
+      "homepage": "https://github.com/shpaw415/openviking-grok-plugin",
+      "keywords": ["openviking", "open viking", "viking memory", "openviking mcp"],
+      "domains": ["openviking.ai", "www.openviking.ai", "docs.openviking.ai", "blog.openviking.ai", "github.com/volcengine/OpenViking"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -366,6 +366,30 @@
         ]
       }
     },
+    "openviking": {
+      "sha": "90343ff1cb885d303379914f179283c2940c9acb",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "ov",
+            "description": "Show OpenViking MCP plugin status — server health, identity, and config source"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "openviking",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "openviking",
+            "description": "Use OpenViking long-term memory and context database via the openviking MCP tools. Trigger when the user mentions memor…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "191601b4954527a87f4f004eaa355c8f30a855bf",
       "version": "1.3.6",


### PR DESCRIPTION
## Summary

Adds a third-party catalog entry for **openviking** — a Grok CLI plugin that connects to an [OpenViking](https://github.com/volcengine/OpenViking) context database via a local stdio → HTTP MCP proxy.

- **Source:** https://github.com/shpaw415/openviking-grok-plugin
- **Pinned SHA:** `90343ff1cb885d303379914f179283c2940c9acb`
- **Components:** 1 MCP server (`openviking` stdio), 1 command (`/ov`), 1 skill (`openviking`)

### What the plugin does

- Spawns `node servers/mcp-proxy.mjs` as a plugin MCP server
- Forwards JSON-RPC to the user’s OpenViking server `/mcp` endpoint
- Resolves credentials from (highest first): `OPENVIKING_*` env → `~/.openviking/ovcli.conf` → `~/.openviking/ov.conf` → local default `http://127.0.0.1:1933`
- **Does not** embed API keys in Grok `config.toml`

### Network / credentials (for security review)

| Item | Detail |
|------|--------|
| Network | User-configured OpenViking base URL only (from ovcli.conf / env); default local `127.0.0.1:1933` |
| Auth | Optional Bearer API key + optional account/user headers |
| Secrets location | `~/.openviking/ovcli.conf` (mode 600) or env vars — not in plugin files |
| Hooks | None in this release |
| Install scripts | Repo ships optional `install.sh` for convenience; marketplace install is pure `grok plugin install` |

This is a **community** Grok client for OpenViking (not an official Volcengine/xAI first-party plugin). License: Apache-2.0 (proxy adapted from OpenViking’s published memory-plugin examples).

### Validation run locally

```bash
python3 scripts/generate-plugin-index.py
python3 scripts/validate-catalog.py
python3 scripts/generate-plugin-index.py --check
```

All passed.

## Checklist

- [x] Entry added to `.grok-plugin/marketplace.json` (unique kebab-case `name`)
- [x] Remote source pins full 40-char lowercase commit `sha`
- [x] `.grok-plugin/plugin-index.json` regenerated and committed
- [x] `homepage` + clear `description`; brand-scoped `keywords` / `domains`
- [x] Plugin licensed (Apache-2.0) and stated in source repo
- [x] Security expectations reviewed (stdio proxy only; no RCE install hooks; no secret exfiltration)

## Install (after merge)

```bash
grok plugin marketplace update
grok plugin install openviking --trust
```

Or today from the source repo:

```bash
grok plugin install shpaw415/openviking-grok-plugin --trust
```