### PR TITLE
Add BlitzReels video editing and generation plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "blitzreels",
+      "description": "Create and edit short-form videos with BlitzReels. Turn long-form media and supported social URLs, including X posts, into captioned clips; generate videos and carousels; edit timelines; preview results; and export finished assets through the hosted OAuth MCP server.",
+      "category": "media",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/blitzreels/agent-skills.git",
+        "sha": "f07e9dd26fa3f8e882ef4ef55ae61ed7c5e5e47d"
+      },
+      "homepage": "https://blitzreels.com/agents",
+      "keywords": ["blitzreels", "blitz reels", "blitzreels video"],
+      "domains": ["blitzreels.com", "www.blitzreels.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,40 @@
         ]
       }
     },
+    "blitzreels": {
+      "sha": "f07e9dd26fa3f8e882ef4ef55ae61ed7c5e5e47d",
+      "version": "2.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "blitzreels",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "blitzreels-carousels",
+            "description": "Create still-slide carousels with BlitzReels. Use for multi-image posts, photo mode, or swipe decks."
+          },
+          {
+            "name": "blitzreels-clipping",
+            "description": "Create, select, reframe, repair, caption, or export short clips from long-form media, including supported YouTube, Inst…"
+          },
+          {
+            "name": "blitzreels-editing",
+            "description": "Edit BlitzReels projects through CLI or REST. Use for timeline, caption, media, preview, or export changes."
+          },
+          {
+            "name": "blitzreels-generation",
+            "description": "Generate AI media with BlitzReels. Use for faceless videos, images, clips, voiceovers, music, SFX, or authored briefs."
+          },
+          {
+            "name": "blitzreels-x-video",
+            "description": "Turn an X or Twitter post, native X video, thread, conversation, or current trend into short-form video with BlitzReels…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6",
       "version": "1.7.0",


### PR DESCRIPTION
## What this PR does

Adds BlitzReels video editing and generation to the xAI catalog, with five workflow skills and one hosted OAuth MCP server.
Users can turn source videos into captioned shorts, inspect projects and transcripts, edit timelines and audio,
generate images/video/voice/music/sound, reuse characters and Story Kits, build carousels and X-to-video workflows,
and export finished MP4s.

- Plugin: `blitzreels`, version `2.1.0`
- Source: https://github.com/blitzreels/agent-skills.git
- Pinned revision: `0da20c89696705bc392d7e724768aa39ffb479d0`
- Homepage: https://www.blitzreels.com/agents

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] Source is published under the official BlitzReels organization and is MIT licensed.

## Checklist

- [x] Exactly one new catalog entry, with a unique kebab-case name and brand-scoped keywords/domains.
- [x] Remote source pins a public, reachable full commit SHA.
- [x] Component index regenerated with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes.
- [x] `python3 scripts/generate-plugin-index.py --check` passes.
- [x] `grok plugin validate` passes for the pinned source.
- [x] Homepage, description, README, and license are present.

## Security

- [x] No hooks, install scripts, remote-code execution component, or shell-exec MCP server.
- [x] No reading or exfiltration of local secrets, tokens, environment files, or environment variables.
- [x] One hosted MCP connection, scoped to the user's authorized BlitzReels workspaces.

The endpoint is `https://www.blitzreels.com/api/mcp`.
Browser OAuth may redirect through the documented auth tenant at
`https://hrkmsptefdhrnzzsphip.supabase.co`; no local API key is required.
Skills require approval before paid generation, export, publishing, deletion, or other consequential actions.

## Notes for reviewers

The branch incorporates current catalog changes and preserves every unrelated catalog and component-index entry.
The generated BlitzReels record contains five skills and the HTTP MCP server.
This update was validated structurally; it did not run a fresh authenticated Grok Bot editing or paid-generation flow.
