### PR TITLE
Add DualEntry accounting plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "dualentry",
+      "description": "DualEntry accounting MCP. Query the live ledger, search records and entities, and draft accounting changes with the same permissions as the DualEntry dashboard.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dualentry/grok-plugin.git",
+        "sha": "fb2117def11f905d833b22d70f0e15f0636897c0"
+      },
+      "homepage": "https://docs.dualentry.com/developers/guides/mcp-integration",
+      "keywords": ["dualentry", "dualentry accounting", "dualentry ledger", "dualentry mcp", "dualentry journal entry"],
+      "domains": ["dualentry.com", "app.dualentry.com", "api.dualentry.com", "docs.dualentry.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,18 @@
         ]
       }
     },
+    "dualentry": {
+      "sha": "fb2117def11f905d833b22d70f0e15f0636897c0",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "dualentry",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds DualEntry as a third-party plugin so Grok Build can query a live DualEntry accounting ledger and draft changes with the signed-in user's own permissions.

- Plugin name: `dualentry`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/dualentry/grok-plugin.git` @ `fb2117def11f905d833b22d70f0e15f0636897c0`
- Homepage: https://docs.dualentry.com/developers/guides/mcp-integration

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): one endpoint, `https://api.dualentry.com/mcp/`, the DualEntry production API. It is the only host contacted. The plugin ships no hooks, commands, agents, scripts, or skills — it is a single streamable-HTTP MCP server declared in `.mcp.json`, plus a README.
- Credentials/permissions it requires (and why): OAuth 2.1 authorization code with PKCE and dynamic client registration (RFC 7591). Grok registers itself and opens a browser for DualEntry sign-in; the token is stored by the client. There is no API key, and the plugin reads no environment variable or local file. Tool access is bounded server-side by the signed-in user's existing DualEntry role permissions, so the plugin can never see more than that user's dashboard shows.

