### PR TITLE
Add upgrade-audit (Martial Systems LLC)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,35 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "upgrade-audit",
+      "description": "Martial Systems Upgrade Audit. Inventory your GitHub repos, review shipped logic when a new Grok generation ships, write a PDF, then audit, fix, or open a PR. You choose audit, fix, or pr, and whether stalled child agents are killed.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/martialsystems/upgrade-audit.git",
+        "sha": "47f5b9a55ddd3255f38ee015fac3d88a0f2367b1"
+      },
+      "homepage": "https://martialgames.net/tools/upgrade-audit/",
+      "keywords": [
+        "upgrade-audit",
+        "martial systems",
+        "martialsystems"
+      ],
+      "domains": [
+        "martialgames.net",
+        "martialsys.net"
+      ],
+      "version": "1.1.0",
+      "author": {
+        "name": "Martial Systems LLC",
+        "email": "martialsys@gmail.com"
+      },
+      "tags": [
+        "upgrade-audit",
+        "martial-systems"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,27 +288,14 @@
       "source": {
         "source": "url",
         "url": "https://github.com/martialsystems/upgrade-audit.git",
-        "sha": "47f5b9a55ddd3255f38ee015fac3d88a0f2367b1"
+        "sha": "7b4486773f9141ec8e91a35e45ce3408b2b187cd"
       },
       "homepage": "https://martialgames.net/tools/upgrade-audit/",
-      "keywords": [
-        "upgrade-audit",
-        "martial systems",
-        "martialsystems"
-      ],
-      "domains": [
-        "martialgames.net",
-        "martialsys.net"
-      ],
-      "version": "1.1.0",
-      "author": {
-        "name": "Martial Systems LLC",
-        "email": "martialsys@gmail.com"
-      },
-      "tags": [
-        "upgrade-audit",
-        "martial-systems"
-      ]
+      "keywords": ["upgrade-audit", "martial systems", "martialsystems"],
+      "domains": ["martialgames.net", "martialsys.net"],
+      "version": "1.2.0",
+      "author": {"name": "Martial Systems LLC", "email": "martialsys@gmail.com"},
+      "tags": ["upgrade-audit", "martial-systems"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1000,7 +1000,7 @@
       }
     },
     "upgrade-audit": {
-      "sha": "47f5b9a55ddd3255f38ee015fac3d88a0f2367b1",
+      "sha": "7b4486773f9141ec8e91a35e45ce3408b2b187cd",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -999,6 +999,17 @@
         ]
       }
     },
+    "upgrade-audit": {
+      "sha": "47f5b9a55ddd3255f38ee015fac3d88a0f2367b1",
+      "components": {
+        "skills": [
+          {
+            "name": "upgrade-audit",
+            "description": "Walk product repos on GitHub and run a model-upgrade logic audit when a new Grok generation ships. Confirms findings ad…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6",
       "version": "0.48.1",


### PR DESCRIPTION
## What this PR does

- Plugin name: upgrade-audit
- Type: remote source
- Source URL + pinned SHA: https://github.com/martialsystems/upgrade-audit.git @ `7b4486773f9141ec8e91a35e45ce3408b2b187cd`
- Homepage: https://martialgames.net/tools/upgrade-audit/
- Version: 1.2.0

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official account (`martialsystems`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (proprietary personal use on the landing README and LICENSE).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (none: this plugin is one skill, no hooks, no MCP).
- Network endpoints this plugin calls (and why): GitHub via the user's installed `gh` and `git` (repo list, clone, optional PR). No Martial Systems upload or telemetry.
- Credentials/permissions it requires (and why): local `gh auth login` (`repo` scope) so inventory can see the user's owned repos. Device policy (`audit`/`fix`/`pr` and `none`/`stall`) is a local JSON file.

## Notes for reviewers

The cloned source at the pinned SHA **is** the plugin and the Python runner (`plugin.json`, `skills/`, `bin/upgrade-audit`, `src/upgrade_audit/`, `catalog/`). `grok plugin install` copies that tree. There is no required extra zip. A versioned zip on Releases is an optional snapshot of the same tree.

The operator catalog of Martial Systems products is not in this tree. The public catalog starts empty and is filled by `inventory --adopt` under the logged-in `gh` user.

Keywords are product-scoped (`upgrade-audit`, `martial systems`) so the CTA does not fire on generic review or PDF chats.