### PR TITLE
Add rab plugin (RAB reactive state skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "rab",
+      "description": "Skills for the RAB reactive state architecture: write @rabjs/react code with the right conventions, debug live rab apps over CDP, and drive the React Native debug bridge.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ximing/rab.git",
+        "sha": "05105fd23e9d183a10d58c2fc50d1a3f80d78331"
+      },
+      "homepage": "https://github.com/ximing/rab",
+      "keywords": ["rab", "rabjs", "rab react", "rabjs react", "rab debug"],
+      "domains": ["ximing.github.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -745,6 +745,26 @@
         ]
       }
     },
+    "rab": {
+      "sha": "05105fd23e9d183a10d58c2fc50d1a3f80d78331",
+      "version": "9.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "rab-cdp-debug",
+            "description": "用于指导 Agent 通过 Chrome DevTools MCP 的 `evaluate_script` 工具，结合 `window.__RS_ROOT_CONTAINER__` API 对 `@rabjs/react` 应用进行逻辑验…"
+          },
+          {
+            "name": "rab-react",
+            "description": "React响应式状态管理库，用于 `@rabjs/react` 包的 React 响应式开发指导。当用户提到 `@rabjs/react`、响应式组件、`RSRoot`、`RSStrict`、`observer`、`view`、`useS…"
+          },
+          {
+            "name": "rab-rn-debug",
+            "description": "用于指导 Agent 通过本地调试服务（rab-rn-debug）以 HTTP 指令调试 React Native 真机/模拟器上的 @rabjs 应用。当用户提到 RN Service 逻辑验证、调试移动端 rab 应用、真机/模拟器…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "950acebcef3445f3915ea0709876c3ba9c237a7f",
       "version": "1.4.0",


### PR DESCRIPTION
## Summary

Adds a catalog entry for **rab**, pointing at [ximing/rab](https://github.com/ximing/rab) (pinned to commit `05105fd23e9d183a10d58c2fc50d1a3f80d78331`).

RAB is an AI-first reactive state architecture for React and React Native: observable `Service` instances in dependency containers, where humans, tests, and agents operate on the same named state surface. The plugin ships three skills:

| Skill | Purpose |
| --- | --- |
| `rab-react` | Write `@rabjs/react` code with the right conventions (`observer`, `useService`, `bindServices`, Service lifecycle, async state models). |
| `rab-cdp-debug` | Inspect, call, and assert Service instances of a running rab app via Chrome DevTools MCP `evaluate_script`. |
| `rab-rn-debug` | Debug a React Native app on device/emulator through the `@rabjs/rn-debug-server` local bridge (structured HTTP commands, assertions, console log pull). |

## Submission checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, kebab-case unique name (`rab`)
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable
- [x] `.grok-plugin/plugin-index.json` regenerated via `scripts/generate-plugin-index.py` and committed
- [x] `scripts/validate-catalog.py` and `generate-plugin-index.py --check` both pass locally
- [x] `homepage` set, clear `description`, brand-scoped `keywords`/`domains`, `category: development`
- [x] Upstream plugin carries a `.claude-plugin/plugin.json` manifest (accepted for Claude-ecosystem plugins), MIT licensed
- [x] I own the upstream repository

## Security

The plugin is documentation-only skills — no hooks, no MCP servers, no scripts, no network access at install time. `rab-cdp-debug` assumes the user has already configured Chrome DevTools MCP; `rab-rn-debug` only drives a plain HTTP API on `localhost` served by the user's own debug server. No declared endpoints or credentials required.