### PR TITLE
Add Pi Security plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,20 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "pi-security",
+      "description": "Official Pi Security integration (MCP Server + Skills). Investigate findings, review security posture, get remediation guidance, start design reviews, import Markdown reports, and apply secure-development guidance.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/pi-sloane/grok-plugin.git",
+        "sha": "dcf8dc9fcc2b54866866d2d07b1e85a3bda05d85",
+        "path": "plugins/pi-security"
+      },
+      "homepage": "https://www.pi.security/",
+      "keywords": ["pi security", "pi security appsec", "pi security findings", "pi security remediation", "pi security threat modeling", "pi security design review"],
+      "domains": ["pi.security", "mcp.pi.security"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -601,6 +601,44 @@
         ]
       }
     },
+    "pi-security": {
+      "sha": "dcf8dc9fcc2b54866866d2d07b1e85a3bda05d85",
+      "version": "0.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "pi-security",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ingest-markdown-report",
+            "description": "Submit one security report to Pi from inline Markdown and a .md or .markdown filename after tenant verification and fre…"
+          },
+          {
+            "name": "investigate-finding",
+            "description": "Investigate Pi Security findings by listing, locating, explaining, summarizing, or comparing exact FND-XXX IDs, UUIDs,…"
+          },
+          {
+            "name": "remediation-guidance",
+            "description": "Fetch existing Pi remediation guidance for a finding or vulnerable package, and optionally prepare one missing package…"
+          },
+          {
+            "name": "review-security-posture",
+            "description": "Review Pi Security posture by combining threat-model application context with Code Gatekeeper pull-request and issue re…"
+          },
+          {
+            "name": "secure-development-playbook",
+            "description": "Retrieve Pi secure-development guidance once for a stable engineering task, reconcile it with current repository eviden…"
+          },
+          {
+            "name": "security-design-review",
+            "description": "Start one Pi Security design review from a supported Confluence or Notion URL or inline Markdown after tenant verificat…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "2b8ae2ee306f823d54879d3da7f8496b73c31d5d",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official Pi Security plugin to the Grok Build marketplace as a pinned remote source.

- Plugin name: `pi-security`
- Type: remote source with URL subpath
- Source URL + pinned SHA: `https://github.com/pi-sloane/grok-plugin.git` @ `dcf8dc9fcc2b54866866d2d07b1e85a3bda05d85`
- Source path: `plugins/pi-security`
- Homepage: https://www.pi.security/

The plugin provides one hosted HTTP MCP server and six skills for investigating findings, reviewing security posture, retrieving remediation guidance, starting security design reviews, importing Markdown reports, and applying secure-development guidance.

The source repository is also a standalone Pi Security plugin marketplace, so the catalog entry uses `path: "plugins/pi-security"` to select the installable plugin root.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`pi-sloane` is Pi Security's GitHub organization for Sloane and Grok integrations. The pinned plugin manifest identifies Pi Security, `contact@pi.security`, https://www.pi.security/, and the MIT license.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated: MIT in the upstream repository and plugin manifest.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.pi.security/mcp` — Pi Security's hosted MCP endpoint for authenticated tenant queries and explicitly requested Pi actions.
- Credentials/permissions it requires (and why):
  - A Pi Security account with access to at least one tenant.
  - Browser-based OAuth/sign-in and the Pi tenant scopes granted through that flow.
  - No embedded API key, local service, or manually configured secret is required.

The plugin contains no lifecycle hooks, commands, agents, executable scripts, or installation scripts. Its six skills constrain access to named Pi tools, verify the connected tenant before tenant-data access, and require fresh explicit confirmation before uploads, design-review creation, package-plan generation, or feedback submission. Intended uploads send only user-provided content to Pi after that confirmation.

## Validation

```bash
python3 scripts/generate-plugin-index.py
python3 scripts/validate-catalog.py
python3 scripts/generate-plugin-index.py --check
```

Results:

- [x] Catalog validation passes.
- [x] Generated plugin index is current.
- [x] The index records version `0.2.1`, one HTTP MCP server, and six skills.

## Notes for reviewers

The source is pinned to the current public `main` commit. `keywords` and `domains` are limited to Pi Security's brand and owned domains to avoid generic CTA matches.

