### PR TITLE
Add StarryKit plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "starrykit",
+      "description": "Create polished, editable presentations, posters, social graphics, infographics, diagrams, and visual documents with StarryKit. Start from a prompt, image, website, or design reference, refine every element, and export to PowerPoint, PDF, Google Slides, SVG, PNG, JPEG, or HTML.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/StarryKit/starrykit-plugin.git",
+        "sha": "f2682753fe7e8fdba17c6010c9c670b941524ce3"
+      },
+      "homepage": "https://starrykit.com",
+      "keywords": ["starrykit", "starrykit design", "starrykit presentation", "starrykit visual documents"],
+      "domains": ["starrykit.com", "mcp.starrykit.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -502,6 +502,24 @@
         ]
       }
     },
+    "starrykit": {
+      "sha": "f2682753fe7e8fdba17c6010c9c670b941524ce3",
+      "version": "0.4.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "starrykit",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "starrykit",
+            "description": "Create, inspect, refine, and export polished editable presentations, posters, social graphics, diagrams, and other visu…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "1953b6cce7344d880a054c42b8dd21ca3e50ebd5",
       "version": "0.4.1",


### PR DESCRIPTION
## What this PR does

- Plugin name: `starrykit`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/StarryKit/starrykit-plugin.git` at `f2682753fe7e8fdba17c6010c9c670b941524ce3`
- Homepage: https://starrykit.com

StarryKit adds a hosted MCP server and Skill for creating, refining, and exporting editable presentations and visual documents from Grok Build.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a public, reachable 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the remote plugin includes bilingual READMEs and `.grok-plugin/plugin.json`.
- [x] The plugin manifest states the MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks or local executables; MCP scope is limited to the hosted StarryKit service.
- Network endpoint: `https://mcp.starrykit.com/mcp`, used to create, inspect, refine, and export StarryKit visual documents.
- Credentials/permissions: browser OAuth to the user's StarryKit account; no API key or client secret is embedded in the plugin.

## Notes for reviewers

The source is maintained in the official StarryKit GitHub organization. The repository has native Grok, Claude, and Codex manifests; automated tests lock shared release identity and component paths while allowing host-specific discovery copy.