### PR TITLE
Add Meeting Mate plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,18 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "meeting-mate",
+      "description": "Official Meeting Mate plugin (hosted MCP + skills). Search meeting recordings, pull transcripts and summaries, extract action items, and manage follow-up tasks from Grok Build.",
+      "category": "productivity",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/meeting-mate"
+      },
+      "homepage": "https://meetingmateapp.com",
+      "keywords": ["meeting mate", "meetingmate", "meeting mate recordings", "meetingmateapp"],
+      "domains": ["meetingmateapp.com", "www.meetingmateapp.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,31 @@
         ]
       }
     },
+    "meeting-mate": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "meeting-mate",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "meeting-mate",
+            "description": "Official Meeting Mate overview for Grok Build. Use when the user mentions Meeting Mate, meetingmate, meetingmateapp, or…"
+          },
+          {
+            "name": "meeting-mate-recordings",
+            "description": "Search and read Meeting Mate recordings. Use when the user asks for Meeting Mate recordings, transcripts, summaries, ke…"
+          },
+          {
+            "name": "meeting-mate-tasks",
+            "description": "Manage Meeting Mate follow-up tasks. Use when the user wants to create, list, complete, or update tasks in Meeting Mate…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/external_plugins/meeting-mate/.grok-plugin/plugin.json
+++ b/external_plugins/meeting-mate/.grok-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "meeting-mate",
+  "version": "1.0.0",
+  "description": "Official Meeting Mate plugin for Grok Build. Search recordings, pull transcripts and summaries, extract action items, and manage follow-up tasks via the hosted Meeting Mate MCP server.",
+  "author": {
+    "name": "Meeting Mate",
+    "url": "https://meetingmateapp.com"
+  },
+  "homepage": "https://meetingmateapp.com",
+  "repository": "https://github.com/jaspervanhardeveld/plugin-marketplace",
+  "license": "MIT",
+  "keywords": [
+    "meeting mate",
+    "meetingmate",
+    "meetingmateapp",
+    "recordings",
+    "transcripts",
+    "mcp"
+  ]
+}

--- a/external_plugins/meeting-mate/.mcp.json
+++ b/external_plugins/meeting-mate/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "meeting-mate": {
+      "type": "http",
+      "url": "https://meetingmateapp.com/api/mcp",
+      "note": "Official Meeting Mate hosted MCP server. On first connection Grok opens a browser OAuth flow. No API key is required for that path. Tools read and write meeting recordings, transcripts, summaries, action items, and tasks for the signed-in workspace."
+    }
+  }
+}

--- a/external_plugins/meeting-mate/LICENSE
+++ b/external_plugins/meeting-mate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Meeting Mate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external_plugins/meeting-mate/README.md
+++ b/external_plugins/meeting-mate/README.md
@@ -1,0 +1,76 @@
+# Meeting Mate plugin for Grok Build
+
+Official [Meeting Mate](https://meetingmateapp.com) plugin for Grok Build.
+
+This plugin connects Grok to Meeting Mate's hosted MCP server so you can search meeting recordings, pull transcripts and summaries, extract action items, and manage follow-up tasks from the conversation.
+
+## What it does
+
+- List and search Meeting Mate recordings across your workspaces
+- Fetch transcripts, summaries, key points, decisions, and action items
+- Ask questions about a specific recording
+- Create, list, and complete follow-up tasks
+- Upload audio for transcription when the client provides a downloadable file
+
+## Install
+
+In Grok Build, run `/plugin`, search for **Meeting Mate**, and install it.
+
+On first use Grok opens a browser OAuth flow against `https://meetingmateapp.com`. Sign in and approve the requested scopes.
+
+API and MCP access require a Meeting Mate Pro or Teams plan. Create keys or OAuth apps in the [Developer Dashboard](https://meetingmateapp.com/dashboard/developers).
+
+## Network and credentials
+
+This plugin does not ship executables, hooks, or install scripts.
+
+| Endpoint | Why |
+|---|---|
+| `https://meetingmateapp.com/api/mcp` | Hosted MCP server (JSON-RPC over HTTP) |
+| `https://meetingmateapp.com/oauth/authorize` | OAuth authorization |
+| `https://meetingmateapp.com/oauth/token` | OAuth token exchange |
+| `https://meetingmateapp.com/oauth/register` | Dynamic client registration for MCP clients |
+| `https://meetingmateapp.com/docs/api/mcp` | Public MCP documentation |
+
+Credentials:
+
+- **OAuth (default):** browser sign-in on first MCP connection. Tokens stay in Grok's local MCP credential store.
+- **API key fallback:** a Meeting Mate API key from the Developer Dashboard, sent only as `Authorization: Bearer` to `https://meetingmateapp.com/api/mcp`.
+
+The plugin never reads `.env`, SSH keys, or unrelated environment variables.
+
+## MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `list_recordings` | List recordings, optionally filtered by status, date, or workspace |
+| `search_recordings` | Search by title, description, or transcript text |
+| `get_recording` | Recording metadata |
+| `get_transcript` | Speaker-labeled transcript |
+| `get_summary` | Summary, key points, and decisions |
+| `get_action_items` | Extracted action items |
+| `get_audio` | Signed audio download URL |
+| `get_recording_status` | Processing status |
+| `ask_recording` | Compact recording context for a question |
+| `upload_and_process_recording` | Upload audio and start processing (`recordings:write`) |
+| `rename_recording` | Rename a recording (`recordings:write`) |
+| `delete_recording` | Soft-delete a recording (`recordings:write`) |
+| `regenerate_summary` | Regenerate the summary (`recordings:write`) |
+| `create_task` | Create a follow-up task (`tasks:write`) |
+| `complete_task` | Complete or update a task (`tasks:write`) |
+| `list_tasks` | List tasks |
+| `whoami` | Authenticated account and scopes |
+| `health_check` | API health |
+| `get_scopes` | Available API scopes |
+| `get_endpoints` | REST API endpoint list |
+
+## Docs
+
+- Product: https://meetingmateapp.com
+- MCP docs: https://meetingmateapp.com/docs/api/mcp
+- OAuth docs: https://meetingmateapp.com/docs/api/oauth
+- Developer dashboard: https://meetingmateapp.com/dashboard/developers
+
+## License
+
+MIT

--- a/external_plugins/meeting-mate/skills/meeting-mate-recordings/SKILL.md
+++ b/external_plugins/meeting-mate/skills/meeting-mate-recordings/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: meeting-mate-recordings
+description: >-
+  Search and read Meeting Mate recordings. Use when the user asks for Meeting
+  Mate recordings, transcripts, summaries, key points, decisions, action items,
+  or audio, or wants to ask a question about a specific Meeting Mate meeting.
+---
+
+# Meeting Mate recordings
+
+Use the hosted Meeting Mate MCP tools. Identify recordings by UUID from search or list results.
+
+## Find a recording
+
+1. If the user mentions a title, person, topic, or quote, call `search_recordings` with that query.
+2. If they want recent meetings, call `list_recordings`. Optional filters: `status`, `date_from`, `workspace_uuid`, `limit`.
+3. If several matches exist, show a short list (name, date, UUID, status) and let the user pick. Do not pick silently unless one result is an obvious match.
+
+## Read a recording
+
+Pick the smallest tool that answers the question:
+
+| User wants | Tool |
+|---|---|
+| Metadata / status | `get_recording` or `get_recording_status` |
+| Summary, key points, decisions | `get_summary` |
+| Action items only | `get_action_items` |
+| What was said | `get_transcript` (`format=compact` unless they ask for word-level timing) |
+| A specific question about one meeting | `ask_recording` with `uuid` + `question` |
+| Audio link | `get_audio` |
+
+Do not dump a full transcript into the reply unless the user asked for the transcript. Summarize first.
+
+## Write actions
+
+Only when the user asked:
+
+- `rename_recording` — new title
+- `delete_recording` — confirm the UUID and name first
+- `regenerate_summary` — existing recording
+- `upload_and_process_recording` — only when the client provides a downloadable audio file. Requires `recordings:write`.
+
+After upload, poll `get_recording_status` until processing finishes before fetching summary or transcript.
+
+## Response style
+
+- Name the meeting and date.
+- Separate decisions, action items, and open questions.
+- Cite the recording UUID so follow-up tool calls stay exact.
+- If processing is not finished, say so and check status instead of inventing a summary.

--- a/external_plugins/meeting-mate/skills/meeting-mate-tasks/SKILL.md
+++ b/external_plugins/meeting-mate/skills/meeting-mate-tasks/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: meeting-mate-tasks
+description: >-
+  Manage Meeting Mate follow-up tasks. Use when the user wants to create, list,
+  complete, or update tasks in Meeting Mate, including action items taken from
+  a Meeting Mate recording.
+---
+
+# Meeting Mate tasks
+
+Use Meeting Mate MCP task tools. Do not create tasks in other apps unless the user asks.
+
+## List
+
+Call `list_tasks`. Optional filters:
+
+- `status` — open tasks by default when the user says "open" or "todo"
+- `recording_uuid` — tasks linked to one meeting
+- `limit`
+
+Show title, status, deadline, priority, and recording link when present.
+
+## Create
+
+Call `create_task` only when the user asked to create or capture a follow-up.
+
+Useful fields:
+
+- `title` (required)
+- `description`
+- `recording_uuid` when the task comes from a meeting
+- `deadline` as ISO 8601 date
+- `priority`: `normal`, `high`, or `urgent`
+
+If action items came from `get_action_items` or `ask_recording`, offer to create one task per item. Do not bulk-create without confirmation when there are more than three items.
+
+Requires `tasks:write`.
+
+## Complete or update
+
+Call `complete_task` with `task_id` from `list_tasks`. Default new status is `done`. Confirm the task title when several tasks look similar.
+
+## From a recording
+
+Typical flow:
+
+1. Find the recording with `search_recordings` or `list_recordings`.
+2. Read action items with `get_action_items` (or `ask_recording`).
+3. Create tasks the user accepted, passing `recording_uuid`.

--- a/external_plugins/meeting-mate/skills/meeting-mate/SKILL.md
+++ b/external_plugins/meeting-mate/skills/meeting-mate/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: meeting-mate
+description: >-
+  Official Meeting Mate overview for Grok Build. Use when the user mentions
+  Meeting Mate, meetingmate, meetingmateapp, or wants to connect Grok to
+  Meeting Mate recordings, transcripts, summaries, action items, or tasks.
+  Prefer the hosted Meeting Mate MCP server over guessing REST calls.
+---
+
+# Meeting Mate
+
+Meeting Mate is a meeting recording product at [meetingmateapp.com](https://meetingmateapp.com). This plugin talks to the official hosted MCP server. Do not invent Meeting Mate API URLs or scrape the web app.
+
+## Connect
+
+1. Confirm the Meeting Mate MCP server is available. If a tool call asks for authorization, let the user complete the browser OAuth flow.
+2. If auth fails, point the user to the [Developer Dashboard](https://meetingmateapp.com/dashboard/developers) and [MCP docs](https://meetingmateapp.com/docs/api/mcp).
+3. Call `whoami` once after connect to learn the account, workspace, and scopes.
+4. API and MCP access require Meeting Mate Pro or Teams.
+
+The only network endpoint this plugin uses is `https://meetingmateapp.com` (MCP at `/api/mcp`, OAuth at `/oauth/*`). Never send Meeting Mate tokens to another host.
+
+## Choose the right skill
+
+- Find, read, or analyze recordings, transcripts, summaries, or action items → `meeting-mate-recordings`
+- Create, list, or complete follow-up tasks → `meeting-mate-tasks`
+
+## Tool rules
+
+- Use MCP tools. Do not reconstruct REST requests unless the user explicitly asks for curl/API examples.
+- Identify recordings by UUID returned from `list_recordings` or `search_recordings`. Do not guess UUIDs.
+- Prefer `search_recordings` when the user names a meeting, person, or topic.
+- Prefer `ask_recording` when the user has a question about one recording. It returns compact summary + transcript context.
+- Use write tools (`rename_recording`, `delete_recording`, `regenerate_summary`, `upload_and_process_recording`, `create_task`, `complete_task`) only when the user asked for that change.
+- If a tool returns a scope error, explain which scope is missing and send the user to the Developer Dashboard.
+
+## Docs
+
+- MCP: https://meetingmateapp.com/docs/api/mcp
+- OAuth: https://meetingmateapp.com/docs/api/oauth
+- Endpoints: https://meetingmateapp.com/docs/api/recordings


### PR DESCRIPTION
## What this PR does

- Plugin name: `meeting-mate`
- Type: local (`external_plugins`)
- Source URL + pinned SHA (remote), or vendored path (local): `./external_plugins/meeting-mate`
- Homepage: https://meetingmateapp.com

Adds the official Meeting Mate plugin: hosted MCP server plus skills for recordings, transcripts, summaries, action items, and follow-up tasks.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

Meeting Mate is published at [meetingmateapp.com](https://meetingmateapp.com). I am the founder/maintainer. The plugin is vendored locally (same pattern as Neon) so the catalog does not point at a personal-account remote source.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://meetingmateapp.com/api/mcp` — hosted MCP (JSON-RPC over HTTP)
  - `https://meetingmateapp.com/oauth/authorize`, `/oauth/token`, `/oauth/register` — OAuth / DCR for first-time browser sign-in
- Credentials/permissions it requires (and why):
  - Browser OAuth on first MCP connect (default). Tokens stay in Grok's local MCP credential store.
  - Optional API key from the Meeting Mate Developer Dashboard, sent only as `Authorization: Bearer` to the hosted MCP.
  - API/MCP access requires a Meeting Mate Pro or Teams plan.

## Notes for reviewers

The plugin ships no hooks, install scripts, or local executables. It only configures the hosted MCP at `https://meetingmateapp.com/api/mcp` and three brand-scoped skills.

Keywords/domains are limited to Meeting Mate product terms (`meeting mate`, `meetingmate`, `meetingmateapp.com`) so the plugin CTA does not fire on generic meeting requests.

## Test plan

- [ ] Catalog validator and plugin-index `--check` pass in CI
- [ ] `/plugin` search for "Meeting Mate" shows this entry
- [ ] Install wires up MCP `meeting-mate` and the three skills
- [ ] First tool call opens browser OAuth against meetingmateapp.com
- [ ] After auth, `whoami` / `list_recordings` return the signed-in workspace


Made with [Cursor](https://cursor.com)