### PR TITLE
Add the storeconnect plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -225,6 +225,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "storeconnect",
+      "description": "StoreConnect development plugin for Grok Build: Salesforce-native commerce and CMS — storefront Liquid templates, forms and reloadable components, catalog and content, point of sale, and the StoreConnect object model in Salesforce.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/GetStoreConnect/ai.git",
+        "sha": "7be65db020ada44c1780a34501264eed6ac19e80",
+        "path": "providers/grok/storeconnect"
+      },
+      "homepage": "https://github.com/GetStoreConnect/ai",
+      "keywords": ["storeconnect", "storeconnect theme", "storeconnect liquid", "storeconnect pos", "storeconnect store"],
+      "domains": ["storeconnect.com", "support.storeconnect.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -464,6 +464,102 @@
         ]
       }
     },
+    "storeconnect": {
+      "sha": "7be65db020ada44c1780a34501264eed6ac19e80",
+      "version": "0.9.2",
+      "components": {
+        "agents": [
+          {
+            "name": "sc-pos-developer",
+            "description": "Configure and extend StoreConnect POS, including outlets, registers, payments, fulfillment, layouts, views, actions, pr…"
+          },
+          {
+            "name": "sc-salesforce-manager",
+            "description": "Manage StoreConnect records and relationships through connected StoreConnect tools or Salesforce data tooling. Use for…"
+          },
+          {
+            "name": "sc-store-designer",
+            "description": "Plan StoreConnect builds and redesigns, coordinate content, data, theme, and quality work, and define a safe implementa…"
+          },
+          {
+            "name": "sc-theme-developer",
+            "description": "Implement StoreConnect Liquid templates, theme assets, forms, components, controllers, and styling. Use for storefront…"
+          },
+          {
+            "name": "sc-theme-reviewer",
+            "description": "Read-only audit of a StoreConnect storefront or theme, run in a separate context. Follows `storeconnect-theme-review`,…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "sc-auth",
+            "description": "Connect to one store URL now and confirm the store, environment, and signed-in identity. For platform and tool-selectio…"
+          },
+          {
+            "name": "sc-publish",
+            "description": "Publish one staged change now — review, explicit human approval, submit, then verify live. For deployment planning and…"
+          },
+          {
+            "name": "sc-theme-review",
+            "description": "Audit one theme path, template, or page URL now and return ranked, verified findings. For the check catalog and severit…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "storeconnect-apex-integration",
+            "description": "Customer-owned Apex and other Salesforce-side patterns around a StoreConnect storefront — deciding whether a requiremen…"
+          },
+          {
+            "name": "storeconnect-components",
+            "description": "StoreConnect reloadable Liquid components and storefront interactivity — the {% component %} tag and its reload events,…"
+          },
+          {
+            "name": "storeconnect-controllers",
+            "description": "Run server-side logic around a StoreConnect page request using Liquid controller templates — the before/after/final pha…"
+          },
+          {
+            "name": "storeconnect-debug-performance",
+            "description": "Instrument and speed up StoreConnect Liquid — the web Console, the debug and timer tags, drop and record introspection,…"
+          },
+          {
+            "name": "storeconnect-forms",
+            "description": "StoreConnect storefront forms — the Liquid form tag, registered form names and usable fields (login, register, account,…"
+          },
+          {
+            "name": "storeconnect-liquid",
+            "description": "Write StoreConnect Liquid template logic and read record data — Drops and their exact attributes, the {% query %} tag,…"
+          },
+          {
+            "name": "storeconnect-platform",
+            "description": "Entry point for all StoreConnect work — the Salesforce-native commerce, POS, CMS, and website platform. Covers asynchro…"
+          },
+          {
+            "name": "storeconnect-pos-customization",
+            "description": "Customize StoreConnect POS through supported layouts, filters, views, actions, scripts, styles, and print templates. Us…"
+          },
+          {
+            "name": "storeconnect-pos-setup",
+            "description": "Configure and troubleshoot StoreConnect POS outcomes — outlet and register readiness, staff access, product availabilit…"
+          },
+          {
+            "name": "storeconnect-salesforce-data",
+            "description": "Create, query, relate, and delete StoreConnect Salesforce records - stores, pages, content blocks, menus, articles, cat…"
+          },
+          {
+            "name": "storeconnect-sync-deploy",
+            "description": "Safely deploy changes to a StoreConnect store with connected StoreConnect tools, storeconnect-cli, or an explicitly app…"
+          },
+          {
+            "name": "storeconnect-theme-development",
+            "description": "Change how a StoreConnect storefront looks or is structured — override base-theme templates by key (pages/blocks/snippe…"
+          },
+          {
+            "name": "storeconnect-theme-review",
+            "description": "Read-only quality audit of a StoreConnect Liquid theme or storefront — layout integrity, SEO and structured data, acces…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "4b7495aa701334e453555ce4afb0029b06df590b",
       "version": "0.3.7",


### PR DESCRIPTION
## What this PR does

Adds StoreConnect — a Salesforce-native commerce, POS and CMS platform — as a remote-source plugin. 13 skills, 3 slash commands and 5 specialist agents covering storefront Liquid templates, forms and reloadable components, catalog and content, point of sale, and the StoreConnect object model in Salesforce.

- Plugin name: `storeconnect`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/GetStoreConnect/ai.git` at `7be65db020ada44c1780a34501264eed6ac19e80`, with `source.path` = `providers/grok/storeconnect`
- Homepage: https://github.com/GetStoreConnect/ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`GetStoreConnect` is the StoreConnect organization; `GetStoreConnect/ai` is our public AI distribution repository. MIT licensed.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The regenerated index records version `0.9.2` and components `skills: 13, commands: 3, agents: 5`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The package is markdown only — skills, commands and agent prompts. It ships no hooks, no scripts, no `.mcp.json` and no `.lsp.json`, so the generated index contains no `mcpServers` entry.

- **Network endpoints this plugin calls (and why):** none at install or load time. At runtime a store administrator may separately configure an MCP connection to their own store's `/mcp` endpoint on their own domain. No endpoint is committed anywhere in our repository, because every StoreConnect store serves its own — a validator in that repo fails the build if a resolved MCP configuration appears, and the only committed examples use `store.example.com`.
- **Credentials/permissions it requires (and why):** none. Installing connects nothing and includes no credentials. The skills instruct agents to use the host's native sign-in flow and explicitly forbid putting tokens in files, prompts or chat messages.

## Notes for reviewers

- **Monorepo layout, hence `source.path`.** `GetStoreConnect/ai` generates eight provider packages from one canonical source so they cannot drift, so the Grok package is a subdirectory rather than the repo root. Same arrangement as `stripe/ai` and `tinyfish-io/...` in the current catalog. Pointing at the repo root would index 13 skills and miss the manifest, commands and agents — I checked with `plugin_catalog.py` before choosing this.
- **Directory layout matches the scanner, not a guess.** Skills, commands and agents sit at the plugin root because that is what `scan_skills` and `scan_markdown_dir` read; the manifest declares no component paths, following `external_plugins/neon`.
- **Keywords and domains are brand-scoped**, per the CTA warning in CONTRIBUTING — `storeconnect`, `storeconnect theme`, `storeconnect pos`, and our own hosts only. Nothing like `commerce`, `salesforce` or `pos` on its own, which would misfire the plugin CTA on unrelated requests.
- The plugin is write-capable against a connected store, and the procedures that do so are deliberate: staged changes, an explicit human approval gate, and a live verification afterwards. `sc-publish` will not infer or reuse approval.