### PR TITLE
Add qencode plugin.

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "qencode",
+      "description": "Qencode video transcoding API and Media Storage. Submit encode jobs, monitor status, browse recipes, and manage CDN buckets — via hosted MCP with OAuth.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Qencode-Corp/mcp.git",
+        "sha": "83befc3d3b9d7015b5fac21e7065132d3c09bd83"
+      },
+      "homepage": "https://qencode.com",
+      "keywords": ["qencode", "qencode transcoding", "qencode mcp"],
+      "domains": ["qencode.com", "mcp.qencode.com", "docs.qencode.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -432,6 +432,18 @@
         ]
       }
     },
+    "qencode": {
+      "sha": "83befc3d3b9d7015b5fac21e7065132d3c09bd83",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "qencode",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",


### PR DESCRIPTION
## What this PR does

- [x] New plugin
- [ ] Plugin update (bump sha / refresh local files)

- **Plugin name:** `qencode`
- **Type:** remote source
- **Source:** `https://github.com/Qencode-Corp/mcp.git` @ `83befc3d3b9d7015b5fac21e7065132d3c09bd83`
- **Homepage:** https://qencode.com

Hosted HTTP MCP at `https://mcp.qencode.com/mcp` (OAuth). Plugin ships `.mcp.json` + `.grok-plugin/plugin.json` only — no local skills/hooks/scripts.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org (`Qencode-Corp/mcp`).

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json`
- [x] Remote source pins a full 40-char lowercase commit `sha`
- [x] Regenerated `.grok-plugin/plugin-index.json` via `python3 scripts/generate-plugin-index.py`
- [x] Passed locally: `python3 scripts/validate-catalog.py` and `python3 scripts/generate-plugin-index.py --check`
- [x] Homepage, clear description, brand-scoped keywords/domains; license MIT (stated in plugin manifest + LICENSE in source repo)

## Security

- [x] No remote-code download/execution (`curl | bash`, postinstall fetch, etc.)
- [x] No reading/exfiltration of secrets, tokens, or env vars
- [x] Hooks / MCP scope are least-privilege (single hosted HTTP MCP endpoint; no hooks)

## Notes for reviewers

Qencode MCP is a hosted OAuth Resource Server. The marketplace plugin only points Grok Build at `https://mcp.qencode.com/mcp`. Auth goes through `https://auth.qencode.com`. No code from the cloned repo runs as a local MCP process.