### PR TITLE
feat: add Search1API plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -159,6 +159,19 @@
       "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
     },
     {
+      "name": "search1api",
+      "description": "Live web search, page retrieval, news, sitemap discovery, and trending-topic research through Search1API's hosted MCP server and research skill. Connect with OAuth when prompted to search current sources and return source-backed results.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/superagents-lab/grok-search1api.git",
+        "sha": "f062245909dafec41c1ad8e55860489c57d8522a"
+      },
+      "homepage": "https://www.search1api.com/docs",
+      "keywords": ["search1api", "search1 api"],
+      "domains": ["search1api.com", "www.search1api.com", "mcp.search1api.com"]
+    },
+    {
       "name": "railway",
       "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -390,6 +390,24 @@
         ]
       }
     },
+    "search1api": {
+      "sha": "f062245909dafec41c1ad8e55860489c57d8522a",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "search1api",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "search1api",
+            "description": "Live web search, page retrieval, news, sitemap discovery, and trending topics through Search1API. Use when the user ask…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "f6b4882489b34b5dce8f21648286a570d56110da",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `search1api`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/superagents-lab/grok-search1api.git` at `f062245909dafec41c1ad8e55860489c57d8522a`
- Homepage: https://www.search1api.com/docs

Adds Search1API live web search, page retrieval, news, sitemap discovery, and trending-topic research through one hosted HTTP MCP server and one research skill.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name.
- [x] Remote source pins a public, reachable full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the source includes `README.md`, `.grok-plugin/plugin.json`, and an MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] The plugin has no hooks, scripts, agents, bundled binaries, or filesystem permissions; MCP scope is limited to the declared Search1API tools.
- Network endpoints this plugin calls (and why): `https://mcp.search1api.com/mcp` for user-requested web search, page retrieval, news, sitemap discovery, and trending-topic research.
- Credentials/permissions it requires (and why): Search1API OAuth when prompted by Grok Build; the host handles the OAuth flow and users are not asked to paste credentials into prompts.

## Notes for reviewers

The source is published by the official Search1API GitHub organization. Grok Build 0.2.118 validates the manifest and detects one skill plus one HTTP MCP server. Direct GitHub installation and remote custom-marketplace add/sync were both tested successfully.
