### PR TITLE
Add nimble plugin (remote source, Nimbleway/agent-skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Nimbleway/agent-skills.git",
-        "sha": "a20381d24acd0fefeb26d7ca9d674a2cae4c8c4c"
+        "sha": "b341a85ee75e9d60c5627d5c2d109df06a6b8053"
       },
       "homepage": "https://www.nimbleway.com",
       "keywords": ["nimble", "nimble web search", "nimbleway"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -240,6 +240,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "nimble",
+      "description": "Live web search for AI agents. Find current pages, read any URL, and run research agents that work across many sources and return findings with citations. Includes reusable Extraction Templates for consistently shaped records from known sites, and Web Search Agents for research, enrichment, and dataset building.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Nimbleway/agent-skills.git",
+        "sha": "8bc9c811f82a3096d07c211ea0543c73203fea01"
+      },
+      "homepage": "https://www.nimbleway.com",
+      "keywords": ["nimble", "nimble web search", "nimbleway"],
+      "domains": ["nimbleway.com", "www.nimbleway.com", "mcp.nimbleway.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Nimbleway/agent-skills.git",
-        "sha": "7755b52997f7daf0d8c2b2a2067fc2e55945ac0a"
+        "sha": "a20381d24acd0fefeb26d7ca9d674a2cae4c8c4c"
       },
       "homepage": "https://www.nimbleway.com",
       "keywords": ["nimble", "nimble web search", "nimbleway"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "nimble": {
-      "sha": "7755b52997f7daf0d8c2b2a2067fc2e55945ac0a",
+      "sha": "a20381d24acd0fefeb26d7ca9d674a2cae4c8c4c",
       "version": "1.7.0",
       "components": {
         "agents": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -432,6 +432,96 @@
         ]
       }
     },
+    "nimble": {
+      "sha": "8bc9c811f82a3096d07c211ea0543c73203fea01",
+      "version": "1.6.1",
+      "components": {
+        "agents": [
+          {
+            "name": "nimble-analyst",
+            "description": "Deep analysis agent for Nimble business skills. Use when a skill needs to synthesize research findings, cross-reference…"
+          },
+          {
+            "name": "nimble-researcher",
+            "description": "Fast data gathering agent for Nimble business skills. Use proactively when a skill needs to search the web, find news,…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "search",
+            "description": "Web search (default for all search and research queries)"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "nimble",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "brand-mention-monitor",
+            "description": "Scans Reddit, X, LinkedIn, Instagram, TikTok, YouTube, blogs, news, and review platforms for brand mentions — scoring e…"
+          },
+          {
+            "name": "company-deep-dive",
+            "description": "Use this skill ANY TIME the user asks about a specific company. Triggers: \"tell me about [company]\", \"research [company…"
+          },
+          {
+            "name": "competitor-intel",
+            "description": "Searches the live web via Nimble APIs to monitor competitors and produce a structured intelligence briefing. Runs paral…"
+          },
+          {
+            "name": "competitor-positioning",
+            "description": "Tracks how competitors position themselves online — scrapes homepages, features, pricing, and blogs to extract messagin…"
+          },
+          {
+            "name": "healthcare-providers-enrich",
+            "description": "Fills gaps in existing healthcare practitioner lists — adds missing phone numbers, credentials, specialties, contact in…"
+          },
+          {
+            "name": "healthcare-providers-extract",
+            "description": "Extracts structured practitioner data from healthcare practice websites. Returns names, credentials, specialties, conta…"
+          },
+          {
+            "name": "healthcare-providers-verify",
+            "description": "Validates practitioner credentials and license status against the NPI registry. Cross-references specialties, credentia…"
+          },
+          {
+            "name": "launch-monitor",
+            "description": "Monitors press, social, developer communities, and competitor channels from any point around a product launch — trackin…"
+          },
+          {
+            "name": "local-places",
+            "description": "Discovers, enriches, and scores local businesses in any neighborhood using Nimble Web Search Agents (WSAs) and web data…"
+          },
+          {
+            "name": "market-finder",
+            "description": "Discovers all businesses of a given type in any geography using Nimble WSAs. Two modes: Discovery finds businesses from…"
+          },
+          {
+            "name": "meeting-prep",
+            "description": "Researches meeting attendees and their companies before any meeting using real-time web data. Surfaces roles, recent ac…"
+          },
+          {
+            "name": "nimble-databricks-data-products",
+            "description": "Builds Databricks data products from live web data, end to end: discovers the right Nimble web-data agents, scrapes int…"
+          },
+          {
+            "name": "nimble-web-expert",
+            "description": "Get web data now — fast, incremental, immediately responsive to what the user needs. The only way Claude can access liv…"
+          },
+          {
+            "name": "seo-intel",
+            "description": "SEO intelligence toolkit covering the full lifecycle via live web data: keyword research, rank tracking, site audits, c…"
+          },
+          {
+            "name": "talent-sourcing",
+            "description": "Finds qualified candidates for a role by searching LinkedIn, Indeed, GitHub, and other professional platforms using Nim…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "nimble": {
-      "sha": "a20381d24acd0fefeb26d7ca9d674a2cae4c8c4c",
+      "sha": "b341a85ee75e9d60c5627d5c2d109df06a6b8053",
       "version": "1.7.0",
       "components": {
         "agents": [


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-fable-5`)

## What this PR does

Adds the Nimble plugin as a remote-source catalog entry. Nimble gives Grok agents live web search, page extraction, Extraction Templates, and Web Search Agents with citations, plus ready-made business-research skills.

- Plugin name: nimble
- Type: remote source
- Source URL + pinned SHA: https://github.com/Nimbleway/agent-skills.git @ `8bc9c811f82a3096d07c211ea0543c73203fea01`
- Homepage: https://www.nimbleway.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, LICENSE at the source repo root).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.nimbleway.com/mcp` (hosted Nimble MCP server over HTTP with OAuth — search/extract/agents tools); skills optionally invoke the `@nimble-way/nimble-cli` npm CLI, which calls Nimbleway's public API for the same capabilities.
- Credentials/permissions it requires (and why): the hosted MCP server authenticates via OAuth at connect time; the optional CLI path uses a user-supplied `NIMBLE_API_KEY` environment variable. The plugin ships no credentials and reads none beyond that documented variable.

## Notes for reviewers

Submitted by a member of the Nimbleway integrations team from a personal GitHub account; the plugin source itself lives under the official `Nimbleway` org, and `homepage`/`domains` are Nimbleway-owned. Keywords/domains are brand-scoped per CONTRIBUTING.md. The pinned commit is on the source repo's active integration branch (PR Nimbleway/agent-skills#67); we will bump the pin via a follow-up if you prefer a default-branch commit.