### PR TITLE
Add NotesQR plugin — anonymous P2P file sharing (no signup, any size, mobile)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -248,7 +248,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/NotesQR/notesqr-share.git",
-        "sha": "7f5e997e2cba84690722c53b2b8282d09feff7a5",
+        "sha": "e1a78850f714ee2d953695138bef649c749eecc0",
         "path": "grok-plugin"
       },
       "homepage": "https://notesqr.com/use-cases/cli-mcp-agents",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -248,7 +248,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/NotesQR/notesqr-share.git",
-        "sha": "e1a78850f714ee2d953695138bef649c749eecc0",
+        "sha": "08f742f27f93c7f4a8362c6c86015ce54612720f",
         "path": "grok-plugin"
       },
       "homepage": "https://notesqr.com/use-cases/cli-mcp-agents",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,34 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "notesqr",
+      "description": "Anonymous WebRTC P2P file and folder sharing — no signup, any size, cross-device including mobile browsers. MCP tools to host a room or download while both peers stay online. Ideal for QA builds (APK/IPA), logs, datasets, and agent-to-human handoffs.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/NotesQR/notesqr-share.git",
+        "sha": "7f5e997e2cba84690722c53b2b8282d09feff7a5",
+        "path": "grok-plugin"
+      },
+      "homepage": "https://notesqr.com/use-cases/cli-mcp-agents",
+      "keywords": [
+        "notesqr",
+        "file transfer",
+        "p2p",
+        "webrtc",
+        "anonymous file share",
+        "no signup",
+        "folder share",
+        "large file transfer",
+        "mobile file share",
+        "cross device",
+        "app testing",
+        "qa file share",
+        "mcp file transfer"
+      ],
+      "domains": ["notesqr.com", "www.notesqr.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -432,6 +432,34 @@
         ]
       }
     },
+    "notesqr": {
+      "sha": "7f5e997e2cba84690722c53b2b8282d09feff7a5",
+      "version": "2.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "recv",
+            "description": "Download files from a NotesQR room URL or room id while the sender is online (anonymous, no signup)."
+          },
+          {
+            "name": "send",
+            "description": "Host an anonymous NotesQR P2P room and share files or folders (any size, no signup). Returns a URL to open on phone, br…"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "notesqr",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "notesqr-share",
+            "description": "Send or receive files and folders anonymously via WebRTC P2P (notesqr.com). No account, any size, cross-device includin…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -433,7 +433,7 @@
       }
     },
     "notesqr": {
-      "sha": "e1a78850f714ee2d953695138bef649c749eecc0",
+      "sha": "08f742f27f93c7f4a8362c6c86015ce54612720f",
       "version": "2.1.0",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -433,7 +433,7 @@
       }
     },
     "notesqr": {
-      "sha": "7f5e997e2cba84690722c53b2b8282d09feff7a5",
+      "sha": "e1a78850f714ee2d953695138bef649c749eecc0",
       "version": "2.1.0",
       "components": {
         "commands": [


### PR DESCRIPTION
## Summary

Adds **notesqr** to the Grok Build plugin catalog.

Remote source: [NotesQR/notesqr-share](https://github.com/NotesQR/notesqr-share) at `grok-plugin/` (pinned SHA `e1a78850f714ee2d953695138bef649c749eecc0`).

Provides MCP tools (`notesqr_p2p_send`, `notesqr_p2p_recv`), an agent skill, and `/send` / `/recv` slash commands.

Anonymous WebRTC peer-to-peer file and folder sharing via [notesqr.com](https://notesqr.com). No user account required. Share a short room URL that works on phones, tablets, and desktops. Both peers must stay online during transfer; bytes are not stored on NotesQR servers.

No API key or OAuth — optional room password only.