### PR TITLE
Add wave plugin (hosted MCP server + skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "wave",
+      "description": "Wave AI notetaker integration (hosted MCP server + skill). Search and synthesize your Wave meetings, phone calls, and recordings — semantic search across transcripts and summaries, meeting prep, weekly digests, verbatim speaker-labeled quotes, and action-item management. Sign in with your Wave account via OAuth; no API key needed.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mohrer-associates/wave-grok-plugin.git",
+        "sha": "c120cad198523434e097c8abc2d2e72151cdb94c"
+      },
+      "homepage": "https://wave.co",
+      "keywords": ["wave ai", "wave notes", "wave meeting notes", "wave recordings", "wave transcript"],
+      "domains": ["wave.co", "app.wave.co", "mcp.wave.co"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -979,6 +979,24 @@
         ]
       }
     },
+    "wave": {
+      "sha": "c120cad198523434e097c8abc2d2e72151cdb94c",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wave",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "wave",
+            "description": "Search and synthesize the user's Wave meetings, calls, and recordings — meeting prep, weekly reviews, verbatim quotes,…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "aaec99ac7acea93013b6a831feb58467051626a6",
       "version": "1.16.1",


### PR DESCRIPTION
## What this PR does

New plugin: **Wave** — AI notetaker for meetings, phone calls, and recordings. The plugin bundles the hosted Wave MCP server config plus one skill for searching and synthesizing the user's recording library (semantic search, meeting prep, weekly digests, verbatim speaker-labeled quotes, action items).

- Plugin name: `wave`
- Type: remote source
- Source URL + pinned SHA: https://github.com/mohrer-associates/wave-grok-plugin.git @ `c120cad198523434e097c8abc2d2e72151cdb94c`
- Homepage: https://wave.co

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`mohrer-associates` is the GitHub org of Mohrer Associates, the company behind Wave (wave.co). All Wave repositories live under this org; the plugin's homepage and MCP endpoint are on the `wave.co` domain we operate.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.wave.co/` only — our hosted MCP server (JSON-RPC over HTTP). `https://app.wave.co` is opened in the user's browser during the OAuth flow but never called by the plugin itself.
- Credentials/permissions it requires (and why): an OAuth 2.0 + PKCE bearer token (or a manual `wave_mcp_*` token minted from app.wave.co), scoped to the authenticated user's own Wave sessions. The plugin ships no hooks, commands, or executable code — it is an `.mcp.json` config plus one markdown skill. Write tools are limited to action-item edits and folder membership; nothing can delete a session or alter a recording or transcript.

## Notes for reviewers

The same hosted MCP server already serves Claude and ChatGPT users in production. Keywords and domains are brand-scoped (multi-word `wave *` terms and our own domains) to avoid CTA misfires on the generic word "wave".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHQduLyWSGwPMz2fpP2Fky
