### PR TITLE
Add stacktree plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "stacktree",
+      "description": "Turn HTML an agent produces into a live page on a private, unguessable URL. Gate it with a passcode or a company email domain that viewers pass without creating an account, set an expiry or burn-after-read, and replace the page in place so the link you already shared keeps showing the current version. Publishing one 24-hour page needs no account at all.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/stevysmith/stacktree-mcp.git",
+        "sha": "3b56cda36604d75697138bd3221653a28c775103"
+      },
+      "homepage": "https://stacktr.ee",
+      "keywords": ["stacktree", "stacktr.ee", "publish to stacktree"],
+      "domains": ["stacktr.ee"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/stevysmith/stacktree-mcp.git",
-        "sha": "3b56cda36604d75697138bd3221653a28c775103"
+        "sha": "9af8ef24300313cdb16334ee3a252a66d9abd038"
       },
       "homepage": "https://stacktr.ee",
       "keywords": ["stacktree", "stacktr.ee", "publish to stacktree"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,24 @@
         ]
       }
     },
+    "stacktree": {
+      "sha": "3b56cda36604d75697138bd3221653a28c775103",
+      "version": "0.6.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "stacktree",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "stacktree-publish",
+            "description": "Share an HTML page privately with someone outside the chat: a client, a colleague, a stakeholder. Turns HTML you just g…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
       "version": "0.6.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "stacktree": {
-      "sha": "3b56cda36604d75697138bd3221653a28c775103",
+      "sha": "9af8ef24300313cdb16334ee3a252a66d9abd038",
       "version": "0.6.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds Stacktree, publishing for agent-generated HTML: one call turns a page into a private, unguessable URL that can be gated, expired, and replaced in place.

- Plugin name: `stacktree`
- Type: remote source
- Source URL + pinned SHA: https://github.com/stevysmith/stacktree-mcp.git @ `3b56cda36604d75697138bd3221653a28c775103`
- Homepage: https://stacktr.ee

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I have explained why not below).

Sourced from `stevysmith/stacktree-mcp`, a personal account rather than an org. I am the author of Stacktree and the sole publisher of the `stacktree-mcp` npm package (npm maintainer `stevysmith <stevy@hey.com>`), and the same account owns the entry `ee.stacktr/publish` in the official MCP Server Registry. Happy to move the source under a `stacktree` org if you would prefer that before merging.

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` in kebab-case and unique.
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] `.grok-plugin/plugin-index.json` regenerated and committed.
- [x] `homepage`, clear `description`, brand-scoped `keywords`/`domains`, and a `category`.
- [x] Licensed: MIT, stated in the source repo.
- [x] Read the security expectations.

Ran locally, all clean:

```
python3 scripts/generate-plugin-index.py
python3 scripts/validate-catalog.py          # Catalog OK
python3 scripts/generate-plugin-index.py --check  # Plugin index OK
```

The diff is additive only: +31 lines, no existing entries touched.

## Notes

The plugin exposes the hosted MCP server at `https://api.stacktr.ee/mcp` (streamable HTTP, OAuth 2.1 with dynamic client registration) plus a `stacktree-publish` skill. A stdio path exists too via `npx -y stacktree-mcp`.

Already works in the Grok ecosystem today: asked a Grok Bot to "create a standard intro page and publish it to stacktree" and it published unattended to https://stacktr.ee/p/b0mJDVwkpcWQKZkYPNKR2G/ using the anonymous no-account path.