### PR TITLE
Add WordPress.com plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "wordpress-com",
+      "description": "Official WordPress.com integration for Grok Build. Connect with OAuth to manage WordPress.com sites and create native, editable WordPress block content through the WordPress.com MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Automattic/grok-wpcom-plugin.git",
+        "sha": "4c3e0adbd29959c84527300b908dd5f7344228f4"
+      },
+      "homepage": "https://wordpress.com",
+      "keywords": ["wordpress.com", "wordpress.com mcp", "wordpress.com site"],
+      "domains": ["wordpress.com", "public-api.wordpress.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -248,7 +248,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Automattic/grok-wpcom-plugin.git",
-        "sha": "4c3e0adbd29959c84527300b908dd5f7344228f4"
+        "sha": "7ed1f234bdd953b5a1b9313b15236d4d19021403"
       },
       "homepage": "https://wordpress.com",
       "keywords": ["wordpress.com", "wordpress.com mcp", "wordpress.com site"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -942,6 +942,24 @@
           }
         ]
       }
+    },
+    "wordpress-com": {
+      "sha": "4c3e0adbd29959c84527300b908dd5f7344228f4",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wordpress-com",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "edit-wordpress-block-content",
+            "description": "Create and edit serialized WordPress block content for posts, pages, patterns, templates, and template parts. Use when…"
+          }
+        ]
+      }
     }
   }
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -944,7 +944,7 @@
       }
     },
     "wordpress-com": {
-      "sha": "4c3e0adbd29959c84527300b908dd5f7344228f4",
+      "sha": "7ed1f234bdd953b5a1b9313b15236d4d19021403",
       "version": "0.1.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the official WordPress.com plugin for Grok Build. The plugin connects Grok to the WordPress.com MCP server through browser-based OAuth and includes guidance for creating native, editable WordPress block content.

- Plugin name: `wordpress-com`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Automattic/grok-wpcom-plugin.git` at `7ed1f234bdd953b5a1b9313b15236d4d19021403`
- Homepage: https://wordpress.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The plugin is maintained by Automattic, the company behind WordPress.com, in the official `Automattic` GitHub organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with the kebab-case name `wordpress-com`.
- [x] The remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the upstream plugin includes `README.md` and `.grok-plugin/plugin.json`.
- [x] The GPL-2.0-or-later license is stated in the plugin manifest and the upstream repository includes the license text.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] The plugin contains no hooks or local executables; its MCP scope is limited to the declared WordPress.com server.
- Network endpoints this plugin calls (and why): `https://public-api.wordpress.com/wpcom/v2/mcp/v1`, the official WordPress.com MCP endpoint used for site and content operations. Browser OAuth uses WordPress.com authorization endpoints discovered through the MCP authorization flow.
- Credentials/permissions it requires (and why): a WordPress.com account and the WordPress.com MCP actions explicitly enabled by the user. OAuth credentials are managed by Grok and are not bundled with or read by the plugin.

## Notes for reviewers

The pinned plugin includes a square WordPress.com app icon for marketplace and Grok Bot plugin surfaces. Grok Build 1.0.3 validated the manifest and logo path, discovered the skill and HTTP MCP server, completed WordPress.com OAuth, and successfully executed the read-only site-listing workflow, including pagination, without mutations.

AI assistance disclosure: OpenAI GPT-5.6 Sol was used through OpenCode to inspect the marketplace contract, prepare the catalog entry, regenerate the component index, and run the reported validation. Chris Huber reviewed and is responsible for the submission.
