### PR TITLE
Add Kling AI plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,18 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "kling-ai",
+      "description": "Kling AI image and video generation integration. Sign in with Kling AI to create images and videos, upload references, check credits, and monitor generation tasks through the hosted OAuth MCP server.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/kling-ai"
+      },
+      "homepage": "https://kling.ai",
+      "keywords": ["kling ai", "kling image generation", "kling video generation", "kling mcp"],
+      "domains": ["kling.ai", "klingai.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,27 @@
         ]
       }
     },
+    "kling-ai": {
+      "version": "1.0.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "Plugin-Grok-kling-ai",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "install-kling-ai-plugin",
+            "description": "Install, refresh, or troubleshoot the Kling AI plugin and remote OAuth MCP registration in Grok Build. Preserve the pac…"
+          },
+          {
+            "name": "kling-ai",
+            "description": "Create and monitor Kling AI image and video generations through the OAuth-protected remote MCP server in Grok Build. Us…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,7 +328,7 @@
       }
     },
     "kling-ai": {
-      "version": "1.0.3",
+      "version": "1.0.0",
       "components": {
         "mcpServers": [
           {

--- a/external_plugins/kling-ai/.grok-plugin/plugin.json
+++ b/external_plugins/kling-ai/.grok-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "kling-ai",
+  "version": "1.0.3",
+  "description": "Create and monitor AI image and video generations with Kling's OAuth MCP",
+  "author": {
+    "name": "KLING AI Pte Ltd",
+    "url": "https://kling.ai"
+  },
+  "homepage": "https://kling.ai",
+  "license": "MIT",
+  "keywords": ["kling", "kling-ai", "image-generation", "video-generation", "mcp"]
+}

--- a/external_plugins/kling-ai/.grok-plugin/plugin.json
+++ b/external_plugins/kling-ai/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kling-ai",
-  "version": "1.0.3",
+  "version": "1.0.0",
   "description": "Create and monitor AI image and video generations with Kling's OAuth MCP",
   "author": {
     "name": "KLING AI Pte Ltd",

--- a/external_plugins/kling-ai/.mcp.china.json
+++ b/external_plugins/kling-ai/.mcp.china.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "Plugin-Grok-kling-ai": {
+      "type": "http",
+      "url": "https://klingai.com/mcp",
+      "headers": {
+        "X-Kling-Integration": "Plugin-Grok"
+      }
+    }
+  }
+}

--- a/external_plugins/kling-ai/.mcp.json
+++ b/external_plugins/kling-ai/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "Plugin-Grok-kling-ai": {
+      "type": "http",
+      "url": "https://kling.ai/mcp",
+      "headers": {
+        "X-Kling-Integration": "Plugin-Grok"
+      }
+    }
+  }
+}

--- a/external_plugins/kling-ai/LICENSE
+++ b/external_plugins/kling-ai/LICENSE
@@ -1,0 +1,25 @@
+MIT License
+
+Copyright (c) 2026 KLING AI Pte Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Kling, KLING AI, 可灵 and related marks are trademarks of KLING AI Pte Ltd and
+its affiliates. This license covers the plugin source in this repository only,
+not the Kling AI service or its generated content.

--- a/external_plugins/kling-ai/README.md
+++ b/external_plugins/kling-ai/README.md
@@ -1,0 +1,92 @@
+# Kling AI for Grok
+
+This directory is a native Grok Build plugin. It contains a Grok manifest,
+Agent Skills, and one selected OAuth-protected remote MCP registration. Use
+the marketplace default `.mcp.json` for Global (`https://kling.ai/mcp`). For a
+China-region private distribution, replace it with the inactive
+`.mcp.china.json` template (`https://klingai.com/mcp`) before installation.
+Never activate both. The plugin does not bundle `mcp-app/`, start a local MCP
+server, or require a Kling API key.
+
+## Install in Grok Build
+
+Install [Grok Build](https://docs.x.ai/build/overview), then validate and
+install this plugin from the repository root:
+
+```bash
+grok plugin validate grok/kling-ai
+grok plugin install "$PWD/grok/kling-ai" --trust
+grok plugin enable kling-ai
+grok inspect
+```
+
+Open `/mcps` in the Grok TUI, select `Plugin-Grok-kling-ai`, and press `i` to
+complete Kling OAuth in the browser. Then verify the connection:
+
+```bash
+grok mcp list
+grok mcp doctor Plugin-Grok-kling-ai
+```
+
+Only trust the plugin after inspecting its source. Grok keeps plugin MCP
+servers inactive until the plugin is trusted.
+
+## Connect from grok.com
+
+Grok web supports custom MCP connectors independently of Grok Build plugins:
+
+1. Open <https://grok.com/connectors>.
+2. Choose **New Connector → Custom**.
+3. Enter the Global endpoint `https://kling.ai/mcp` and complete OAuth. China
+   accounts use `https://klingai.com/mcp` instead; never add both.
+
+This web flow connects the remote tools but does not install the Grok Build
+Skills in this directory. Use the Grok Build plugin when you need the full
+confirmation, single-submit, and result-handling instructions.
+
+## OAuth and results
+
+Grok owns the OAuth client, PKCE flow, credential storage, and refresh. The
+packaged `X-Kling-Integration: Plugin-Grok` header is telemetry-only and must
+not affect authentication, rollout, billing, or generation behavior.
+
+The plugin sends requests only to the one active Kling MCP endpoint. Requests
+may include the creative prompt, selected generation parameters, uploaded
+reference media, and task identifiers needed to create or query the requested
+work. Kling returns account-scoped capability, credit, task, and output data
+through that connection. The plugin bundle does not read Grok's OAuth tokens,
+does not run a local server, and does not store a second copy of request or
+result data. Grok manages the local OAuth credential; Kling processes service
+data under the [Kling AI Privacy Policy](https://kling.ai/docs/privacy-policy)
+and [Kling AI Terms of Service](https://kling.ai/docs/user-policy).
+
+Grok Build's public documentation confirms remote MCP tools and OAuth, but it
+does not currently document MCP Apps rendering as a supported surface. Do not
+claim an interactive widget until it is verified on the target build; preserve
+the same remote call's text/resource fallback and primary result link.
+
+## Official marketplace submission
+
+xAI's official catalog is
+[`xai-org/plugin-marketplace`](https://github.com/xai-org/plugin-marketplace).
+Follow [the release checklist](docs/RELEASE_CHECKLIST.md). A third-party remote
+submission should point at a public plugin-root repository owned by the real
+publisher and pin a full 40-character commit SHA. Alternatively, the plugin can
+be vendored under the official catalog's `external_plugins/` directory.
+
+Being listed does not make a third-party plugin authored, endorsed, or verified
+by xAI. This package identifies its publisher as KLING AI Pte Ltd; marketplace
+submission and public branding must be performed by an account authorized to
+represent that publisher.
+
+## License
+
+[MIT](LICENSE)
+
+## Verify
+
+```bash
+npm run check --prefix grok/kling-ai
+npm test --prefix grok/kling-ai
+node scripts/verify-host-parity.mjs
+```

--- a/external_plugins/kling-ai/docs/RELEASE_CHECKLIST.md
+++ b/external_plugins/kling-ai/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,37 @@
+# Grok Build release checklist
+
+## Local plugin gate
+
+- [ ] `.grok-plugin/plugin.json` is valid and its version matches `package.json`.
+- [ ] `.mcp.json` registers only Global and the inactive `.mcp.china.json` registers only China, both as `Plugin-Grok-kling-ai`; validate the Global marketplace package and test the China private-distribution variant separately.
+- [ ] The telemetry-only header is `X-Kling-Integration: Plugin-Grok`.
+- [ ] The archive contains no `mcp-app/`, local MCP server, OAuth tokens, `.env`, profile config, or caches.
+- [ ] `grok plugin validate grok/kling-ai` passes on the supported Grok Build version.
+- [ ] A clean `grok plugin install <path> --trust` plus `grok plugin enable kling-ai` exposes both Skills and exactly one MCP server.
+- [ ] `/mcps` authorization, OAuth refresh/reconnect, `grok mcp doctor`, and account switching pass.
+- [ ] Text/resource fallback works; interactive MCP App rendering is not claimed until the target Grok surface is verified.
+- [ ] Generation confirmation, at-most-once submission, ambiguous-timeout recovery, and `generationId` preservation are manually verified.
+- [ ] `npm run check`, `npm test`, and root `node scripts/verify-host-parity.mjs` pass.
+
+## xAI official marketplace gate
+
+xAI's official catalog is <https://github.com/xai-org/plugin-marketplace>.
+For a third-party remote source, publish this directory as the root of a
+public repository owned by the actual publisher. Then:
+
+1. Fork `xai-org/plugin-marketplace` and branch from `main`.
+2. Add exactly one `kling-ai` entry to `.grok-plugin/marketplace.json` with a clear description, `homepage`, product-scoped `keywords`/`domains`, category, public repository URL, and a full 40-character lowercase commit SHA.
+3. Run `python3 scripts/generate-plugin-index.py` in the marketplace fork; never edit the generated index manually.
+4. Run `python3 scripts/validate-catalog.py` and `python3 scripts/generate-plugin-index.py --check`.
+5. Open a PR using xAI's template and disclose both possible network endpoints, the one-active-region invariant, OAuth requirement, requested permissions, and telemetry-only integration header.
+
+Alternative: vendor the plugin under the official repository's
+`external_plugins/kling-ai/` and use a local source entry. Remote source is
+the official contribution guide's recommended path for third parties.
+
+- [ ] The submitted source is public, reachable, licensed, and under the real publisher's organization rather than an unrelated personal account.
+- [ ] The catalog source is pinned to a reachable full commit SHA, not a branch, tag, or abbreviated SHA.
+- [ ] The repository README declares network endpoints, OAuth/permissions, privacy/terms URLs, data handling, and publisher ownership.
+- [ ] No `curl | bash`, postinstall execution, secret reading/exfiltration, obfuscated payload, broad hook, or local shell-exec MCP server is present.
+- [ ] The official catalog PR has passed CI and code-owner review before any “available in the xAI marketplace” claim is published.
+- [ ] Marketing states that third-party catalog inclusion is not xAI authorship, endorsement, or verification.

--- a/external_plugins/kling-ai/package.json
+++ b/external_plugins/kling-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kling-ai-grok-plugin",
-  "version": "1.0.3",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "description": "Grok Build plugin and remote MCP configuration for Kling AI",

--- a/external_plugins/kling-ai/package.json
+++ b/external_plugins/kling-ai/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kling-ai-grok-plugin",
+  "version": "1.0.3",
+  "private": true,
+  "type": "module",
+  "description": "Grok Build plugin and remote MCP configuration for Kling AI",
+  "scripts": {
+    "check": "node ../../scripts/verify-host-parity.mjs",
+    "test": "node ../../scripts/verify-host-parity.mjs",
+    "verify": "node ../../scripts/verify-host-parity.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/external_plugins/kling-ai/skills/install-kling-ai-plugin/SKILL.md
+++ b/external_plugins/kling-ai/skills/install-kling-ai-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: install-kling-ai-plugin
 description: Install, refresh, or troubleshoot the Kling AI plugin and remote OAuth MCP registration in Grok Build. Preserve the packaged server key and do not add a duplicate connection.
-version: 1.0.3
+version: 1.0.0
 author: KLING AI
 license: MIT
 metadata:

--- a/external_plugins/kling-ai/skills/install-kling-ai-plugin/SKILL.md
+++ b/external_plugins/kling-ai/skills/install-kling-ai-plugin/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: install-kling-ai-plugin
+description: Install, refresh, or troubleshoot the Kling AI plugin and remote OAuth MCP registration in Grok Build. Preserve the packaged server key and do not add a duplicate connection.
+version: 1.0.3
+author: KLING AI
+license: MIT
+metadata:
+  author: KLING AI
+  short-description: Install Kling AI in Grok Build
+---
+
+# Install Kling AI in Grok Build
+
+1. The marketplace package defaults to Global: `.mcp.json` activates `https://kling.ai/mcp`. For a China-region private distribution, replace it with the inactive `.mcp.china.json` template for `https://klingai.com/mcp` before installation. Preserve exactly one server named `Plugin-Grok-kling-ai` with `X-Kling-Integration: Plugin-Grok`; never activate both templates.
+2. Validate and install the complete plugin directory:
+
+   ```bash
+   grok plugin validate /absolute/path/to/grok/kling-ai
+   grok plugin install /absolute/path/to/grok/kling-ai --trust
+   grok plugin enable kling-ai
+   ```
+
+3. Do not copy only the Skill, add a second MCP server, bundle a local server, or request a Kling API key.
+4. Run `grok inspect`, `grok plugin details kling-ai`, and `grok mcp list`; verify that one packaged server is active.
+5. Open `/mcps`, select `Plugin-Grok-kling-ai`, and press `i` to complete browser OAuth. Grok owns PKCE, credentials, and refresh; do not create a second OAuth flow.
+6. Run `grok mcp doctor Plugin-Grok-kling-ai` and start a new session so Skills and tools refresh. Do not submit a generation as part of setup.

--- a/external_plugins/kling-ai/skills/kling-ai/SKILL.md
+++ b/external_plugins/kling-ai/skills/kling-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kling-ai
 description: Create and monitor Kling AI image and video generations through the OAuth-protected remote MCP server in Grok Build. Use for text-to-image, image-to-image, text-to-video, image-to-video, uploads, task status, and credit checks.
-version: 1.0.3
+version: 1.0.0
 author: KLING AI
 license: MIT
 metadata:

--- a/external_plugins/kling-ai/skills/kling-ai/SKILL.md
+++ b/external_plugins/kling-ai/skills/kling-ai/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: kling-ai
+description: Create and monitor Kling AI image and video generations through the OAuth-protected remote MCP server in Grok Build. Use for text-to-image, image-to-image, text-to-video, image-to-video, uploads, task status, and credit checks.
+version: 1.0.3
+author: KLING AI
+license: MIT
+metadata:
+  author: KLING AI
+  short-description: Generate images and videos with Kling AI
+---
+
+# Kling AI for Grok Build
+
+Use only the packaged server `Plugin-Grok-kling-ai`. The marketplace package activates Global `https://kling.ai/mcp`; a China-region private distribution may instead activate `https://klingai.com/mcp`. Never activate both regions in one session. This plugin contains configuration and Skills only; it does not bundle, start, or depend on a local MCP server.
+
+## Safety and submission contract
+
+- Use Grok-native MCP OAuth. Never request an API key or expose credentials, cookies, authorization headers, private account fields, or signed URLs in logs.
+- Treat generation as a credit-consuming write action. Show the final workflow, model, duration/resolution or aspect ratio, and obtain explicit confirmation immediately before submission unless the current user message explicitly authorizes immediate submission with final settings.
+- Submit at most once per approved intent. Never automatically retry failed, timed-out, or ambiguous submissions.
+- Discover the live remote tools and schemas at runtime; provider schemas override examples in this Skill.
+- Upload attached or local media before generation when the live workflow requires it. Reuse the returned provider reference exactly as the schema requires.
+- After acceptance, use the remote `query_tasks` tool when status checking is needed. Do not invent a local result or claim that a card will refresh itself.
+
+Read [references/tool-workflows.md](references/tool-workflows.md) before a generation call. Read [references/troubleshooting.md](references/troubleshooting.md) only after an authorization, schema, upload, or provider failure.
+
+## OAuth client identity
+
+Grok owns OAuth dynamic registration, PKCE, credential storage, and refresh. Preserve that native flow. The packaged server key and `X-Kling-Integration: Plugin-Grok` header provide telemetry-only integration attribution and must not affect authorization, billing, or rollout.
+
+## Workflow
+
+1. Identify the requested generation or read-only operation.
+2. Ask only for missing creative requirements that materially affect the result.
+3. Inspect the live schema and confirm the final billable settings.
+4. Call the selected remote generation tool at most once.
+5. Preserve and report the exact `generationId` and any `taskTraceId` returned by the provider.
+6. If the active Grok surface supports the returned MCP App resource, let it render the resource. Otherwise report the same call's text fallback and one link to the primary output when available; do not synthesize or duplicate media.
+7. For a direct status request, call remote `query_tasks` once and report the current state.
+
+## Defaults
+
+Use defaults only when the user did not specify alternatives and the live schema supports them:
+
+- video resolution: `720p`
+- video duration: `5` seconds
+- text-to-video aspect ratio: `16:9`
+- image-to-video aspect ratio: derive from the first frame unless required
+
+## Failure behavior
+
+- Authorization failure: open `/mcps`, select `Plugin-Grok-kling-ai`, and press `i`; retry only after authorization succeeds.
+- Invalid model or argument: refresh the live schema and revise only the unsupported field.
+- Provider task failure: explain the provider message and preserve the `generationId`; do not resubmit.
+- Lost or timed-out submission response: treat billing state as unknown and query existing tasks before considering any new submission.

--- a/external_plugins/kling-ai/skills/kling-ai/references/tool-workflows.md
+++ b/external_plugins/kling-ai/skills/kling-ai/references/tool-workflows.md
@@ -1,0 +1,10 @@
+# Grok Build MCP workflow
+
+Grok namespaces MCP tools from the packaged server. Inspect the active tool
+names rather than reconstructing them from this document.
+
+1. Inspect the active MCP tools and their current schemas; do not infer model names or enums from this file.
+2. For media inputs, call the discovered upload tool first and preserve its returned reference.
+3. After the user confirms final billable settings, call the selected generation tool exactly once.
+4. Preserve `generationId` and `taskTraceId`. On ambiguity, call the discovered `query_tasks` tool rather than resubmitting.
+5. Do not parallelize generation submissions or speculative retries.

--- a/external_plugins/kling-ai/skills/kling-ai/references/troubleshooting.md
+++ b/external_plugins/kling-ai/skills/kling-ai/references/troubleshooting.md
@@ -1,0 +1,7 @@
+# Grok Build troubleshooting
+
+- Run `grok inspect`, `grok plugin details kling-ai`, and `grok mcp list` to inspect discovery and the native connection.
+- Run `grok mcp doctor Plugin-Grok-kling-ai` for connectivity diagnostics.
+- Open `/mcps`, select `Plugin-Grok-kling-ai`, and press `i` for first authorization or intentional re-authentication.
+- Reload the extensions modal with `r` or start a new session after plugin or Skill changes.
+- If a submission times out, query existing tasks by returned identifiers or current account history. Never blind-retry a credit-consuming tool.


### PR DESCRIPTION
## What this PR does

- Plugin: `kling-ai`
- Type: third-party vendored plugin under `external_plugins`
- Homepage: https://kling.ai
- Default region: Global (`https://kling.ai/mcp`)

Adds the Kling AI plugin for Grok Build with two Agent Skills and one OAuth-protected remote MCP registration for image and video generation workflows.

## Publisher and ownership

- [x] Submission is authorized by the requester for the Kling AI integration project.
- Publisher declared by the plugin manifest: **KLING AI Pte Ltd**.
- The working source repository is currently internal, so this submission uses the marketplace's supported vendored-source form.
- xAI reviewers may request additional publisher verification before merge.

## Validation

- [x] Added exactly one `kling-ai` entry to `.grok-plugin/marketplace.json`.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes.
- [x] `python3 scripts/generate-plugin-index.py --check` passes.
- [x] `grok plugin validate` passes with Grok Build 1.0.5.
- [x] Socket Security project and PR checks pass.
- [x] Semgrep scan passes.

## OAuth verification status

Grok Build owns OAuth discovery, dynamic registration, PKCE, credential storage, and refresh. Local verification confirmed that:

1. The installed plugin registers exactly one active Kling server as `Plugin-Grok-kling-ai`.
2. It targets the Global endpoint `https://kling.ai/mcp`.
3. The endpoint is reachable and returns OAuth authorization required.
4. Grok's native MCP authentication flow starts and reaches the browser authorization step.

The final user consent was intentionally cancelled during this submission pass, so no access token was retained and no credit-consuming generation call was made. Full consent, reconnect, refresh, and account-switch behavior can be completed during reviewer testing.

## Security and behavior

- No `curl | bash`, remote code execution, hooks, postinstall scripts, local MCP runtime, or executable dependencies.
- No API key, client secret, bearer token, cookie, or environment secret is requested or bundled.
- `X-Kling-Integration: Plugin-Grok` is sent only to the configured Kling MCP origin for integration attribution; it must not affect authentication, billing, or rollout.
- Generation is a credit-consuming write. The Skill requires explicit confirmation of final settings and at-most-once submission.
- The marketplace package activates exactly one regional endpoint. The China endpoint appears only in inactive private-distribution documentation/template material and is not loaded by Grok Marketplace.
