### PR TITLE
Add accountsos plugin (AI accounting, 26 countries: MCP server + tax skills + commands)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "accountsos",
+      "description": "AccountsOS AI accounting integration. Query transactions and balances, manage VAT and MTD, track HMRC and Companies House deadlines, log expenses, and chase invoices through the hosted AccountsOS MCP server, with UK tax knowledge skills verified for the 2026/27 tax year.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/thriveventurelabs/accountsos-agent-plugin.git",
+        "sha": "4a56a6cf7a31f0b46f804b324dbf4d68c2074e06"
+      },
+      "homepage": "https://accounts-os.com",
+      "keywords": ["accountsos", "accounts-os", "accountsos vat", "finn accountant"],
+      "domains": ["accounts-os.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,62 @@
 {
   "version": 1,
   "plugins": {
+    "accountsos": {
+      "sha": "4a56a6cf7a31f0b46f804b324dbf4d68c2074e06",
+      "version": "1.2.0",
+      "components": {
+        "commands": [
+          {
+            "name": "categorize",
+            "description": "Bulk review and categorize uncategorized transactions."
+          },
+          {
+            "name": "deadlines",
+            "description": "Overview of all filing deadlines with penalty warnings and countdown."
+          },
+          {
+            "name": "invoices",
+            "description": "Review outstanding and overdue invoices with chase suggestions."
+          },
+          {
+            "name": "log-expense",
+            "description": "Quick expense logging with automatic categorization."
+          },
+          {
+            "name": "vat-check",
+            "description": "Check quarterly VAT position, outstanding amounts, and filing readiness."
+          },
+          {
+            "name": "weekly-check",
+            "description": "Full weekly financial review — balance, transactions, deadlines, VAT position, invoices, and DLA."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "accountsos",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "expense-categories",
+            "description": "What UK businesses can and cannot claim as tax-deductible expenses. Auto-fires when the user asks about claiming expens…"
+          },
+          {
+            "name": "tax-deadlines",
+            "description": "UK filing dates, penalties, and compliance calendar for limited companies and sole traders. Auto-fires when the user as…"
+          },
+          {
+            "name": "uk-accounting",
+            "description": "Core UK limited company accounting knowledge. Auto-fires when the user discusses corporation tax, dividends, salary, di…"
+          },
+          {
+            "name": "vat-rules",
+            "description": "UK VAT registration, rates, schemes, and Making Tax Digital rules. Auto-fires when the user discusses VAT, registration…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

New plugin submission.

- Plugin name: `accountsos`
- Type: remote source
- Source URL + pinned SHA: https://github.com/thriveventurelabs/accountsos-agent-plugin.git @ `4a56a6cf7a31f0b46f804b324dbf4d68c2074e06`
- Homepage: https://accounts-os.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://accounts-os.com/api/mcp` only, the AccountsOS hosted MCP server that serves the user's own accounting data. Declared in the repo README.
- Credentials/permissions it requires (and why): `ACCOUNTSOS_API_KEY` (user-created in AccountsOS Settings, revocable, scoped to their own company), sent as a Bearer token to that one endpoint. No other credentials, no hooks, no shell, no telemetry.

## Notes for reviewers

AccountsOS is an AI accounting platform by Thrive Venture Labs (UK). The same repo already ships this plugin for the Claude ecosystem (`.claude-plugin/plugin.json`); this submission adds the `.grok-plugin` manifest alongside it, the same one-repo-many-agents pattern as the Vercel plugin. Skills and commands are plain markdown carrying UK tax rules (each fact cites gov.uk), verified for the 2026/27 tax year and refreshed annually. The npm scope for our MCP server matches the org (`@thriveventurelabs/accountsos-mcp`).
