### PR TITLE
Add 60fps plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "60fps",
+      "description": "Search 2,000+ real iOS interaction clips by describing the motion you want, then get compile-checked SwiftUI that recreates it. Every clip carries a written motion breakdown: start state, transition, end state, timing and easing, taken from apps that shipped.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/60fps-Design/plugin.git",
+        "sha": "77a5ea819999d4ff6c3fdaef65c0815b34f39fc8"
+      },
+      "homepage": "https://60fps.design/mcp",
+      "keywords": ["60fps", "60fps design", "60fps mcp"],
+      "domains": ["60fps.design", "mcp.60fps.design"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -233,7 +233,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/60fps-Design/plugin.git",
-        "sha": "77a5ea819999d4ff6c3fdaef65c0815b34f39fc8"
+        "sha": "a15b1a6feccf7a504eaf220342987523093947b6"
       },
       "homepage": "https://60fps.design/mcp",
       "keywords": ["60fps", "60fps design", "60fps mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,12 +2,12 @@
   "version": 1,
   "plugins": {
     "60fps": {
-      "sha": "77a5ea819999d4ff6c3fdaef65c0815b34f39fc8",
+      "sha": "a15b1a6feccf7a504eaf220342987523093947b6",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
-            "name": "60fps",
+            "name": "library",
             "description": "http"
           }
         ],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,24 @@
 {
   "version": 1,
   "plugins": {
+    "60fps": {
+      "sha": "77a5ea819999d4ff6c3fdaef65c0815b34f39fc8",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "60fps",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "motion-reference",
+            "description": "Build an iOS interaction by copying one that already shipped. Use when asked to design or implement any animation, tran…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds 60fps, a reference library of real iOS interaction clips. You describe the motion you want, it
returns clips from apps that shipped, each with a written motion breakdown, and a compile-checked
SwiftUI file that recreates it.

- Plugin name: `60fps`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/60fps-Design/plugin.git` @ `77a5ea819999d4ff6c3fdaef65c0815b34f39fc8`
- Homepage: https://60fps.design/mcp

It ships one hosted MCP server and one skill. The skill also says when *not* to use the library,
since it is iOS and motion only, and semantic search always returns something.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. MIT, in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

There is no install script, no hook, no command and no agent. The plugin is a manifest, one
`.mcp.json` pointing at a hosted server, and one `SKILL.md`. Nothing executes on the user's machine.

- Network endpoints this plugin calls (and why): `https://mcp.60fps.design/mcp` only, which is our
  own server. It is read only: five tools that search the library and return text, and it never
  writes anything anywhere. Separately, the server itself fetches storyboard images from Framer's
  image CDN so they can be returned inline. That request happens server side and carries nothing
  about the caller: no headers, no identifiers, no licence key.
- Credentials/permissions it requires (and why): a 60fps PRO licence, because the library is a paid
  product. Sign-in is OAuth in the browser on first connection, the same shape as the Vercel entry
  already in this catalogue. No API key is stored in the plugin and the manifest contains no secrets.
  Without a licence the tools connect and return 401 rather than failing oddly.

## Notes for reviewers

The source repo is under our org, `60fps-Design`, and the same repo carries the Cursor and Claude
Code manifests beside the Grok one, so all three read the same skill and the same server config.

One thing worth knowing before you test: **the server is PRO gated**, so an unlicensed reviewer sees
a 401 on every tool and the plugin will look broken. Happy to provide a complimentary licence key
for review, just say where to send it.
