### PR TITLE
Add official Mako plugin (hosted MCP + skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "mako",
+      "description": "Official Mako plugin (hosted MCP + skill). Explore SQL and Mongo warehouse connections, validate queries, and build React data apps with live or parquet bindings. Sign in with your Mako account on first use — no API key to paste. OAuth is read-only by default.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mako-ai/mako-grok-plugin.git",
+        "sha": "680d25ef23cba7aadae14c80d5f0fd1546bf6e31"
+      },
+      "homepage": "https://mako.ai",
+      "keywords": ["mako", "mako mcp", "mako app", "data apps", "sql warehouse"],
+      "domains": ["mako.ai", "app.mako.ai", "docs.mako.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,24 @@
         ]
       }
     },
+    "mako": {
+      "sha": "680d25ef23cba7aadae14c80d5f0fd1546bf6e31",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mako",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mako",
+            "description": "Use when exploring a Mako workspace, querying connected warehouses (SQL or Mongo), building or editing a Mako React dat…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds the official Mako plugin to the Grok plugin marketplace.

- **Plugin name:** `mako`
- **Type:** remote source
- **Source URL + pinned SHA:** `https://github.com/mako-ai/mako-grok-plugin.git@680d25ef23cba7aadae14c80d5f0fd1546bf6e31`
- **Homepage:** https://mako.ai

### What Mako provides

Mako lets AI agents explore warehouse data and ship React data apps through its hosted MCP server.

| Capability | What it does |
|---|---|
| Discover | List connections, databases, and tables (SQL or Mongo) |
| Query | Run read-only SQL, or long-running consoles for slow warehouses |
| Apps | Create React data apps, bind live or parquet datasets, preview, publish |
| Dashboards | Search existing dashboards and update source queries |
| dbt | Read/edit models; warehouse and Git writes are admin opt-in scopes |

The MCP server uses browser-based OAuth. Users connect a Mako workspace without pasting an API key into Grok. OAuth grants are always read-only.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The plugin repository is published [here](https://github.com/mako-ai/mako-grok-plugin) under the official [`mako-ai`](https://github.com/mako-ai) organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] License is stated as MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or environment variables.
- [x] Hooks and MCP scope are least-privilege.
- **Network endpoint:** `https://app.mako.ai/api/mcp` — Mako’s hosted MCP server for data discovery, SQL exploration, apps, dashboards, and dbt.
- **Credentials:** OAuth through the MCP client; no embedded credentials or API key required.
- The plugin contains no lifecycle hooks or installation scripts.

## Notes for reviewers

The source repository is maintained by Mako under its official GitHub organization. Self-hosted Mako deployments can point the MCP URL at `https://your-mako-host/api/mcp`.


Made with [Cursor](https://cursor.com)