### PR TITLE
Add DualEntry accounting MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "dualentry",
+      "description": "DualEntry accounting MCP. Query the live ledger, search records and entities, and draft accounting changes with the same permissions as the DualEntry dashboard.",
+      "category": "accounting",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dualentry/grok-plugin.git",
+        "sha": "fb2117def11f905d833b22d70f0e15f0636897c0"
+      },
+      "homepage": "https://docs.dualentry.com/developers/guides/mcp-integration",
+      "keywords": ["dualentry", "dualentry accounting", "dualentry ledger", "dualentry mcp", "dualentry journal entry"],
+      "domains": ["dualentry.com", "app.dualentry.com", "api.dualentry.com", "docs.dualentry.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,18 @@
         ]
       }
     },
+    "dualentry": {
+      "sha": "fb2117def11f905d833b22d70f0e15f0636897c0",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "dualentry",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds the official DualEntry plugin for Grok Build from [dualentry/grok-plugin](https://github.com/dualentry/grok-plugin).

- Plugin name: DualEntry
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/dualentry/grok-plugin.git @ fb2117def11f905d833b22d70f0e15f0636897c0
- Homepage: https://docs.dualentry.com/developers/guides/mcp-integration

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): one endpoint, https://api.dualentry.com/mcp/, the DualEntry production API. It is the only host contacted. The plugin ships no hooks, commands, agents, scripts, or skills - it is a single streamable-HTTP MCP server declared in .mcp.json, plus a README.
- Credentials/permissions it requires (and why): Credentials/permissions it requires (and why): OAuth 2.1 authorization code with PKCE and dynamic client registration (RFC 7591). Grok registers itself and opens a browser for DualEntry sign-in; the token is stored by the client. There is no API key, and the plugin reads no environment variable or local file. Tool access is bounded server-side by the signed-in user's existing DualEntry role permissions, so the plugin can never see more than that user's dashboard shows.

## Notes for reviewers

Source is our official org, github.com/dualentry. DualEntry is the accounting product at https://dualentry.com/; the plugin points at our own hosted MCP server.

License: the plugin is proprietary to DualEntry, which holds and grants the rights to distribute it for this listing. The source repo carries no OSS license file, matching the other vendor plugin repos already in this catalog.

Components: one MCP server, nothing else. Tools are scoped reads (search records, record detail and history, related records, list companies, search entities, bank-match suggestions, contract and fixed-asset schedule previews) plus writes that save a record or entity from an explicit user-confirmed payload. The source repo ships a README.md and .grok-plugin/plugin.json even though it is remote-sourced.

Category: filed under accounting, which is a new value in the catalog.
