### PR TITLE
Add Local YDB Toolkit plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "local-ydb-toolkit",
+      "description": "Plan, diagnose, and safely operate Docker-based local YDB deployments locally or over SSH. Includes the Local YDB skill and a pinned stdio MCP server; mutating tools are plan-first and execute only with confirm: true.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/astandrik/local-ydb-toolkit.git",
+        "sha": "82e334dd792cebbcdbc9fb91610614697746e41c"
+      },
+      "homepage": "https://local-ydb-toolkit.ydb-qdrant.tech/",
+      "keywords": ["ydb", "local ydb", "local-ydb", "local ydb toolkit"],
+      "domains": ["local-ydb-toolkit.ydb-qdrant.tech"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,24 @@
         ]
       }
     },
+    "local-ydb-toolkit": {
+      "sha": "82e334dd792cebbcdbc9fb91610614697746e41c",
+      "version": "0.1.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "local-ydb",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "local-ydb",
+            "description": "Operate local-ydb deployments, especially Docker setups using ghcr.io/ydb-platform/local-ydb, CMS-created tenants, Grap…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `local-ydb-toolkit`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/astandrik/local-ydb-toolkit.git` at `82e334dd792cebbcdbc9fb91610614697746e41c`
- Homepage: https://local-ydb-toolkit.ydb-qdrant.tech/

The generated component index detects plugin version `0.1.1`, the `local-ydb` skill, and the `local-ydb` stdio MCP server pinned to `@astandrik/local-ydb-mcp@0.15.4`.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the verified publisher identity used by this plugin. The publisher is the same GitHub account, `astandrik`; there is no separate organization account.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] Remote source pins a public, reachable full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally, including under Python 3.11 used by CI.
- [x] Homepage and clear description are set.
- [x] License is stated as MIT in the source plugin manifests and root `LICENSE`.

## Security

- [x] No `curl | bash`, remote-code download/exec, `postinstall`, hooks, or obfuscated payloads.
- [x] No secret discovery or exfiltration. The MCP reads only explicitly configured non-secret settings and credential files referenced by the selected local profile.
- [x] MCP scope is limited to 39 Local YDB operations. Mutations are plan-first and require explicit `confirm: true`; the plugin has no lifecycle hooks.

Network endpoints this plugin calls, and why:

- `registry.npmjs.org`: `npx` resolves the exact MCP package version on first launch.
- The user-configured local or SSH host plus its YDB gRPC/monitoring endpoints: only for requested inspection or operations.
- `ghcr.io` and Docker Hub registry/auth endpoints: only for requested image pulls or allowlisted version discovery.
- `github.com` / `api.github.com`: only when the user explicitly follows the skill workflow to inspect upstream YDB source.

Credentials/permissions it requires, and why:

- Access to the local Docker daemon, or to the explicitly configured SSH target, for requested deployment operations.
- Optional YDB username/password files and SSH credentials referenced from the user-controlled config. Credentials remain local and are not marketplace fields or telemetry.

## Validation evidence

- Catalog validator: passed.
- Generated index freshness check: passed on Python 3.11.
- Published MCP protocol smoke: initialize/list passed with exactly 39 tools.
- Source SHA equals public repository HEAD at submission time.
- Homepage returned HTTP 200.

## Notes for reviewers

Local YDB Toolkit is an MIT-licensed project published and maintained by `astandrik`. The skill explicitly states that it cannot claim Docker/YDB access without a connected shell or MCP runtime, and requires read-only discovery plus rollback planning before risky operations.