### PR TITLE
Document Neon branch log observability

### DIFF
--- a/external_plugins/neon/skills/neon/SKILL.md
+++ b/external_plugins/neon/skills/neon/SKILL.md
@@ -176,6 +176,12 @@ When the Neon MCP server is available, use its read-only `query_logs`, `list_log
 
 ### Query logs with `@neon/sdk`
 
+Install `@neon/sdk`, Neon's TypeScript client for the Neon API:
+
+```bash
+npm i @neon/sdk
+```
+
 Use `neon.logs.query()` in application code. It returns a lazy paginated result:
 
 ```typescript

--- a/external_plugins/neon/skills/neon/SKILL.md
+++ b/external_plugins/neon/skills/neon/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   storage", "serverless functions", "background jobs", or
   "run code near my database", "AI gateway", "LLM proxy",
   "model routing", or "call an LLM" → AI Gateway; "database", "Postgres", or
-  "authentication" → Postgres and Auth.
+  "authentication" → Postgres and Auth; "branch logs", "query logs",
+  "observability", or "telemetry" → branch log APIs.
 ---
 
 # Neon
@@ -166,6 +167,76 @@ If env vars are injected at runtime instead of written to disk — or you simply
 When an agent should not write a local `.env`, instruct it (for example in your `AGENTS.md`) to run `neonctl checkout <branch> --no-env-pull` and rely on runtime injection.
 
 For reading env you *already* have on disk (typed and validated against your `neon.ts`), use `parseEnv` — see [Neon Infrastructure as Code](#neon-infrastructure-as-code) below.
+
+## Observability
+
+Neon exposes branch-scoped service logs through a typed SDK and a Loki-compatible HTTP API. Logs currently require a project enrolled in the beta and located in `us-east-2`. The `@neon/sdk` API returns `404` with `reason: "telemetry_not_enabled"` when a branch cannot serve logs.
+
+When the Neon MCP server is available, use its read-only `query_logs`, `list_log_fields`, and `list_log_field_values` tools for interactive agent work.
+
+### Query logs with `@neon/sdk`
+
+Use `neon.logs.query()` in application code. It returns a lazy paginated result:
+
+```typescript
+import { createNeonClient } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
+const query = neon.logs.query(
+  process.env.NEON_PROJECT_ID!,
+  process.env.NEON_BRANCH_ID!,
+  {
+    source: "function",
+    since: "1h",
+    limit: 100,
+    sort_order: "desc",
+  },
+);
+
+const page = await query.page();
+if (page.error) throw page.error;
+
+console.log(page.data.items);
+console.log(page.data.cursor); // pass to query.page(cursor) for the next page
+```
+
+`limit` applies to each page. Use `for await (const record of query)` to stream every page with errors thrown, or `query.all()` to collect every page in a `{ data, error }` result.
+
+With default client settings, `neon.logs.fields(projectId, branchId)` returns `{ data: string[], error }`. `neon.logs.fieldValues(projectId, branchId, fieldName, query?)` returns `{ data: { values, is_truncated }, error }`. When `is_truncated` is true, narrow `since` or `source` before using the values as filters.
+
+Use `source` to select `function` or `storage` records. The SDK type also accepts `pg_endpoint`, but that source has not been observed emitting records. Other structured filters include `service_name`, `scope_name`, `severity_text`, `minimum_severity`, `body_contains`, and `trace_id`. Some backends reject `minimum_severity`. `severity_text` is the fallback, but it is a case-sensitive exact match for one stored level, typically uppercase such as `ERROR`; it does not include higher levels.
+
+An SDK query's time window defaults to one hour and cannot exceed seven days. Supply either `since` or `start_time`, not both. A raw `logql` expression replaces the structured content filters, but `limit`, `sort_order`, and the time window still apply.
+
+The SDK and Loki-compatible HTTP API name the same selections differently:
+
+| `@neon/sdk` | Loki-compatible HTTP |
+| --- | --- |
+| `source: "function"` | `entity_type="function"` label |
+| `service_name`, `scope_name`, `trace_id`, `severity_text` | Same-named labels |
+| `minimum_severity` | `severity_text=~` regex covering that level and above |
+| `sort_order: "asc"` / `"desc"` | `direction=forward` / `backward` |
+| `since`, `start_time`, `end_time` | `since`, `start`, `end` |
+
+The SDK's `body_contains` filter maps to Loki's `|=` line filter.
+
+### Query the Loki-compatible HTTP API
+
+Use the direct HTTP surface for non-TypeScript clients or when a raw Loki response is required:
+
+```bash
+curl --get \
+  "https://console.neon.tech/telemetry/v1/projects/${NEON_PROJECT_ID}/branches/${NEON_BRANCH_ID}/loki/api/v1/query_range" \
+  --header "Authorization: Bearer ${NEON_API_KEY}" \
+  --data-urlencode 'query={entity_type="function"}' \
+  --data-urlencode 'since=1h' \
+  --data-urlencode 'limit=100' \
+  --data-urlencode 'direction=backward'
+```
+
+The response uses the Loki `streams` envelope. Errors use `{ "status": "error", "error": "..." }`. A query needs at least one stream-label matcher. This API accepts stream selectors and line filters, not aggregations, parsers, or formatting stages. Its `since` parameter uses Go durations such as `1h`; `start` and `end` accept RFC3339 timestamps or Unix nanoseconds.
+
+The HTTP interface has no cursor pagination. `limit` caps one response, and a non-empty `warnings` array means records were dropped. Narrow the time window or filters and query again. Use `/labels` to list stream labels and `/label/{name}/values` to list values for one label. This HTTP surface is separate from the public Neon OpenAPI specification.
 
 ## Neon Infrastructure as Code
 


### PR DESCRIPTION
## Problem

The vendored Neon skill does not explain how agents can read branch logs or choose between the typed SDK and Loki-compatible HTTP interfaces.

## Solution

Add the Observability section from the source Neon skill. It covers beta availability, MCP routing, SDK installation and pagination, field discovery, SDK-to-Loki filter mapping, the direct HTTP request, and each interface's limits and error shape.

Source change: https://github.com/neondatabase/agent-skills/pull/84

## Verification

- `python3 scripts/generate-plugin-index.py --check`
- `python3 scripts/validate-catalog.py`
- plugin index remained current

## For attention

The Neon Functions skill is not currently vendored in this marketplace, so this PR updates the existing parent Neon skill only.