### PR TITLE
feat(plugins): add mitosis-memory

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "mitosis-memory",
+      "description": "Query a user's private Mitosis memory — connected email, calendar, documents, contacts and chat history — with citations, and write durable facts back.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/OperatingSystem-1/mitosis-agent-plugin.git",
+        "sha": "c5793148df76d5bcb2ab429808469a6c050f8e3a"
+      },
+      "homepage": "https://mitosislabs.ai",
+      "keywords": ["mitosis", "mitosis memory", "mitosis brain"],
+      "domains": ["mitosislabs.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,48 @@
         ]
       }
     },
+    "mitosis-memory": {
+      "sha": "c5793148df76d5bcb2ab429808469a6c050f8e3a",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mitosis",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "memory-ask",
+            "description": "Query the user's private Mitosis memory (email, calendar, documents, contacts, chat, project history) and get back a ci…"
+          },
+          {
+            "name": "memory-connect",
+            "description": "Wire this agent to the user's private Mitosis memory so the connection survives future sessions. Use when the user says…"
+          },
+          {
+            "name": "memory-ingest",
+            "description": "Ingest local files or a whole Markdown folder (such as an Obsidian vault) into the user's Mitosis memory so they become…"
+          },
+          {
+            "name": "memory-manifest",
+            "description": "Discover what a user's Mitosis memory actually contains — connected sources, item counts, and the people and topics it…"
+          },
+          {
+            "name": "memory-recall",
+            "description": "Semantic-only vector search across the user's Mitosis memory, returning hits with their source and a content excerpt. U…"
+          },
+          {
+            "name": "memory-remember",
+            "description": "Write a durable fact, decision, or insight back into the user's Mitosis memory with provenance, so future sessions inhe…"
+          },
+          {
+            "name": "memory-status",
+            "description": "Check the state of the user's Mitosis memory pipeline — totals, embedding and graph coverage, and per-feed freshness. U…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds one new entry for **mitosis-memory** — a plugin that connects an agent to a user's private [Mitosis](https://mitosislabs.ai) memory: their connected email, calendar, documents, contacts and chat history, queryable with citations, plus a tool to write durable facts back.

It ships a remote MCP server and seven skills that tell the agent when to reach for it.

- Plugin name: `mitosis-memory`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/OperatingSystem-1/mitosis-agent-plugin.git` @ `c5793148df76d5bcb2ab429808469a6c050f8e3a`
- Homepage: https://mitosislabs.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Published by Mitosis Labs, Inc., which operates the platform the plugin connects to. `OperatingSystem-1` is our company GitHub org — it carries the product's former name (OS-1) from before the Mitosis rebrand, which is why the org and brand names differ. All our repos live there. Happy to make that lineage clearer if you'd prefer.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

Branched off current `main` (`e2bc017`). The diff is 55 insertions and no deletions — regeneration left the other 17 entries untouched. `keywords` and `domains` are brand-scoped so the plugin CTA can't mis-fire on generic memory or search requests. License is MIT, stated in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin is JSON manifests plus seven `SKILL.md` files. No hooks, no install scripts, no shell, no bundled binaries.

- **Network endpoints this plugin calls (and why):** `https://mitosislabs.ai/api/mcp` only — the remote MCP server that answers the queries. Nothing else.
- **Credentials/permissions it requires (and why):** none to paste, and no API key. Auth is OAuth 2.0 with PKCE, with the client registered dynamically (RFC 7591); the user signs in through the browser the first time a tool is called and chooses at consent which memory to expose. Four of the eleven tools (`get_pricing`, `search_docs`, `get_platform_status`, `list_skills`) are a public surface needing no account at all; the seven `cortex_*` tools read the user's own data and require that sign-in.

## Notes for reviewers

Mitosis is a commercial service (trial, then paid plans) — disclosed in the source repo's README rather than buried. The MCP server is hosted by us; the MIT license covers the repo contents, not the service.

Verified before opening: your `scripts/plugin_catalog.py` resolves our tree to `mcpServers: 1, skills: 7, version: 1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)