### PR TITLE
Add Expo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/expo/skills.git",
-        "sha": "d1c68a21ec6a9249cfd2e3885364bb47b243adb2",
+        "sha": "b4473913cadf6222dec3fe7f60600012bfe926ac",
         "path": "plugins/expo"
       },
       "homepage": "https://docs.expo.dev/agents/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,7 +266,7 @@
       },
       "homepage": "https://docs.expo.dev/agents/",
       "keywords": ["expo", "react native", "android development", "ios development", "deploy to app store", "deploy to play store", "verify in ios simulator", "verify in android emulator"],
-      "domains": ["expo.dev", "docs.expo.dev", "eas.expo.dev", "expo.io"]
+      "domains": ["expo.dev", "docs.expo.dev", "expo.io"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/expo/skills.git",
-        "sha": "b4473913cadf6222dec3fe7f60600012bfe926ac",
+        "sha": "279872d51fd5b39230b942dd064514b0609def62",
         "path": "plugins/expo"
       },
       "homepage": "https://docs.expo.dev/agents/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "expo",
+      "description": "Official Expo plugin. Everything your agent needs to build, verify, deploy, and monitor an app on Android, iOS, and web.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/expo/skills.git",
+        "sha": "d1c68a21ec6a9249cfd2e3885364bb47b243adb2",
+        "path": "plugins/expo"
+      },
+      "homepage": "https://docs.expo.dev/agents/",
+      "keywords": ["expo", "react native", "android development", "ios development", "deploy to app store", "deploy to play store", "verify in ios simulator", "verify in android emulator"],
+      "domains": ["expo.dev", "docs.expo.dev", "eas.expo.dev", "expo.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -206,8 +206,8 @@
       }
     },
     "expo": {
-      "sha": "b4473913cadf6222dec3fe7f60600012bfe926ac",
-      "version": "1.11.1",
+      "sha": "279872d51fd5b39230b942dd064514b0609def62",
+      "version": "1.11.2",
       "components": {
         "hooks": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -206,8 +206,8 @@
       }
     },
     "expo": {
-      "sha": "d1c68a21ec6a9249cfd2e3885364bb47b243adb2",
-      "version": "1.11.0",
+      "sha": "b4473913cadf6222dec3fe7f60600012bfe926ac",
+      "version": "1.11.1",
       "components": {
         "hooks": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -205,6 +205,121 @@
         ]
       }
     },
+    "expo": {
+      "sha": "d1c68a21ec6a9249cfd2e3885364bb47b243adb2",
+      "version": "1.11.0",
+      "components": {
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Skill"
+          },
+          {
+            "name": "UserPromptExpansion"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "expo",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "eas-app-stores",
+            "description": "EAS service (paid). Deploy Expo apps to the app stores with EAS - build and submit to the iOS App Store, Google Play St…"
+          },
+          {
+            "name": "eas-hosting",
+            "description": "EAS service (paid). Deploy Expo websites and Expo Router API routes to EAS Hosting - export the web bundle, run eas dep…"
+          },
+          {
+            "name": "eas-observe",
+            "description": "EAS service (paid). Use for anything related to EAS Observe - adding `expo-observe` to an Expo project (AppMetricsRoot/…"
+          },
+          {
+            "name": "eas-simulator",
+            "description": "EAS service (paid). Run and control a user's app on a remote iOS/Android simulator hosted on EAS cloud. Read before run…"
+          },
+          {
+            "name": "eas-update-insights",
+            "description": "EAS service (paid). Check the health of published EAS Update: crash rates, install/launch counts, unique users, payload…"
+          },
+          {
+            "name": "eas-workflows",
+            "description": "EAS service (paid). Helps understand and write EAS workflow YAML files for Expo projects. Use this skill when the user…"
+          },
+          {
+            "name": "expo-animation",
+            "description": "Framework (OSS). Build animations in React Native and Expo, making the decisions in the order that determines whether t…"
+          },
+          {
+            "name": "expo-app-clip",
+            "description": "Framework (OSS). Add an iOS App Clip target to an Expo app. Use when the user mentions App Clip, AASA, apple-app-site-a…"
+          },
+          {
+            "name": "expo-brownfield",
+            "description": "Framework (OSS). Integrate Expo and React Native into an existing native iOS or Android app. Use when the user mentions…"
+          },
+          {
+            "name": "expo-data-fetching",
+            "description": "Framework (OSS). Use when implementing or debugging ANY network request, API call, or data fetching. Covers fetch API,…"
+          },
+          {
+            "name": "expo-design-system",
+            "description": "Framework (OSS). Build and maintain a design system inside an Expo app - a reusable theme of design tokens (color, spac…"
+          },
+          {
+            "name": "expo-dev-client",
+            "description": "Framework (OSS). Build and distribute Expo development clients locally or via TestFlight for internal testing. For prod…"
+          },
+          {
+            "name": "expo-dom",
+            "description": "Framework (OSS). Use Expo DOM components to run web code in a webview on native and as-is on web. Migrate web code to n…"
+          },
+          {
+            "name": "expo-examples",
+            "description": "Framework (OSS). Expo's official example projects - the expo/examples repo of ~70 `with-*` integrations (Stripe, Clerk,…"
+          },
+          {
+            "name": "expo-module",
+            "description": "Framework (OSS). Guide for creating and writing Expo native modules and views using the Expo Modules API (Swift, Kotlin…"
+          },
+          {
+            "name": "expo-native-ui",
+            "description": "Framework (OSS). Build beautiful, native-feeling Expo screens. Covers Apple HIG styling, semantic colors, native contro…"
+          },
+          {
+            "name": "expo-project-structure",
+            "description": "Framework (OSS). Folder structure for a new Expo app. Use when scaffolding or laying out a new Expo project with Expo R…"
+          },
+          {
+            "name": "expo-router",
+            "description": "Framework (OSS). Navigation and routing for Expo Router. Covers file-based routes, groups and dynamic routes, folder or…"
+          },
+          {
+            "name": "expo-skill-feedback",
+            "description": "Submit feedback on an Expo skill—or Expo itself—and control bundled anonymous usage telemetry (off by default / opt-in)…"
+          },
+          {
+            "name": "expo-tailwind-setup",
+            "description": "Framework (OSS). Set up Tailwind CSS v4 in Expo with react-native-css and NativeWind v5 for universal styling"
+          },
+          {
+            "name": "expo-ui",
+            "description": "Framework (OSS). Build native UI with the @expo/ui package: real SwiftUI on iOS and Jetpack Compose on Android rendered…"
+          },
+          {
+            "name": "expo-upgrade",
+            "description": "Framework (OSS). Guidelines for upgrading Expo SDK versions and fixing dependency issues"
+          },
+          {
+            "name": "expo-web-to-native",
+            "description": "Framework (OSS). Migrate an existing web React app to a native iOS/Android app with Expo. Use when the user wants to tu…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "72fcf1f4b170bcaa78fa8bef2f27cce15f4d58f4",
       "version": "2.2.95",


### PR DESCRIPTION
## What this PR does

- Plugin name: `expo`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/expo/skills.git` @ `d1c68a21ec6a9249cfd2e3885364bb47b243adb2`, path `plugins/expo`
- Homepage: https://docs.expo.dev/agents/

Official Expo plugin for Grok Build: skills for Expo Router, native UI, EAS Build/Submit/Update/Hosting, plus the hosted Expo MCP server at `https://mcp.expo.dev/mcp` (OAuth).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`expo/skills`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in `plugins/expo`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.expo.dev/mcp` — hosted Expo MCP (Streamable HTTP, OAuth). Docs, EAS builds/workflows, TestFlight, store reviews.
  - `https://api.expo.dev` — optional `submit-expo-feedback` from skills.
  - PostHog — opt-in, off-by-default anonymous skill telemetry (Claude Code hooks only; Grok skips `UserPromptExpansion`).
- Credentials/permissions it requires (and why):
  - Expo account OAuth (`mcp:access`) for MCP tools that read/write the user's Expo/EAS projects.
  - Plugin trust for hooks/MCP, same as other marketplace plugins.

## Notes for reviewers

Expo already lists this MCP in Claude's connector directory. We verified OAuth + `build_list` against Grok custom connectors.

Hooks: `PostToolUse` (matcher `Skill`) and `UserPromptExpansion` power optional skill telemetry. Telemetry is off until the user opts in. `UserPromptExpansion` is not a Grok event and is skipped. `CLAUDE_PLUGIN_ROOT` is honored via Grok's alias.

The pin is `expo/skills` `main` at 1.11.0 (`.claude-plugin` manifest). A follow-up SHA bump will pick up `.grok-plugin/plugin.json` once that lands on `main`.