### PR TITLE
Add Mobbin plugin (remote MCP server)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -243,12 +243,12 @@
     },
     {
       "name": "mobbin",
-      "description": "Mobbin design reference integration (MCP server). Search real-world UI & UX design references for mobile apps, web apps, and websites — browse curated patterns, flows, and screens for design inspiration and implementation directly from Grok.",
+      "description": "Search real-world UI & UX design references for mobile apps, web apps, and websites with Mobbin, directly from Grok.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/mobbin/mobbin-mcp-server.git",
-        "sha": "194bb87b9187d526a92f7090aa1d0bd291561b5c"
+        "sha": "d24b602b051fbae7e030e88a78fe099ee69c6741"
       },
       "homepage": "https://docs.mobbin.com/mcp",
       "keywords": ["mobbin", "mobbin design", "mobbin ui", "mobbin ux", "mobbin references"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "mobbin",
+      "description": "Mobbin design reference integration (MCP server). Search real-world UI & UX design references for mobile apps, web apps, and websites — browse curated patterns, flows, and screens for design inspiration and implementation directly from Grok.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mobbin/mobbin-mcp-server.git",
+        "sha": "194bb87b9187d526a92f7090aa1d0bd291561b5c"
+      },
+      "homepage": "https://docs.mobbin.com/mcp",
+      "keywords": ["mobbin", "mobbin design", "mobbin ui", "mobbin ux", "mobbin references"],
+      "domains": ["mobbin.com", "docs.mobbin.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,7 +328,7 @@
       }
     },
     "mobbin": {
-      "sha": "194bb87b9187d526a92f7090aa1d0bd291561b5c",
+      "sha": "d24b602b051fbae7e030e88a78fe099ee69c6741",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,18 @@
         ]
       }
     },
+    "mobbin": {
+      "sha": "194bb87b9187d526a92f7090aa1d0bd291561b5c",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mobbin",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds **Mobbin** as a new plugin — a remote MCP server for searching real-world UI & UX design references (mobile apps, web apps, websites) directly from Grok.

- Plugin name: `mobbin`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/mobbin/mobbin-mcp-server.git` @ `194bb87b9187d526a92f7090aa1d0bd291561b5c`
- Homepage: https://docs.mobbin.com/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`mobbin/mobbin-mcp-server`).

Submitted by a Mobbin engineer; source repo is Mobbin's official org, so first-party ownership is verifiable.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege — the plugin ships only a single remote MCP server, no hooks/scripts.
- Network endpoints this plugin calls (and why): `https://api.mobbin.com/mcp` — Mobbin's hosted MCP server (Streamable HTTP), the sole endpoint; it serves the design-reference search tools.
- Credentials/permissions it requires (and why): OAuth on first connect. Auth is not declared in the plugin — Grok performs standard OAuth (with dynamic client registration) via the server's discovery metadata at connect time. No API keys or local secrets.

## Notes for reviewers

Same shape as the existing remote-MCP entries (e.g. `figma`, `tavily`): a single hosted MCP server, OAuth at connect time, no local execution. The pinned commit is `main` HEAD of the official repo.
