### PR TITLE
Add adspirer plugin (MCP server + skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "adspirer",
+      "description": "Manage paid media from Grok Build (MCP server + skills). Create, analyze, and optimize ad campaigns across Google Ads, Meta Ads (Facebook & Instagram), TikTok Ads, LinkedIn Ads, Amazon Ads, and ChatGPT Ads — keyword research with live CPC data, campaign creation, cross-platform performance review, wasted-spend and creative-fatigue detection, and budget optimization. New campaigns are always created paused.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Adspirer/adspirer-grok-plugin.git",
+        "sha": "f698b3a4fcbc88f35edf56bf8d6311f6826c71b1"
+      },
+      "homepage": "https://www.adspirer.com",
+      "keywords": ["adspirer", "adspirer ads", "adspirer campaign", "adspirer mcp"],
+      "domains": ["adspirer.com", "www.adspirer.com", "adspirer.ai", "mcp.adspirer.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,103 @@
 {
   "version": 1,
   "plugins": {
+    "adspirer": {
+      "sha": "f698b3a4fcbc88f35edf56bf8d6311f6826c71b1",
+      "components": {
+        "agents": [
+          {
+            "name": "performance-marketing-agent",
+            "description": "Brand-specific performance marketing agent. Use proactively when the user asks about ad campaigns, campaign performance…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "performance-review",
+            "description": "Run a cross-platform performance review for this brand"
+          },
+          {
+            "name": "refresh-brand-context",
+            "description": "Re-scan brand docs and update AGENTS.md with latest info"
+          },
+          {
+            "name": "setup",
+            "description": "Set up your brand workspace — connect to Adspirer and pull campaign data"
+          },
+          {
+            "name": "wasted-spend",
+            "description": "Find and fix wasted ad spend across all platforms"
+          },
+          {
+            "name": "write-ad-copy",
+            "description": "Write brand-voice-compliant ad copy for a specific platform"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "adspirer",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "adspirer-agent",
+            "description": "Paid-media advertising agent behavior for Adspirer — create, analyze, and optimize ad campaigns across Google Ads, Meta…"
+          },
+          {
+            "name": "adspirer-amazon-ads",
+            "description": "Create and manage Amazon Ads through Adspirer — Sponsored Products, Sponsored Brands, and Sponsored Display, with ASIN…"
+          },
+          {
+            "name": "adspirer-chatgpt-ads",
+            "description": "Create and manage ChatGPT Ads (OpenAI Ads) through Adspirer — ads that appear inside ChatGPT responses. Use for OpenAI…"
+          },
+          {
+            "name": "adspirer-creative",
+            "description": "Write and refresh ad creative with Adspirer — headlines, descriptions, primary text, and ad copy for Google, Meta, TikT…"
+          },
+          {
+            "name": "adspirer-docs",
+            "description": "Answer questions about Adspirer itself — pricing, plans, quota and tool-call limits, what Adspirer can do, connecting a…"
+          },
+          {
+            "name": "adspirer-google-ads",
+            "description": "Create and manage Google Ads campaigns through Adspirer — Search, Performance Max, Demand Gen, YouTube, and Display. Us…"
+          },
+          {
+            "name": "adspirer-launch",
+            "description": "Plan and launch a new ad campaign with Adspirer — start, create, set up, or launch campaigns on one or several platform…"
+          },
+          {
+            "name": "adspirer-linkedin-ads",
+            "description": "Create and manage LinkedIn Ads through Adspirer — sponsored content, single image, video, carousel, text ads, and lead-…"
+          },
+          {
+            "name": "adspirer-mcp",
+            "description": "How to call the Adspirer MCP hub correctly — the router two-step (action \"list_tools\" then action \"execute\" with tool_n…"
+          },
+          {
+            "name": "adspirer-meta-ads",
+            "description": "Create and manage Meta Ads (Facebook and Instagram) through Adspirer — image, video, carousel, and lead-gen campaigns,…"
+          },
+          {
+            "name": "adspirer-optimize",
+            "description": "Find and fix wasted ad spend with Adspirer — cut spend that isn't converting, add negative keywords, exclude audiences…"
+          },
+          {
+            "name": "adspirer-performance-review",
+            "description": "Review ad performance across platforms with Adspirer — how are my ads doing, weekly or monthly reports, a cross-channel…"
+          },
+          {
+            "name": "adspirer-setup",
+            "description": "Set up your brand workspace — connect to Adspirer, scan brand docs, pull campaign data, and create AGENTS.md. Use on fi…"
+          },
+          {
+            "name": "adspirer-tiktok-ads",
+            "description": "Create and manage TikTok Ads through Adspirer — in-feed video, Spark Ads, carousel, app promotion, and conversions camp…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

New third-party plugin: **Adspirer** — paid-media management for Grok Build. Create, analyze, and optimize ad campaigns across Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, Amazon Ads, and ChatGPT Ads through Adspirer's hosted MCP server, with 14 skills, 5 slash commands, and a performance-marketing subagent.

- Plugin name: `adspirer`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Adspirer/adspirer-grok-plugin.git` @ `f698b3a4fcbc88f35edf56bf8d6311f6826c71b1`
- Homepage: https://www.adspirer.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

`Adspirer/adspirer-grok-plugin` is a generated distribution repo under our company org. The upstream source of truth is our public monorepo [`amekala/ads-mcp`](https://github.com/amekala/ads-mcp) (maintainer's account), which also feeds our Claude, Cursor, Codex, Gemini, and ChatGPT distributions. First-party ownership is independently verifiable: the official MCP Registry lists the server under the DNS-verified `com.adspirer` namespace with that repo as its `repository.url`.

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` in kebab-case and unique.
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] `.grok-plugin/plugin-index.json` regenerated and committed.
- [x] `homepage` + clear `description`; brand-scoped `keywords`/`domains`; `category` set.
- [x] The plugin is licensed and the license is stated (MIT, in `plugin.json` and `LICENSE`).
- [x] I've read Security expectations and the plugin complies.

Ran locally: `validate-catalog.py` ✓, `generate-plugin-index.py` ✓, `generate-plugin-index.py --check` ✓.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege — the plugin ships **no hooks, no scripts, no LSP servers**; it is skills, commands, one agent definition, and one `.mcp.json`. Nothing in it executes code on the user's machine.
- Network endpoints this plugin calls (and why): `https://mcp.adspirer.com/mcp` — the only endpoint; streamable-HTTP MCP server through which all campaign reads/writes go. `https://www.adspirer.com` appears in prose only (sign-in/docs links), never called by the plugin.
- Credentials/permissions it requires (and why): OAuth 2.1 with PKCE + dynamic client registration (RFC 7591), handled by Grok's MCP client on first connection. No API keys, no local credential files, no env vars. Ad-platform tokens are held server-side, scoped to accounts the user explicitly connects.

Safety posture worth noting for an ads product: all new campaigns are created **PAUSED**, and no budget change or campaign deletion happens without explicit user approval — this is enforced in the skills and the agent prompt.

## Notes for reviewers

- **Update flow:** the source repo is auto-generated from `ads-mcp` by a daily sync workflow and only receives a commit when plugin content actually changes — so your nightly SHA bump will see HEAD move exactly when there's a real plugin release, not on unrelated monorepo commits. We intentionally omit `version` and rely on your bump script's "both lack version → SHA is the identity" path; if you'd prefer a version field, happy to add one.
- **`category: "marketing"`** is new to the catalog — closest honest fit for an ads-management plugin. Fine to change if you'd rather slot it elsewhere.
- Keywords/domains are deliberately brand-scoped (`adspirer`, our domains only) per the contribution guide — no generic `ads`/`google ads` terms that could mis-fire the CTA.