### PR TITLE
Add Adanos market sentiment skill

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "adanos",
+      "description": "Official Adanos Market Sentiment skill for read-only stock and crypto sentiment research across Reddit, X / FinTwit, financial news, and Polymarket signals.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/adanos-software/adanos-market-sentiment-skill.git",
+        "sha": "aec82dfb2aa064cdf4ab8a916f526debebb74787"
+      },
+      "homepage": "https://adanos.org/",
+      "keywords": ["adanos", "adanos market sentiment", "adanos sentiment"],
+      "domains": ["adanos.org", "api.adanos.org"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "plugins": {
+    "adanos": {
+      "sha": "aec82dfb2aa064cdf4ab8a916f526debebb74787",
+      "components": {
+        "skills": [
+          {
+            "name": "adanos-market-sentiment",
+            "description": "Official Adanos Market Sentiment API skill. Use when users ask for stock or crypto sentiment, buzz, trending assets, ma…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the official **Adanos** skill to the Grok Build plugin marketplace. The skill provides read-only stock and crypto market sentiment research across Reddit, X / FinTwit, financial news, and Polymarket signals.

- Plugin name: `adanos`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/adanos-software/adanos-market-sentiment-skill.git` @ `aec82dfb2aa064cdf4ab8a916f526debebb74787`
- Homepage: https://adanos.org/

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`adanos-software`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a public, reachable 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] The upstream skill is MIT licensed.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` behavior.
- [x] No reading or exfiltration of unrelated secrets, tokens, or files.
- [x] No hooks or MCP servers; the plugin exposes one read-only skill.
- Network endpoints: `https://api.adanos.org` for Adanos Market Sentiment API requests and `https://adanos.org` for account registration/documentation.
- Credentials: protected API endpoints require the user-provided `ADANOS_API_KEY`. The skill does not transmit it anywhere except `api.adanos.org`.

## Notes for reviewers

The source is maintained in the official `adanos-software` organization. The source commit passes 14 unit tests and its live OpenAPI coverage check accounts for all 53 operations in Adanos OpenAPI version 1.49.0. Keywords and domains are intentionally brand-scoped.