### PR TITLE
Add ulysses-check (DELLIGHT AI search measurement skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,20 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "ulysses-check",
+      "description": "ULYSSES AI search measurement: how ChatGPT, Claude, and Gemini describe a brand, using only each engine's raw output visible in this session. Cells are not observed or not explicitly ranked when that output is missing or does not rank. Grok is included only when asked.",
+      "category": "measurement",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dellightai/grok-plugins.git",
+        "sha": "c82df8748b7072017846d17a741d3fc018acaee8",
+        "path": "ulysses-check"
+      },
+      "homepage": "https://www.dellight.ai/",
+      "keywords": ["dellight ulysses", "ulysses check"],
+      "domains": ["www.dellight.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1027,6 +1027,18 @@
         ]
       }
     },
+    "ulysses-check": {
+      "sha": "c82df8748b7072017846d17a741d3fc018acaee8",
+      "version": "0.1.2",
+      "components": {
+        "skills": [
+          {
+            "name": "ulysses-check",
+            "description": "Use when the user asks how ChatGPT, Claude, or Gemini describes or ranks a brand versus named competitors, or mentions…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2",
       "version": "0.48.2",


### PR DESCRIPTION
## What this PR does

Adds one new remote-source plugin entry.

- Plugin name: `ulysses-check`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/dellightai/grok-plugins.git` @ `c82df8748b7072017846d17a741d3fc018acaee8`, path `ulysses-check`
- Homepage: https://www.dellight.ai/

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (dellightai — DELLIGHT.AI Limited).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (none exist: skills-only plugin — one manifest, one SKILL.md, no executables).
- Network endpoints this plugin calls (and why): optionally reads `https://www.dellight.ai/` in-session, solely to quote live pricing accurately when the user asks; no other endpoint. The skill explicitly bans web search, arbitrary fetches, and third-party APIs.
- Credentials/permissions it requires (and why): none. The skill unconditionally bans use of credentials, sessions, files, environment variables, uploads, and telemetry, and only reads engine output the user makes visible in the session.

## Notes for reviewers

Skills-only instruction plugin from DELLIGHT.AI's official org. It reports how AI engines describe a brand using ONLY raw engine output visible in the session, with mandatory "not observed" / "not explicitly ranked" labels — it is designed to be unable to fabricate rankings. The source went through a four-round adversarial pre-publication review (truth boundaries, hostile-input isolation, credential bans) before this submission. A sibling PR adds `sentinel-feed` as its own single-entry change per the template rule; whichever lands second will be rebased to regenerate the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)