### PR TITLE
feat: add Flueny coding-fluency plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -243,12 +243,12 @@
     },
     {
       "name": "flueny",
-      "description": "Measures how you work with Grok or Claude Code and shows it to you first. Derived signal only: prompts, code, and file contents never leave the machine.",
+      "description": "Measures how you work with Grok and shows it to you first. Derived signal only: prompts, code, and file contents never leave the machine.",
       "category": "productivity",
       "source": {
         "source": "url",
-        "url": "https://github.com/FluenyAI/app-plugin-claude-code.git",
-        "sha": "ad6d058cb6a9befcfc733fda55be294163a6d830"
+        "url": "https://github.com/FluenyAI/app-plugin-grok.git",
+        "sha": "5c5c032fb296ddc13d76de42a9d2ee48db403c82"
       },
       "homepage": "https://flueny.ai",
       "keywords": ["flueny", "flueny coding", "coding fluency"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "flueny",
+      "description": "Measures how you work with Grok or Claude Code and shows it to you first. Derived signal only: prompts, code, and file contents never leave the machine.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/FluenyAI/app-plugin-claude-code.git",
+        "sha": "dbd690eaa612a2348192db44dbabc1f8369c9cd3"
+      },
+      "homepage": "https://flueny.ai",
+      "keywords": ["flueny", "flueny coding", "coding fluency"],
+      "domains": ["flueny.ai"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -248,7 +248,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FluenyAI/app-plugin-claude-code.git",
-        "sha": "dbd690eaa612a2348192db44dbabc1f8369c9cd3"
+        "sha": "ad6d058cb6a9befcfc733fda55be294163a6d830"
       },
       "homepage": "https://flueny.ai",
       "keywords": ["flueny", "flueny coding", "coding fluency"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,7 +328,7 @@
       }
     },
     "flueny": {
-      "sha": "ad6d058cb6a9befcfc733fda55be294163a6d830",
+      "sha": "5c5c032fb296ddc13d76de42a9d2ee48db403c82",
       "version": "0.1.0-spike.1",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,7 +328,7 @@
       }
     },
     "flueny": {
-      "sha": "dbd690eaa612a2348192db44dbabc1f8369c9cd3",
+      "sha": "ad6d058cb6a9befcfc733fda55be294163a6d830",
       "version": "0.1.0-spike.1",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,41 @@
         ]
       }
     },
+    "flueny": {
+      "sha": "dbd690eaa612a2348192db44dbabc1f8369c9cd3",
+      "version": "0.1.0-spike.1",
+      "components": {
+        "commands": [
+          {
+            "name": "connect",
+            "description": "Connect this machine to Flueny (device sign-in, no bash required)"
+          },
+          {
+            "name": "flueny",
+            "description": "What Flueny is measuring on this machine, and how to connect it"
+          },
+          {
+            "name": "status",
+            "description": "Check whether Flueny is actually receiving anything from this machine"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "*"
+          },
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `flueny`
- Type: remote source
- Source URL + pinned SHA: https://github.com/FluenyAI/app-plugin-grok.git @ `5c5c032fb296ddc13d76de42a9d2ee48db403c82`
- Homepage: https://flueny.ai

Adds Flueny to the official Grok Build catalog from the Grok-facing source repo (`FluenyAI/app-plugin-grok`). This is not the Claude Code plugin repo.

Flueny is a coding-fluency client: slash commands (`/flueny:connect`, `/flueny:status`) and SessionStart / PostToolUse / Stop / SessionEnd hooks. Extraction runs on the machine. Only derived signal is sent to the Flueny API. Prompts, code, and file contents never leave the machine.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Published from `FluenyAI/app-plugin-grok`.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [ ] License is stated.

The plugin repo does not yet ship a LICENSE file. Happy to add one (MIT or Apache-2.0) and bump the pin if that is required to land.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://api.flueny.dev` (production default) and the org's configured Flueny API, for OAuth device sign-in (`/oauth/device`, `/oauth/token`), session handshake (`/integrations/coding/session/start`), and derived event ingest (`/integrations/coding/events`).
- Credentials/permissions it requires (and why):
  - A Flueny hook token from device OAuth, stored mode 0600 under `~/.config/flueny/credentials.grok-build.json`.
  - `--trust` so the hooks can run. Hooks are `type: command` because extraction must happen locally; an `http` hook would post the raw payload off the machine.
  - PostToolUse matcher is `*` because the product measures every tool call, not only edits. The hook fails open and prints nothing.

The plugin has no MCP servers, no skills that download binaries, and no `postinstall`.

## Notes for reviewers

- Source is `FluenyAI/app-plugin-grok`, the Grok distribution. Claude Code uses a different repo.
- `grok plugin validate` on that SHA reports name `flueny`, commands, and hooks.
