### PR TITLE
Add markifact plugin (remote source)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,8 @@
       "homepage": "https://www.markifact.com",
       "keywords": ["markifact", "markifact mcp", "markifact marketing"],
       "domains": ["markifact.com"]
+    },
+    {
       "name": "pstack",
       "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
       "category": "development",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "markifact",
+      "description": "Markifact marketing integration. Audit ad spend, launch campaigns, rotate creative, and pull reporting across Google Ads, Meta Ads, TikTok Ads, LinkedIn Ads, GA4, Shopify, HubSpot, and 20+ more platforms. 1000+ operations with human-in-the-loop approval on every write.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/markifact/markifact-mcp.git",
+        "sha": "838239fe594257d8ce9bdb842293984133f6c20e"
+      },
+      "homepage": "https://www.markifact.com",
+      "keywords": ["markifact", "markifact mcp", "markifact marketing"],
+      "domains": ["markifact.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,64 @@
         ]
       }
     },
+    "markifact": {
+      "sha": "838239fe594257d8ce9bdb842293984133f6c20e",
+      "version": "1.0.2",
+      "components": {
+        "agents": [
+          {
+            "name": "performance-marketer",
+            "description": "Senior performance-marketing operator with hands-on access to the user's ad accounts via Markifact. Use proactively for…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "diagnose-underperformer",
+            "description": "Diagnose why a specific Google Ads or Meta Ads campaign / ad set / ad is underperforming and prescribe the next concret…"
+          },
+          {
+            "name": "edit-meta-creative",
+            "description": "Edit a Meta ad's creative content — landing page URL, primary text, headline, description, CTA, link description — acro…"
+          },
+          {
+            "name": "launch-google-search",
+            "description": "Launch a complete Google Ads Search campaign — campaign, ad group, responsive search ads, keywords, sitelinks, callouts…"
+          },
+          {
+            "name": "launch-meta-campaign",
+            "description": "Launch a complete Meta Ads campaign — campaign, ad set, and ad(s) — built paused and ready to review. Use when the user…"
+          },
+          {
+            "name": "launch-pmax",
+            "description": "Launch a Google Ads Performance Max campaign with a complete asset group, audience signals, and (for ecom) listing grou…"
+          },
+          {
+            "name": "negative-keyword-sweep",
+            "description": "Find wasted spend in Google Ads search terms and add negatives at the right scope (account list, campaign, or ad group)…"
+          },
+          {
+            "name": "rotate-creative",
+            "description": "Pause fatigued ads and ship fresh creative variants in their place. Works on both Meta and Google Ads. Use when CTR is…"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "markifact",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "markifact-overview",
+            "description": "Reference — what Markifact is, what the MCP server exposes, and the discover→inspect→run pattern. Always loaded into th…"
+          },
+          {
+            "name": "safe-write-operations",
+            "description": "Reference — rules for safely executing write/destructive operations against ad accounts. Always loaded into the perform…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds the Markifact plugin as a remote-source entry.

- Plugin name: markifact
- Type: remote source
- Source URL + pinned SHA: https://github.com/markifact/markifact-mcp.git @ 838239fe594257d8ce9bdb842293984133f6c20e
- Homepage: https://www.markifact.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (markifact). This PR is opened from my personal account (ahmed-3li); I'm the maintainer of the markifact org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; single remote HTTP MCP server).
- Network endpoints this plugin calls (and why): https://api.markifact.com/mcp, the Markifact MCP server; all platform API calls happen server-side. Nothing executes locally.
- Credentials/permissions it requires (and why): OAuth 2.1 sign-in to the user's Markifact account; platform connections (Google Ads, Meta, etc.) are authorized inside Markifact. Write operations are approval-gated.

## Notes for reviewers

Markifact is a remote MCP server for marketing automation (1000+ operations across Google Ads, Meta, TikTok, LinkedIn, GA4, Shopify, HubSpot, and more). The same repo already serves as our Claude Code plugin marketplace; the `.claude-plugin/plugin.json` manifest applies. Privacy/terms/security docs are in the repo (PRIVACY.md, TERMS.md, SECURITY.md).
