### PR TITLE
Add Padlet plugin — read, create, and edit Padlet boards via Padlet's hosted MCP server

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "padlet",
+      "description": "Work with your Padlet boards through Padlet's hosted MCP server. List, search, and read padlets; create padlets; create, edit, connect, and comment on posts; and analyse post attachments. Sign in with your own Padlet account on first connection — no API keys, nothing to run locally.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/padlet/agent-plugins.git",
+        "sha": "9658f1a28eb8fc958db99127d13f2f4644ba20aa"
+      },
+      "homepage": "https://padlet.com",
+      "keywords": ["padlet", "padlet board", "padlet wall", "padlet post"],
+      "domains": ["padlet.com", "padlet.help", "mcp.padlet.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -432,6 +432,24 @@
         ]
       }
     },
+    "padlet": {
+      "sha": "9658f1a28eb8fc958db99127d13f2f4644ba20aa",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "padlet",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "padlet-toolsets",
+            "description": "Views, enables, and disables toolsets for the Padlet MCP server. Use when the user wants to change which Padlet tools a…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",


### PR DESCRIPTION
## What this PR does

Adds one new catalog entry for the **Padlet** plugin — Padlet's hosted MCP server plus the
`/padlet-toolsets` skill, so Grok Build can read, search, create, and edit padlets and posts
in conversation. Users sign in with their own Padlet account; there are no API keys and
nothing to run locally.

- Plugin name: `padlet`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/padlet/agent-plugins.git` @ `9658f1a28eb8fc958db99127d13f2f4644ba20aa`
- Homepage: https://padlet.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Submitted by a Padlet engineer. The source repo is
[`padlet/agent-plugins`](https://github.com/padlet/agent-plugins), under Padlet's official
GitHub org; the MCP server it registers is Padlet's own hosted service at `mcp.padlet.com`.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The index regeneration produced only the additive `padlet` block — no drift in any other
plugin's entry. License is MIT
([LICENSE](https://github.com/padlet/agent-plugins/blob/main/LICENSE)), stated in the manifest
and the README.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin ships no executable content at all — the whole repo is a manifest per host, one
MCP registration, one `SKILL.md`, two logo assets, a LICENSE, and a README. No scripts, no
binaries, no install or lifecycle hooks.

- **Network endpoints this plugin calls (and why):** `https://mcp.padlet.com` only — Padlet's
  hosted MCP server, registered over streamable HTTP. It is the sole host the plugin contacts,
  and it is where every Padlet operation is executed.
- **Credentials/permissions it requires (and why):** none are stored in the repo.
  Authentication is OAuth 2.1 with PKCE, performed by the host client in the browser on first
  use; tokens are held by the client, never by these files. Every action runs as the
  signed-in user and is bounded by Padlet's own permission model — the plugin can only see and
  change what that user could see and change in Padlet itself.

On least privilege: Padlet's MCP server exposes 69 tools in total, grouped into named
toolsets. The plugin requests only `core` (16 tools — listing, searching, and reading padlets;
creating padlets; creating, editing, connecting, and commenting on posts). Board
administration and school/team library administration are **not** enabled by default.

## Notes for reviewers

**One thing worth calling out up front:** the `/padlet-toolsets` skill writes to the installed
plugin's own `.mcp.json`. It rewrites *only* the value after `toolsets=` in the server URL —
scheme, host, path, and every other query parameter are left intact, and the skill is
documented to refuse anything else. It exists because agent clients cap how many tools a model
can see across all connected MCP servers (roughly 80 in Cursor), so enabling Padlet's full
69-tool surface would crowd out a user's other servers. Shipping `core` and letting people
opt into `board_admin` / `library` deliberately, with a warning, seemed better than shipping
everything. That edit is the only write the plugin performs outside of Padlet itself, and it
only ever happens when a user explicitly runs the skill.

Also relevant to the pin: the commit being pinned moves the MCP registration from `mcp.json`
to `.mcp.json` to match this repo's documented convention, and adds a
`.grok-plugin/marketplace.json` to `padlet/agent-plugins` so the repository can also be added
as a marketplace directly.

Known limitation, documented in the plugin README: Padlet's Sandbox (whiteboard) format is
only partially supported. All other board formats are fully supported.

Happy to adjust `category`, `keywords`, or `domains` — I picked `development` because it's the
catalog's catch-all and none of `deployment` / `database` / `monitoring` / `observability` fit,
and kept keywords brand-scoped so the CTA doesn't mis-fire on unrelated requests.
