### PR TITLE
Add Unstructured Transform MCP

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -228,7 +228,7 @@
     },
     {
       "name": "unstructured-transform",
-      "description": "Unstructured Transform MCP server. Parse PDFs, DOCX, PPTX, XLSX, HTML, emails, and 60+ file types into clean structured markdown, JSON, HTML, or text directly from your agent, with OAuth sign-in and no API key required.",
+      "description": "Unstructured Transform MCP server. Parse PDFs, DOCX, PPTX, XLSX, HTML, emails, and 60+ file types into clean structured markdown, JSON, HTML, or text directly from your agent, with OAuth sign-in.",
       "category": "development",
       "source": {
         "source": "url",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "unstructured-transform",
+      "description": "Unstructured Transform MCP server. Parse PDFs, DOCX, PPTX, XLSX, HTML, emails, and 60+ file types into clean structured markdown, JSON, HTML, or text directly from your agent, with OAuth sign-in and no API key required.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Unstructured-IO/unstructured-mcp-integrations.git",
+        "sha": "5fe3e19f03a3543aa4fe42674ba0aa2db6f49a98",
+        "path": "transform/grok"
+      },
+      "homepage": "https://transform.unstructured.io",
+      "keywords": ["unstructured", "unstructured transform", "transform mcp", "unstructured.io"],
+      "domains": ["transform.unstructured.io", "mcp.transform.unstructured.io", "unstructured.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -676,6 +676,18 @@
         ]
       }
     },
+    "unstructured-transform": {
+      "sha": "5fe3e19f03a3543aa4fe42674ba0aa2db6f49a98",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "transform",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "1e821f3087d6d52b06b918d39d57345e2e4f3cf8",
       "version": "0.46.0",


### PR DESCRIPTION
Adds a marketplace entry for **Unstructured Transform**, a hosted OAuth
`streamable-http` MCP server that parses PDFs, DOCX, PPTX, XLSX, HTML,
emails, and 60+ file types into clean structured markdown, JSON, HTML, or
text.

- Source: `url` pinned to `Unstructured-IO/unstructured-mcp-integrations`
  at `5fe3e19`, scoped via `path: transform/grok` to that subdirectory
  (same pattern as the existing `railway`/`stripe`/`tinyfish` entries) —
  sourced from our official org rather than vendored into a personal fork.
- `category: development` — closest existing bucket; no
  data-processing/document category exists yet.
- `.grok-plugin/plugin-index.json` regenerated via
  `generate-plugin-index.py` and validated with `validate-catalog.py`.

Docs: https://docs.unstructured.io/transform/overview
Get started: https://transform.unstructured.io

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>