### PR TITLE
Add memco Shared Memory plugin to marketplace and plugin index

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "memco-shared-memory",
+      "description": "Persistent shared memory for your team's AI agents. Agents search memco for proven solutions, design rationale, and gotchas before starting work, and persist what they learn afterwards — so when one agent works something out, every agent knows it. Sign in with your memco account on first connection; no API key needed.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/memcoai/marketplace.git",
+        "sha": "a7db3848658d19a87b6fefd60e6a5646c2e94ac0",
+        "path": "plugins/shared-memory"
+      },
+      "homepage": "https://spark.memco.ai",
+      "keywords": ["memco", "memco shared memory", "memco memory", "spark memory"],
+      "domains": ["memco.ai", "spark.memco.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,39 @@
         ]
       }
     },
+    "memco-shared-memory": {
+      "sha": "a7db3848658d19a87b6fefd60e6a5646c2e94ac0",
+      "version": "1.0.0",
+      "components": {
+        "hooks": [
+          {
+            "name": "SessionStart",
+            "description": "startup|resume"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "SubagentStart"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "memco-shared-memory",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "shared-memory",
+            "description": "Use this skill whenever working on any task where the team may have relevant prior knowledge — coding, writing, researc…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
Persistent shared memory for a team's AI agents: agents search memco for proven solutions, design rationale, and gotchas before starting work, and persist what they learn afterwards, so a finding by one agent is available to the rest. Ships an MCP server, a skill, and lifecycle hooks.

Remote source pinned to memcoai/marketplace@a7db384, path plugins/shared-memory.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name: memco-shared-memory
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/memcoai/marketplace.git @ a7db3848658d19a87b6fefd60e6a5646c2e94ac0 (subdirectory: plugins/shared-memory)

- Homepage: https://memco.ai

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://spark.memco.ai/mcp (MCP server for remote memory store operations)
- Credentials/permissions it requires (and why): browser OAuth on first use, no API keys stored;

## Notes for reviewers

<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->

**Who we are.** memco (The Memory Company, https://memco.ai) builds shared memory for AI agents. Both the
`source` URL and the fork this PR comes from are our official `memcoai` org.

**Subdirectory source.** The plugin lives inside our own multi-host marketplace repo, so the
entry pins `path: plugins/shared-memory` rather than the repo root — the same pattern as
`tinyfish` (`path: grok`) and `stripe` (`path: providers/grok/plugin`).

**Why the vendored directory has several manifests.** One plugin directory serves every host
we support, so alongside `.grok-plugin/plugin.json` you'll see `.claude-plugin/`,
`.codex-plugin/`, `.devin-plugin/`, and `.cursor-plugin/` manifests, a per-host MCP config,
and per-host hook files. Grok reads `.grok-plugin/plugin.json` and, by convention,
`hooks/hooks.json`; the rest are inert on Grok.

**The four hooks in the index are no-ops on Grok — this is expected.** The generated index
lists `SessionStart`, `SubagentStart`, `UserPromptSubmit`, and `Stop`. Per the hooks guide,
stdout is ignored for passive events and `UserPromptSubmit` is observe-only, so none of them
can inject anything on Grok. We kept them because the same files serve Claude Code, Codex,
and Devin, and so the plugin would start working if Grok's Claude-compatibility layer ever
honours hook stdout. On Grok the working surface is the MCP server plus the skill.

**Hook scope is minimal.** Every hook command, in all three hook files, is a single `cat` of
a markdown file inside the plugin directory:

    cat "${CLAUDE_PLUGIN_ROOT}/content/session-start.md"

No scripts, no interpreters, no shell pipelines, no network, and no tool matchers — nothing
runs on `Bash` or `Write`. The prompt text lives in `content/*.md` so it can be edited
without touching JSON or code.

**Skill.** One skill, `shared-memory`, describing when to search memory and when to save.
It directs the agent to this plugin's own MCP tools and nothing else.