### PR TITLE
Add gabriel-operator plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "gabriel-operator",
+      "description": "Build Gabriel workflows, apps, agents, pipelines, lists, todos, assets, and digital twins.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Gabriel-Operator/gabriel-operator-codex-plugin.git",
+        "sha": "816fd79f8e0948958e5b7a3765265da6badd4219"
+      },
+      "homepage": "https://github.com/Gabriel-Operator/gabriel-operator-codex-plugin",
+      "keywords": ["gabriel-operator", "gabriel operator", "gabriel workflow", "gabriel page-builder", "gabriel pipeline"],
+      "domains": ["gabrieloperator.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -232,10 +232,10 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/Gabriel-Operator/gabriel-operator-codex-plugin.git",
-        "sha": "816fd79f8e0948958e5b7a3765265da6badd4219"
+        "url": "https://github.com/Gabriel-Operator/gabriel-operator-coding-agent-plugin.git",
+        "sha": "5d34d056b1d1dedc491209a3d0c79d35b1d08797"
       },
-      "homepage": "https://github.com/Gabriel-Operator/gabriel-operator-codex-plugin",
+      "homepage": "https://github.com/Gabriel-Operator/gabriel-operator-coding-agent-plugin",
       "keywords": ["gabriel-operator", "gabriel operator", "gabriel workflow", "gabriel page-builder", "gabriel pipeline"],
       "domains": ["gabrieloperator.com"]
     }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,34 @@
         ]
       }
     },
+    "gabriel-operator": {
+      "sha": "816fd79f8e0948958e5b7a3765265da6badd4219",
+      "version": "1.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "application",
+            "description": "Build and maintain Gabriel Operator Applications — git-backed interactive web apps with an app-config.json definition,…"
+          },
+          {
+            "name": "asset-library",
+            "description": "Maintain a signed-in user's Git-backed generated asset library and Remotion movie manifests."
+          },
+          {
+            "name": "digital-twin-embed",
+            "description": "Maintain Git-backed Gabriel embed appearance via assets/embed-config.json."
+          },
+          {
+            "name": "page-builder",
+            "description": "Orchestrator skill for generating PageBuilderConfig JSON that powers Gabriel Operator's universal app renderer. Covers…"
+          },
+          {
+            "name": "todo-builder",
+            "description": "Build, validate, and maintain Git-backed Gabriel Operator personal To-Do workspaces by editing assets/todos.json. Use t…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,7 +328,7 @@
       }
     },
     "gabriel-operator": {
-      "sha": "816fd79f8e0948958e5b7a3765265da6badd4219",
+      "sha": "5d34d056b1d1dedc491209a3d0c79d35b1d08797",
       "version": "1.1.0",
       "components": {
         "skills": [


### PR DESCRIPTION
## Summary
Adds `gabriel-operator` as a remote-source third-party plugin for Grok Build.

- Source: https://github.com/Gabriel-Operator/gabriel-operator-codex-plugin.git
- Pinned SHA: `816fd79f8e0948958e5b7a3765265da6badd4219`
- Skills-only authoring plugin (workflows, page builder, pipelines, lists, todos, applications, digital twins, assets)

## Validation
- `python3 scripts/validate-catalog.py` — OK
- `python3 scripts/generate-plugin-index.py --check` — OK


Made with [Cursor](https://cursor.com)