### PR TITLE
Add converly plugin (conversion tracking for ad platforms)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -243,7 +243,7 @@
     },
     {
       "name": "converly",
-      "description": "Converly conversion tracking integration. Connect ad platforms (Google Ads, Meta, GA4, LinkedIn, TikTok), build and publish conversion flows that fire when a form is submitted, get the tracking snippet onto a website, and check whether each conversion reached every platform. Authorize with your own Converly account on first use; ad platform credentials are never handled by the plugin.",
+      "description": "Converly is the easiest way to set up server-side conversion tracking in Google Ads, Meta Ads, X Ads, LinkedIn Ads, Microsoft Ads and more. The plugin makes it easy to set up. Simply tell Grok 'Set up conversion tracking in Google Ads when someone submits a form on my Webflow website' and it will build the conversion flow, connect your Google Ads account, publish it, and test it all works.",
       "category": "marketing",
       "source": {
         "source": "url",
@@ -251,7 +251,7 @@
         "sha": "15b8485d3b0a94f6af38d19e371c83906fa5adf8"
       },
       "homepage": "https://converly.io/mcp",
-      "keywords": ["converly", "converly tracking", "converly conversion", "converly flow"],
+      "keywords": ["converly", "converly conversion tracking", "converly google ads", "converly meta capi", "converly flow"],
       "domains": ["converly.io", "app.converly.io"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "converly",
+      "description": "Converly conversion tracking integration. Connect ad platforms (Google Ads, Meta, GA4, LinkedIn, TikTok), build and publish conversion flows that fire when a form is submitted, get the tracking snippet onto a website, and check whether each conversion reached every platform. Authorize with your own Converly account on first use; ad platform credentials are never handled by the plugin.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/converlyio/converly-mcp.git",
+        "sha": "15b8485d3b0a94f6af38d19e371c83906fa5adf8"
+      },
+      "homepage": "https://converly.io/mcp",
+      "keywords": ["converly", "converly tracking", "converly conversion", "converly flow"],
+      "domains": ["converly.io", "app.converly.io"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -243,7 +243,7 @@
     },
     {
       "name": "converly",
-      "description": "Converly is the easiest way to set up server-side conversion tracking in Google Ads, Meta Ads, X Ads, LinkedIn Ads, Microsoft Ads and more. The plugin makes it easy to set up. Simply tell Grok 'Set up conversion tracking in Google Ads when someone submits a form on my Webflow website' and it will build the conversion flow, connect your Google Ads account, publish it, and test it all works.",
+      "description": "Converly is the easiest way to set up server-side conversion tracking in Google Ads, Meta Ads, X Ads, LinkedIn Ads, Microsoft Ads and more. The plugin makes it easy to setup. Simply tell Grok to 'Setup conversion tracking in Google Ads when someone submits a form on my Webflow website' and it will build the conversion flow, connect your Google Ads account, publish it, and test it all works.",
       "category": "marketing",
       "source": {
         "source": "url",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,28 @@
         ]
       }
     },
+    "converly": {
+      "sha": "15b8485d3b0a94f6af38d19e371c83906fa5adf8",
+      "version": "1.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "converly",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "diagnose-missing-conversions",
+            "description": "Find out why Converly conversions aren't showing up. Use when the user says tracking isn't working, conversions are mis…"
+          },
+          {
+            "name": "setup-conversion-tracking",
+            "description": "Set up Converly conversion tracking end to end. Use when the user wants to track form submissions as conversions, send…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
Adds one catalog entry for **Converly**, a server-side conversion tracking platform. Source is pinned to a full commit SHA on a public repo under our own org.

**Plugin:** https://github.com/converlyio/converly-mcp (pinned `15b8485d3b0a94f6af38d19e371c83906fa5adf8`)
**Homepage:** https://converly.io/mcp

## What it does

Converly is the easiest way to set up server-side conversion tracking in Google Ads, Meta Ads, X Ads, LinkedIn Ads, Microsoft Ads and more. The plugin makes it easy to setup. Simply tell Grok to 'Setup conversion tracking in Google Ads when someone submits a form on my Webflow website' and it will build the conversion flow, connect your Google Ads account, publish it, and test it all works.

The plugin bundles the hosted Converly MCP server plus two skills, one for guided setup and one for diagnosing conversions that did not arrive.

## Requirements checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` kebab-case and unique
- [x] Remote source pins a full 40-char lowercase commit SHA; the commit is public and reachable (`git ls-remote` verified)
- [x] `.grok-plugin/plugin-index.json` regenerated with `scripts/generate-plugin-index.py`, not hand-edited
- [x] `homepage`, clear `description`, brand-scoped `keywords`/`domains`, and a `category`
- [x] Plugin is MIT licensed, stated in the repo
- [x] Read and complied with Security expectations

Validated locally with exactly what CI runs:

```
python3 scripts/validate-catalog.py          # Catalog OK
python3 scripts/generate-plugin-index.py --check   # Plugin index OK
```

## Security declaration

Per the contributing guide, endpoints and credentials are declared in the plugin's [README](https://github.com/converlyio/converly-mcp#security-and-data-handling). Summary:

- **No executable code.** The plugin is manifests plus two Markdown skill files. No hooks, no bundled binaries, no `postinstall`, nothing fetched or run at install time.
- **One network endpoint:** `https://app.converly.io/mcp`, our hosted MCP server, declared in `.mcp.json` as a remote streamable HTTP server.
- **No credentials stored or read.** Authorization is OAuth against the user's own Converly account on first use; the token is held by the MCP client. The plugin never reads local files, env vars, SSH keys or `.env`.
- **Ad platform credentials never pass through the plugin or our server.** Connecting a destination returns a Converly-hosted link the user opens in their own browser.
- **Scoped tools only.** No shell-exec tool, no catch-all passthrough. Destructive operations require explicit confirmation and carry destructive annotations.
- **No telemetry** beyond the API calls the user's own actions generate.

## Notes

- Source is under `converlyio`, the org matching our domain, so first-party ownership is verifiable.
- `keywords` and `domains` are deliberately brand-scoped (`converly`, `converly tracking`, `converly.io`) rather than generic terms like "conversion tracking", so the plugin CTA does not misfire on unrelated requests.
- Used `category: "marketing"`, which is new to the catalog. Happy to change it to `development` if you would rather not add a category.
