### PR TITLE
Add grok-ultracode plugin (remote source)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/malakhov-dmitrii/grok-ultracode.git",
-        "sha": "dabf241db8f9d2a493d902d10766a0ca9418ced7"
+        "sha": "c07b9c8eeaf8e157edb99672d34e994617a13be7"
       },
       "homepage": "https://github.com/malakhov-dmitrii/grok-ultracode",
       "keywords": ["grok-ultracode", "ultracode grok", "effort ultracode"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,18 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "grok-ultracode",
+      "description": "Standing Claude-style ultracode for Grok Build CLI. On every substantive task, author and launch a deterministic workflow instead of orchestrating turn by turn.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/malakhov-dmitrii/grok-ultracode.git",
+        "sha": "dabf241db8f9d2a493d902d10766a0ca9418ced7"
+      },
+      "homepage": "https://github.com/malakhov-dmitrii/grok-ultracode",
+      "keywords": ["grok-ultracode", "ultracode grok", "effort ultracode"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,18 @@
         ]
       }
     },
+    "grok-ultracode": {
+      "sha": "dabf241db8f9d2a493d902d10766a0ca9418ced7",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "ultracode",
+            "description": "Standing Claude-style ultracode for Grok Build CLI. On every substantive task, author a deterministic workflow and laun…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,8 +328,8 @@
       }
     },
     "grok-ultracode": {
-      "sha": "dabf241db8f9d2a493d902d10766a0ca9418ced7",
-      "version": "0.1.0",
+      "sha": "c07b9c8eeaf8e157edb99672d34e994617a13be7",
+      "version": "0.1.1",
       "components": {
         "skills": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: `grok-ultracode`
- Type: remote source
- Source URL + pinned SHA: https://github.com/malakhov-dmitrii/grok-ultracode.git @ dabf241db8f9d2a493d902d10766a0ca9418ced7
- Homepage: https://github.com/malakhov-dmitrii/grok-ultracode

Adds a skills-only overlay for Grok Build CLI: standing Claude-style ultracode. Grok already has the workflow runtime; this plugin is the missing `/effort ultracode` layer so every substantive task authors and launches a workflow instead of orchestrating turn by turn.

Catalog slug is `grok-ultracode` (not `ultracode`) so it does not collide with Claude Code's native ultracode feature. The skill inside is still named `ultracode`, so `/ultracode` works after install.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

No company org exists for this overlay. Source is the author's public personal repo (`malakhov-dmitrii/grok-ultracode`), same pattern as `superpowers` (`obra/superpowers`). MIT licensed. Not affiliated with xAI or Anthropic.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none. Skills-only. It tells Grok to use the already-installed `workflow` tool and to read the bundled create-workflow skill under GROK_HOME.
- Credentials/permissions it requires (and why): none. Optional copy of `rules/ultracode.md` into the Grok rules dir is documented separately; the plugin itself does not write that.

## Notes for reviewers

- Components: one skill (`ultracode`). No MCP servers, hooks, agents, or scripts executed at install time.
- Keywords are product-scoped (`grok-ultracode`, `ultracode grok`, `effort ultracode`) to avoid generic CTA misfires.
- `install-rule.sh` in the upstream repo is a user-run helper, not a plugin hook.
