### PR TITLE
Fail closed on SHA pinning for all non-local source shapes

### DIFF
--- a/scripts/validate-catalog.py
+++ b/scripts/validate-catalog.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 """Validate the marketplace catalog index.
 
-Enforces, for every plugin with `"source": {"source": "url", ...}`:
+Enforces, for every plugin whose source is *not* an explicit local source:
 
   - `sha` field is present and non-empty
   - `sha` is a 40-character lowercase hex string (full commit SHA, not a
     tag, branch, or abbreviation)
+
+The check is fail-closed: a source is exempt from pinning only when it says
+`{"type": "local", ...}` or is a relative path string beginning with "./".
+Every other dict shape is treated as remote and must be pinned, and any
+other type is rejected outright. Allow-listing remote spellings instead
+(e.g. only `{"source": "url"}`) silently exempts every shape not on the
+list — including `{"source": "github", "repo": "..."}`, the Claude Code
+shape this validator also sees via `.claude-plugin/marketplace.json`.
 
 This is the catalog-level enforcement layer for SHA pinning. Without a
 pin, the installer would fall back to `git clone --branch <ref>` (or HEAD),
@@ -30,11 +38,46 @@ from pathlib import Path
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
+# The documented string-form source is a relative in-repo path, e.g.
+# "./plugins/foo". Requiring the prefix keeps URLs and scp-style refs from
+# being mistaken for local paths.
+LOCAL_PATH_PREFIX = "./"
+
 # Lookup order matches the marketplace index loader in the Grok CLI.
 CATALOG_PATHS = [
     Path(".grok-plugin/marketplace.json"),
     Path(".claude-plugin/marketplace.json"),
 ]
+
+
+def is_local_source(source: dict) -> bool:
+    """True for sources vendored in this repo, which need no commit pin."""
+    return source.get("type") == "local"
+
+
+def describe_source(source: dict) -> str:
+    """Best-effort identifier for error messages across source shapes."""
+    for key in ("url", "repo", "path"):
+        value = source.get(key)
+        if isinstance(value, str) and value:
+            return f"{key}={value!r}"
+    return f"source={source!r}"
+
+
+def local_path_errors(name: str, value, label: str) -> list[str]:
+    """Shared shape check for in-repo relative plugin paths."""
+    if not isinstance(value, str) or not value.strip():
+        return [f"plugin '{name}': {label} must be a non-empty string."]
+    if (
+        value.startswith("/")
+        or "\\" in value
+        or any(part in ("..", "") for part in value.split("/"))
+    ):
+        return [
+            f"plugin '{name}': {label} {value!r} must be a relative "
+            f"subdirectory inside the repo (no leading '/', no '..', no backslashes)."
+        ]
+    return []
 
 
 def validate_entry(entry: dict, idx: int) -> list[str]:
@@ -43,20 +86,40 @@ def validate_entry(entry: dict, idx: int) -> list[str]:
     name = entry.get("name") or f"<unnamed at index {idx}>"
     source = entry.get("source")
 
-    # String-form sources like "./plugins/foo" are local paths; no sha needed.
-    if not isinstance(source, dict):
-        return errors
+    # String-form sources are local paths like "./plugins/foo". Anything else
+    # spelled as a string — a URL, an scp-style ref, a bare repo name — would
+    # reach the installer as an unpinned remote, so require the documented
+    # local shape rather than exempting every string.
+    if isinstance(source, str):
+        if not source.startswith(LOCAL_PATH_PREFIX):
+            return [
+                f"plugin '{name}': string-form `source` {source!r} must be a "
+                f'relative local path starting with "{LOCAL_PATH_PREFIX}". '
+                f"Remote sources must use the object form with a pinned `sha`."
+            ]
+        return local_path_errors(name, source, "string-form `source`")
 
-    if source.get("source") != "url":
+    if not isinstance(source, dict):
+        return [
+            f"plugin '{name}': `source` must be an object or a local path "
+            f'string starting with "{LOCAL_PATH_PREFIX}", got '
+            f"{'null' if source is None else type(source).__name__}."
+        ]
+
+    # Fail closed: only an explicit local source is exempt from pinning.
+    # Everything else counts as remote, including shapes we haven't seen yet.
+    if is_local_source(source):
         return errors
 
     sha = source.get("sha")
     if not sha:
         errors.append(
-            f"plugin '{name}': missing `sha` field on url source "
-            f"(url={source.get('url')!r}). All url-sourced plugins must "
+            f"plugin '{name}': missing `sha` field on remote source "
+            f"({describe_source(source)}). Every remote-sourced plugin must "
             f"be pinned to a specific commit so a vendor force-push can't "
-            f"silently ship new code to installed users."
+            f"silently ship new code to installed users. If this is a local "
+            f"plugin vendored in this repo, use "
+            f'{{"type": "local", "path": "./..."}}.'
         )
         return errors
 
@@ -75,19 +138,7 @@ def validate_entry(entry: dict, idx: int) -> list[str]:
 
     path = source.get("path")
     if path is not None:
-        if not isinstance(path, str) or not path.strip():
-            errors.append(
-                f"plugin '{name}': url source `path` must be a non-empty string when present."
-            )
-        elif (
-            path.startswith("/")
-            or "\\" in path
-            or any(part in ("..", "") for part in path.split("/"))
-        ):
-            errors.append(
-                f"plugin '{name}': url source `path` {path!r} must be a relative "
-                f"subdirectory inside the repo (no leading '/', no '..', no backslashes)."
-            )
+        errors.extend(local_path_errors(name, path, "remote source `path`"))
 
     return errors
 


### PR DESCRIPTION
## What this PR does

Not a plugin submission — a fix to `scripts/validate-catalog.py`, so the template's plugin checklist doesn't apply.

`validate_entry` exempted everything except one remote spelling:

```python
if not isinstance(source, dict):
    return errors          # every string, null, number, array -> unchecked
if source.get("source") != "url":
    return errors          # every other dict shape -> unchecked
```

Both branches leak. All of these validate clean today with no commit pin:

```json
{"source": "github", "repo": "org/repo"}
{"type": "url",  "url": "https://…"}
{"type": "git",  "url": "https://…"}
{"url": "https://…"}
{"source": "github", "repo": "org/repo", "ref": "main"}
"https://host/org/repo.git"
"git@host:org/repo.git"
null / 42 / ["./plugins/foo"]
```

### Why this is reachable, not theoretical

`CATALOG_PATHS` includes `.claude-plugin/marketplace.json`, so this validator is expected to run against Claude Code catalogs — and `{"source": "github", "repo": "…"}` is exactly the shape those ship. #123 documents it in `anthropics/claude-plugins-official` and `zapier/marketplace`:

```json
{ "name": "sdk", "source": { "source": "github", "repo": "zapier/sdk" } }
```

A catalog built from those entries passes CI with zero pins — in the one file whose docstring exists to prevent that.

## The fix

Invert both tests to **fail closed**:

- A **string** source must be a relative in-repo path starting with `./`, the documented local form. URLs, scp-style refs and bare repo names no longer pass as "local".
- Any **other non-dict** source (`null`, number, array, missing) is rejected rather than silently ignored.
- A **dict** source is exempt only when it is `{"type": "local", …}`. Everything else counts as remote and must be pinned, including shapes that don't exist yet.

The alternative — extending an allow-list to `github`/`git`/etc. — needs a new entry for every new shape and reopens the same hole each time one is missed. Inverting makes unknown shapes pinned-by-default, which is the safer direction for a supply-chain gate.

Two follow-ons in the same diff:
- The relative-path shape check is folded into `local_path_errors()`, now shared by string sources and remote `path` subdirs, so both enforce identical rules.
- The missing-`sha` message hardcoded `url=`, so it printed `url=None` for `repo`-shaped entries. It now uses the first present identifier (`url` / `repo` / `path`) and points at the local-source shape if that's what the author meant.

## Verification

One file, nothing imports it (CI invokes it as a script), so the blast radius is the validator alone.

| Source | before | after |
|---|---|---|
| `{"source":"github","repo":"evil/y"}` | ACCEPTED | **REJECTED** |
| `{"type":"url","url":…}` | ACCEPTED | **REJECTED** |
| `{"type":"git","url":…}` | ACCEPTED | **REJECTED** |
| `{"url":…}` | ACCEPTED | **REJECTED** |
| `{"source":"github","repo":…,"ref":"main"}` | ACCEPTED | **REJECTED** |
| `"https://evil/y.git"` | ACCEPTED | **REJECTED** |
| `"git@github.com:evil/y.git"` | ACCEPTED | **REJECTED** |
| `"evil/y"` / `"/etc/passwd"` / `"./../../etc"` / `""` | ACCEPTED | **REJECTED** |
| `null` / `42` / `["./plugins/foo"]` | ACCEPTED | **REJECTED** |
| `{"source":"url",url,sha}` | accepted | accepted |
| `{"source":"url",url,sha,path}` | accepted | accepted |
| `{"type":"local","path":…}` | accepted | accepted |
| `"./plugins/foo"` | accepted | accepted |
| abbreviated / uppercase sha, escaping `path` | rejected | rejected |

**No catalog changes required** — all 15 current entries already comply:

```
$ python3 scripts/validate-catalog.py
Catalog OK (.grok-plugin/marketplace.json)
```

Sample of the improved error:

```
plugin 'sdk': missing `sha` field on remote source (repo='zapier/sdk'). Every
remote-sourced plugin must be pinned to a specific commit so a vendor
force-push can't silently ship new code to installed users. If this is a local
plugin vendored in this repo, use {"type": "local", "path": "./..."}.
```

## Notes for reviewers

- The string / non-dict half of this came from the Copilot review on the first push — it correctly spotted that `if not isinstance(source, dict): return errors` let a string URL through the same way. Good catch, folded in.
- **No test file added on purpose.** The repo has no tests and no runner, so adding one felt like scope I shouldn't pick for you. I verified with a throwaway script that imports `validate_entry` and asserts the 22 cases above. Happy to add it as `scripts/test_validate_catalog.py` (stdlib `unittest`, one CI line) if you want the regression pinned down — just say the word.
- Requiring `./` on string sources is the one judgement call here: it rejects a bare `plugins/foo`. No catalog entry uses the string form today, and the error message says exactly what to write, but I'm happy to relax it to "any relative path that isn't a URL" if you'd rather.
- Related: #123 and #166 both report the Grok Build scanner dropping root-repo sources. This PR doesn't touch that — it's a separate issue in the Rust scanner — but they're what surfaced this shape-handling gap.
