### PR TITLE
Add whitepact plugin (MCP server + skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,17 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "whitepact",
+      "description": "AI governance MCP server (MCP Server + Skill): trust scoring, PII/harmful-content guardrails, hallucination detection, and compliance checks (NIST AI RMF, EU AI Act, ISO 42001) for any AI agent action or output. All 27 tools are read-only.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/whitepact"
+      },
+      "homepage": "https://github.com/Guruprasath-Annadurai/Whitepact",
+      "keywords": ["whitepact", "ai governance", "trust score", "pii scan", "compliance check", "guardrails"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -897,6 +897,23 @@
         ]
       }
     },
+    "whitepact": {
+      "version": "1.2.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "whitepact",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "whitepact",
+            "description": "AI governance and trust layer for checking whether an AI agent's action or output is safe, fair, compliant, and account…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "5593a1e2ab5ceafe56c3e76b64ed98bb5ed449bd",
       "version": "1.16.0",

--- a/external_plugins/whitepact/.grok-plugin/plugin.json
+++ b/external_plugins/whitepact/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "whitepact",
+  "version": "1.2.3",
+  "description": "AI governance MCP server: trust scoring, PII/harmful-content guardrails, hallucination detection, and compliance checks (NIST AI RMF, EU AI Act, ISO 42001) for any AI agent's actions.",
+  "author": {
+    "name": "WhitePact",
+    "url": "https://github.com/Guruprasath-Annadurai/Whitepact"
+  },
+  "homepage": "https://github.com/Guruprasath-Annadurai/Whitepact",
+  "repository": "https://github.com/Guruprasath-Annadurai/Whitepact",
+  "license": "MIT",
+  "keywords": ["whitepact", "ai governance", "trust score", "pii scan", "compliance", "guardrails", "hallucination detection"]
+}

--- a/external_plugins/whitepact/.mcp.json
+++ b/external_plugins/whitepact/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "whitepact": {
+      "type": "http",
+      "url": "https://whitepact-mcp-http.onrender.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${WHITEPACT_API_KEY}"
+      }
+    }
+  }
+}

--- a/external_plugins/whitepact/README.md
+++ b/external_plugins/whitepact/README.md
@@ -2,8 +2,13 @@
 
 AI governance MCP server: trust scoring, PII/harmful-content guardrails,
 hallucination detection, and compliance checks (NIST AI RMF, EU AI Act,
-ISO 42001) for any AI agent's actions or outputs. 27 tools, all
-read-only — WhitePact evaluates and reports, it never mutates state.
+ISO 42001) for AI-agent actions or outputs. The current MCP surface exposes
+30 tools and 20 advertised resources.
+
+The MCP tool definitions are annotated read-only/non-destructive. On the
+hosted service, WhitePact may still record service-side usage, authentication,
+and governance/evidence records as part of operating the service; that is
+separate from exposing a destructive MCP tool to the calling agent.
 
 - Homepage / source: https://github.com/Guruprasath-Annadurai/Whitepact
 - License: MIT
@@ -18,29 +23,34 @@ read-only — WhitePact evaluates and reports, it never mutates state.
   WhitePact's tools — PII scanning, trust scoring, compliance checks,
   red-teaming, and governance decisions.
 
-## Network endpoints and credentials
+## Network endpoint and credentials
 
-This plugin's MCP server calls exactly one endpoint:
+The plugin itself connects Grok Build to one MCP endpoint:
 
 - `https://whitepact-mcp-http.onrender.com/mcp` (Streamable HTTP)
 
 Authentication is a Bearer API key, read from the `WHITEPACT_API_KEY`
 environment variable and substituted into the request's `Authorization`
-header — see `.mcp.json`. No other network calls, no telemetry, no file
-or secret access beyond reading that one environment variable.
+header — see `.mcp.json`. The plugin configuration does not add telemetry or
+additional local-file access. Individual WhitePact tools/services may perform
+the network or persistence behavior documented by the upstream WhitePact
+project; consult the source repository for the exact current behavior.
 
 ## Setup
 
-1. Get a WhitePact API key from the WhitePact dashboard (a free org is
-   enough to try it; the hosted transport used here requires the org be
-   on a plan with hosted MCP access — the completely free path is
-   self-hosting the `stdio` transport directly, see the main repo).
+1. Obtain a WhitePact API key. The hosted transport used by this plugin
+   requires an organization/plan with hosted MCP access; the self-hosted
+   `stdio` transport is the separate local-install path documented in the
+   main WhitePact repository.
 2. `export WHITEPACT_API_KEY=...` before Grok Build loads this plugin.
-3. WhitePact's 27 tools become available to Grok Build.
+3. WhitePact's current 30-tool MCP surface becomes available to Grok Build,
+   subject to the hosted service's authentication, plan, and governance
+   controls.
 
 ## Safe test prompt
 
 > "Use whitepact's rai_scan tool to check this text for PII: 'Contact
 > John at john@example.com or 555-123-4567.'"
 
-Expected: a redacted copy and a list of PII findings, no writes.
+Expected: the current `rai_scan` result identifies the PII and provides its
+redacted representation; it should not invoke a destructive agent action.

--- a/external_plugins/whitepact/README.md
+++ b/external_plugins/whitepact/README.md
@@ -1,0 +1,46 @@
+# WhitePact
+
+AI governance MCP server: trust scoring, PII/harmful-content guardrails,
+hallucination detection, and compliance checks (NIST AI RMF, EU AI Act,
+ISO 42001) for any AI agent's actions or outputs. 27 tools, all
+read-only — WhitePact evaluates and reports, it never mutates state.
+
+- Homepage / source: https://github.com/Guruprasath-Annadurai/Whitepact
+- License: MIT
+- Registry: listed on the official MCP Registry
+  (`io.github.Guruprasath-Annadurai/whitepact`)
+
+## What this plugin bundles
+
+- An MCP server config (`.mcp.json`) pointing at WhitePact's hosted
+  Streamable HTTP endpoint.
+- A skill (`skills/whitepact/SKILL.md`) describing when to reach for
+  WhitePact's tools — PII scanning, trust scoring, compliance checks,
+  red-teaming, and governance decisions.
+
+## Network endpoints and credentials
+
+This plugin's MCP server calls exactly one endpoint:
+
+- `https://whitepact-mcp-http.onrender.com/mcp` (Streamable HTTP)
+
+Authentication is a Bearer API key, read from the `WHITEPACT_API_KEY`
+environment variable and substituted into the request's `Authorization`
+header — see `.mcp.json`. No other network calls, no telemetry, no file
+or secret access beyond reading that one environment variable.
+
+## Setup
+
+1. Get a WhitePact API key from the WhitePact dashboard (a free org is
+   enough to try it; the hosted transport used here requires the org be
+   on a plan with hosted MCP access — the completely free path is
+   self-hosting the `stdio` transport directly, see the main repo).
+2. `export WHITEPACT_API_KEY=...` before Grok Build loads this plugin.
+3. WhitePact's 27 tools become available to Grok Build.
+
+## Safe test prompt
+
+> "Use whitepact's rai_scan tool to check this text for PII: 'Contact
+> John at john@example.com or 555-123-4567.'"
+
+Expected: a redacted copy and a list of PII findings, no writes.

--- a/external_plugins/whitepact/skills/whitepact/SKILL.md
+++ b/external_plugins/whitepact/skills/whitepact/SKILL.md
@@ -16,36 +16,43 @@ description: >-
 # WhitePact
 
 WhitePact is an AI governance MCP server — a trust and safety layer that
-sits in front of an agent's actions and outputs, not another model. All 27
-tools are read-only: WhitePact evaluates and reports, it never mutates
-state or acts on an agent's behalf.
+sits in front of agent actions and outputs, not another model. Its current
+MCP surface exposes 30 tools and 20 advertised resources. The tool
+definitions are annotated read-only/non-destructive; the hosted WhitePact
+service may still record usage, authentication, and governance/evidence
+records as part of operating the service.
 
 ## When to use this
 
 - Before letting an agent act on untrusted input: scan it for PII or
   harmful content (`rai_scan`).
-- Before trusting a model's claim or output: score it for factual
-  reliability (`rai_trust_score`, `rai_hallucination`).
+- Before trusting a model's claim or output: evaluate it with the relevant
+  trust/hallucination tools (`rai_trust_score`, `rai_hallucination`).
 - When a task needs regulatory grounding: check against NIST AI RMF, the
   EU AI Act, or ISO 42001 (`rai_eu_ai_act_classify`, `rai_iso42001_gap`).
-- Before allowing a proposed agent action to proceed: evaluate it against
-  policy rules for a deterministic ALLOW / ALLOW_WITH_REDACTION /
-  REQUIRE_APPROVAL / DENY / QUARANTINE decision (`rai_policy_check`).
+- For deterministic governance-policy evaluation, use the tool whose
+  documented input contract matches the requested policy/action check; do
+  not invent execution authority that the exposed tool does not provide.
 - To stress-test a prompt or system for adversarial robustness
   (`rai_redteam_analyze`, `rai_redteam_payloads`).
+- For persistent-memory and causal-influence checks, use the current
+  `rai_memory_write_check`, `rai_memory_read_check`, and
+  `rai_causal_influence_check` tools where their documented schemas fit.
 
 ## Setup
 
-Requires a WhitePact API key (free tier available — self-hosted `stdio`
-transport has no quota limit at all; the hosted transport used by this
-plugin requires an org on a plan with hosted access). Get one from the
-WhitePact dashboard, then set `WHITEPACT_API_KEY` in your environment
+Requires a WhitePact API key for the hosted endpoint. The hosted transport
+used by this plugin requires an organization/plan with hosted MCP access;
+the self-hosted `stdio` transport is a separate local-install path described
+in the main WhitePact repository. Set `WHITEPACT_API_KEY` in your environment
 before Grok Build loads this plugin's MCP server.
 
-## Network endpoints and credentials this plugin uses
+## Network endpoint and credentials this plugin uses
 
-- `https://whitepact-mcp-http.onrender.com/mcp` — the only network
-  endpoint this plugin calls, over Streamable HTTP, authenticated with a
-  Bearer API key you provide via `WHITEPACT_API_KEY`.
-- No other network calls, no telemetry, no local file/secret access
-  beyond reading that one environment variable to build the auth header.
+- `https://whitepact-mcp-http.onrender.com/mcp` — the MCP endpoint this
+  plugin configuration connects to over Streamable HTTP, authenticated with
+  the Bearer API key provided via `WHITEPACT_API_KEY`.
+- The plugin configuration itself adds no extra telemetry or local-file
+  access beyond reading that environment variable to construct the auth
+  header. Individual upstream WhitePact tools/services may have network or
+  persistence behavior documented in the WhitePact source repository.

--- a/external_plugins/whitepact/skills/whitepact/SKILL.md
+++ b/external_plugins/whitepact/skills/whitepact/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: whitepact
+description: >-
+  AI governance and trust layer for checking whether an AI agent's action or
+  output is safe, fair, compliant, and accountable before or after it happens.
+  Use whenever the task involves: scanning text for PII or harmful content
+  ("scan for PII", "redact sensitive data"), scoring how trustworthy a claim
+  or model output is ("trust score", "is this hallucinating", "fact-check
+  this claim"), checking regulatory compliance ("EU AI Act", "NIST AI RMF",
+  "ISO 42001", "is this compliant"), red-teaming a prompt for adversarial
+  robustness, or deciding whether a proposed agent action should be allowed,
+  redacted, held for approval, denied, or quarantined ("governance
+  decision", "should this action be allowed").
+---
+
+# WhitePact
+
+WhitePact is an AI governance MCP server — a trust and safety layer that
+sits in front of an agent's actions and outputs, not another model. All 27
+tools are read-only: WhitePact evaluates and reports, it never mutates
+state or acts on an agent's behalf.
+
+## When to use this
+
+- Before letting an agent act on untrusted input: scan it for PII or
+  harmful content (`rai_scan`).
+- Before trusting a model's claim or output: score it for factual
+  reliability (`rai_trust_score`, `rai_hallucination`).
+- When a task needs regulatory grounding: check against NIST AI RMF, the
+  EU AI Act, or ISO 42001 (`rai_eu_ai_act_classify`, `rai_iso42001_gap`).
+- Before allowing a proposed agent action to proceed: evaluate it against
+  policy rules for a deterministic ALLOW / ALLOW_WITH_REDACTION /
+  REQUIRE_APPROVAL / DENY / QUARANTINE decision (`rai_policy_check`).
+- To stress-test a prompt or system for adversarial robustness
+  (`rai_redteam_analyze`, `rai_redteam_payloads`).
+
+## Setup
+
+Requires a WhitePact API key (free tier available — self-hosted `stdio`
+transport has no quota limit at all; the hosted transport used by this
+plugin requires an org on a plan with hosted access). Get one from the
+WhitePact dashboard, then set `WHITEPACT_API_KEY` in your environment
+before Grok Build loads this plugin's MCP server.
+
+## Network endpoints and credentials this plugin uses
+
+- `https://whitepact-mcp-http.onrender.com/mcp` — the only network
+  endpoint this plugin calls, over Streamable HTTP, authenticated with a
+  Bearer API key you provide via `WHITEPACT_API_KEY`.
+- No other network calls, no telemetry, no local file/secret access
+  beyond reading that one environment variable to build the auth header.


### PR DESCRIPTION
## What this PR does

- Plugin name: whitepact
- Type: local (external_plugins)
- Vendored path: ./external_plugins/whitepact
- Homepage: https://github.com/Guruprasath-Annadurai/Whitepact

WhitePact is an AI governance MCP server: trust scoring, PII/harmful-
content guardrails, hallucination detection, and compliance checks
(NIST AI RMF, EU AI Act, ISO 42001) for any AI agent's actions or
outputs. All 27 tools are read-only.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Local source — no SHA needed.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; includes `README.md` + `.grok-plugin/plugin.json`.
- [x] License stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; all 27 MCP tools are read-only).
- Network endpoints this plugin calls (and why): `https://whitepact-mcp-http.onrender.com/mcp` (Streamable HTTP) — the plugin's only network call, to reach WhitePact's hosted governance/trust tools.
- Credentials/permissions it requires (and why): a Bearer API key via `WHITEPACT_API_KEY`, used only to authenticate that one MCP endpoint.

## Notes for reviewers

WhitePact is independently listed on the official MCP Registry (`io.github.Guruprasath-Annadurai/whitepact`) and Smithery. Source repo is my own official org (`Guruprasath-Annadurai/Whitepact`), matching the plugin's branding.