### PR TITLE
Add airwallex plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,7 +266,7 @@
       },
       "homepage": "https://www.airwallex.com/docs",
       "keywords": ["airwallex", "airwallex billing", "airwallex payouts", "airwallex issuing", "airwallex mcp"],
-      "domains": ["airwallex.com", "www.airwallex.com", "demo.airwallex.com"]
+      "domains": ["airwallex.com", "www.airwallex.com", "sandbox.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -264,7 +264,7 @@
         "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
         "path": "plugins/airwallex-agentos"
       },
-      "homepage": "https://www.airwallex.com/docs",
+      "homepage": "https://www.airwallex.com",
       "keywords": ["airwallex", "airwallex billing", "airwallex payouts", "airwallex issuing", "airwallex mcp"],
       "domains": ["airwallex.com", "www.airwallex.com", "sandbox.airwallex.com"]
     }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "airwallex-agentos",
+      "description": "Airwallex financial operations for Grok Build (MCP server + skills). Turn contracts and purchase orders into invoices and subscriptions, onboard suppliers as payout beneficiaries from their invoices, issue virtual and physical cards with spend limits, and review multi-currency balances and FX exposure. Money-out actions are intentionally excluded.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/airwallex/airwallex-marketplace.git",
+        "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
+        "path": "plugins/airwallex-agentos"
+      },
+      "homepage": "https://www.airwallex.com/docs",
+      "keywords": ["airwallex", "airwallex billing", "airwallex payouts", "airwallex issuing", "airwallex mcp"],
+      "domains": ["airwallex.com", "www.airwallex.com", "demo.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,44 @@
 {
   "version": 1,
   "plugins": {
+    "airwallex-agentos": {
+      "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
+      "version": "0.2.4",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airwallex-agentos",
+            "description": "http"
+          },
+          {
+            "name": "airwallex-dev",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "awx-best-practices",
+            "description": "Fallback Airwallex skill — works with the Airwallex CLI or the Airwallex MCP server. Use ONLY when no dedicated workflo…"
+          },
+          {
+            "name": "beneficiary-creation",
+            "description": "Extract bank details from supplier invoices or documents, validate per-country requirements, and create beneficiaries i…"
+          },
+          {
+            "name": "card-provisioning",
+            "description": "Provision virtual or physical corporate cards in Airwallex Issuing — create cardholders, issue cards with spend limits,…"
+          },
+          {
+            "name": "contract-to-billing",
+            "description": "Extract billing details from purchase orders, contracts, or quotes, then set up Airwallex Billing by creating invoices…"
+          },
+          {
+            "name": "manage-cashflow",
+            "description": "Multi-currency cash management — balances, receivables, obligations, FX exposure, runway, rebalancing, and indicative F…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the **Airwallex** plugin: finance operations on a real Airwallex account from Grok Build. Contracts and purchase orders become invoices and subscriptions, suppliers get onboarded as payout beneficiaries from their invoices, cards are issued with spend limits, and balances and FX exposure are reported across currencies. Money-out actions (transfers, FX execution, payouts, refunds) are excluded by design.

- Plugin name: `airwallex`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/airwallex/airwallex-marketplace.git` @ `b418b9913e4919f85257aa1e25319e59464e8fae` (path: `plugins/airwallex-agentos`)

Description copy refreshed to match the Cursor-facing wording:

> Bring Airwallex's global financial infrastructure to AI coding agents. Orchestrate actions across your account in plain language—for example: set up invoices from a PO, onboard suppliers from invoices, issue cards with spend limits, and check current cash position across currencies. AgentOS bundles pre-built finance Skills with MCP servers (and the airwallex CLI). Money-out actions are intentionally excluded.
- Homepage: https://www.airwallex.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`airwallex`). I work at Airwallex and have write access to it.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable (`refs/heads/master` HEAD).
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated: Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. No scripts and no `package.json`: five `SKILL.md` files, their reference docs, and MCP server declarations.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. No hooks, commands, or agents. Both MCP servers are remote `http` endpoints, so nothing executes locally.
- Network endpoints this plugin calls (and why): `https://mcp.airwallex.com/mcp` for production, and `https://mcp.sandbox.airwallex.com/developer` so users can exercise the skills against a sandbox account first.
- Credentials/permissions it requires (and why): OAuth at MCP connect time, or `airwallex auth login` for the CLI path. No keys are stored in the plugin. Skills default to sandbox and require explicit confirmation before a production write.

## Notes for reviewers

5 skills (`contract-to-billing`, `beneficiary-creation`, `card-provisioning`, `manage-cashflow`, `awx-best-practices`), 2 MCP servers, v0.2.6, Apache-2.0.

Validated the catalog and regenerated index locally. The exact public GitHub HEAD was installed in isolated Claude Code, Grok Build, and Codex configs; v0.2.6 and all five skills loaded, and non-destructive offline skill smoke tests passed in Claude Code and Grok. The xAI entry also installs successfully via `grok plugin install airwallex --trust` and fetches the pinned SHA. Cursor manifests were validated, but its current CLI did not provide a reliable isolated headless install/prompt test.

`category` is `development` to match the `stripe` entry. Keywords and domains are brand-scoped, with generic payments terms left out so the CTA does not misfire.

No separate `airwallex-dev` marketplace entry is included in this PR. The AgentOS source declares a sandbox MCP connector named `airwallex-dev`; it is an inherited component of this plugin, not the developer plugin entry.
