### PR TITLE
Add csi plugin (remote source, skills-only)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -248,7 +248,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ximing/csi.git",
-        "sha": "b65bba9cf293e956cb2e4c1b2c045a45a3ff2885"
+        "sha": "42799971e18f4efcc1c28577a6c793a68192c26f"
       },
       "homepage": "https://github.com/ximing/csi",
       "keywords": ["csi", "csi browser", "csi daemon", "csi e2e"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,18 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "csi",
+      "description": "Let the agent drive your real Chrome browser — navigate, click, type, read pages, screenshot, save PDF — through the local CSI daemon using your real login sessions; includes csi-e2e, which turns natural-language browser scenarios into replayable e2e regression suites.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ximing/csi.git",
+        "sha": "b65bba9cf293e956cb2e4c1b2c045a45a3ff2885"
+      },
+      "homepage": "https://github.com/ximing/csi",
+      "keywords": ["csi", "csi browser", "csi daemon", "csi e2e"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,22 @@
         ]
       }
     },
+    "csi": {
+      "sha": "b65bba9cf293e956cb2e4c1b2c045a45a3ff2885",
+      "version": "0.3.0",
+      "components": {
+        "skills": [
+          {
+            "name": "csi",
+            "description": "CSI lets AI control the user's real Chrome browser — navigate, click, type, read, screenshot, save as PDF, and interact…"
+          },
+          {
+            "name": "csi-e2e",
+            "description": "Turn natural-language browser scenarios into replayable e2e regression suites driven by the csi daemon (real Chrome). W…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -182,7 +182,7 @@
       }
     },
     "csi": {
-      "sha": "b65bba9cf293e956cb2e4c1b2c045a45a3ff2885",
+      "sha": "42799971e18f4efcc1c28577a6c793a68192c26f",
       "version": "0.3.0",
       "components": {
         "skills": [


### PR DESCRIPTION
## What this PR does

- Plugin name: `csi`
- Type: remote source
- Source URL + pinned SHA: https://github.com/ximing/csi.git @ `42799971e18f4efcc1c28577a6c793a68192c26f` (current master HEAD, public and reachable)
- Homepage: https://github.com/ximing/csi

New catalog entry at the end of `.grok-plugin/marketplace.json` + regenerated `plugin-index.json`. The pinned sha was bumped once after the source repo added its LICENSE (see below) — same entry, no parallel update.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below). — csi is a personal open-source project; `ximing/csi` is the canonical repo and the brand matches the source.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally (Catalog OK).
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (Plugin index OK).
- [x] `homepage` + clear `description` set.
- [x] License is stated. — PolyForm Noncommercial 1.0.0 ([LICENSE](https://github.com/ximing/csi/blob/master/LICENSE)), also declared as `license` in the plugin manifests.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): **none**. The pinned commit ships two pure-documentation skills (`csi`, `csi-e2e`) — `SKILL.md` + `references/` + template files + LICENSE. No hooks, no MCP servers, no scripts, no postinstall, no network access in the plugin payload itself. (The skills instruct the agent to talk to the user's own locally-running daemon at `127.0.0.1:10088` via curl — a loopback HTTP API on the user's machine, documented at https://github.com/ximing/csi/blob/master/docs/protocol.md.)
- Credentials/permissions it requires (and why): none.

## Notes for reviewers

- The plugin is skills-only; `plugin-index.json` shows exactly the two skills and nothing else.
- Brand-scoped keywords (`csi`, `csi browser`, `csi daemon`, `csi e2e`); `domains` omitted since the project has no custom domain (site is GitHub Pages under github.io).
- Same files are already distributed as plugins for Claude Code, Codex, Cursor, Kimi Code, OpenCode, and Pi via thin manifests in the repo.