### PR TITLE
Add airwallex-dev plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,20 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "airwallex-dev",
+      "description": "Airwallex payments integration skills for Grok Build (MCP server + skills). Generates working integration code for Airwallex Hosted Payment Page, the Drop-in Element, Split Card Element, Billing Hosted Checkout, and connected-account KYC onboarding, plus an implementation plan for card-on-file merchant-initiated transactions.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/airwallex/airwallex-marketplace.git",
+        "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
+        "path": "plugins/airwallex-dev"
+      },
+      "homepage": "https://www.airwallex.com/docs",
+      "keywords": ["airwallex", "airwallex checkout", "airwallex drop-in", "airwallex hosted payment page", "airwallex kyc"],
+      "domains": ["airwallex.com", "www.airwallex.com", "checkout.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,7 +266,7 @@
       },
       "homepage": "https://www.airwallex.com/docs",
       "keywords": ["airwallex", "airwallex checkout", "airwallex drop-in", "airwallex hosted payment page", "airwallex kyc"],
-      "domains": ["airwallex.com", "www.airwallex.com", "checkout.airwallex.com"]
+      "domains": ["airwallex.com", "www.airwallex.com", "sandbox.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -264,7 +264,7 @@
         "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
         "path": "plugins/airwallex-dev"
       },
-      "homepage": "https://www.airwallex.com/docs",
+      "homepage": "https://www.airwallex.com",
       "keywords": ["airwallex", "airwallex checkout", "airwallex drop-in", "airwallex hosted payment page", "airwallex kyc"],
       "domains": ["airwallex.com", "www.airwallex.com", "sandbox.airwallex.com"]
     }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,44 @@
 {
   "version": 1,
   "plugins": {
+    "airwallex-dev": {
+      "sha": "c6cabe472aa2b3cda1b3d1a56e778637f50f9467",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airwallex-dev",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "airwallex-ai-provider-card-mit",
+            "description": "Use this skill to guide an end-to-end implementation plan document for card-only Airwallex Payments flows used by AI pr…"
+          },
+          {
+            "name": "airwallex-billing-checkout",
+            "description": "Guide integration of Airwallex Billing Hosted Checkout for subscription, one-off payment (PAYMENT), and card-saving (SE…"
+          },
+          {
+            "name": "airwallex-dropin",
+            "description": "Generate Airwallex Drop-in Element integration code. Use when user mentions Drop-in, dropIn element, embedded payment U…"
+          },
+          {
+            "name": "airwallex-hpp",
+            "description": "Generate Airwallex Hosted Payment Page (HPP) integration code. Use when user mentions HPP, hosted payment page, redirec…"
+          },
+          {
+            "name": "airwallex-kyc",
+            "description": "Generate Airwallex Connected Account KYC onboarding integration code. Use when user mentions KYC, embedded KYC element,…"
+          },
+          {
+            "name": "airwallex-split-card",
+            "description": "Generate Airwallex Split Card Element integration code. Use when user mentions Split Card, cardNumber element, expiry/c…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the **Airwallex Dev** plugin: integration skills that write Airwallex payments code into the user's project. Covers the Hosted Payment Page redirect flow, the Drop-in Element, the Split Card Element for custom card forms, Billing Hosted Checkout, and connected-account KYC onboarding. A sixth skill produces an implementation plan for card-on-file merchant-initiated transactions instead of generating code.

These skills work on the codebase rather than driving an account, which is what separates this plugin from `airwallex-agentos`.

- Plugin name: `airwallex-dev`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/airwallex/airwallex-marketplace.git` @ `c6cabe472aa2b3cda1b3d1a56e778637f50f9467` (path: `plugins/airwallex-dev`)
- Homepage: https://www.airwallex.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`airwallex`). I work at Airwallex and have write access to it.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable (`refs/heads/master` HEAD).
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated: Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. No scripts and no `package.json`: six `SKILL.md` files and one MCP server declaration.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. Generated code reads API keys from the user's own environment config; the skills never read those values.
- [x] Hooks and MCP scope are least-privilege. No hooks, commands, or agents, and a single remote `http` MCP server.
- Network endpoints this plugin calls (and why): `https://mcp.sandbox.airwallex.com/developer`, the sandbox developer server, so generated snippets match current API shapes. Sandbox only.
- Credentials/permissions it requires (and why): OAuth at MCP connect time against a sandbox account. No keys are stored in the plugin.

## Notes for reviewers

6 skills (`airwallex-hpp`, `airwallex-dropin`, `airwallex-split-card`, `airwallex-billing-checkout`, `airwallex-kyc`, `airwallex-ai-provider-card-mit`), 1 MCP server, v0.1.0, Apache-2.0.

Tested the documented Grok install first: `grok plugin install` resolves the plugin, `grok plugin validate` passes, and all six skills load in a headless `grok -p` session. The same `skills/` and `.mcp.json` already ship to Claude Code, Cursor, and Codex.

Keywords and domains are brand-scoped, with generic terms like `checkout` and `payments` left out so the CTA does not misfire.

`airwallex-agentos` is submitted separately in #309. Both entries point at the same repo and pinned commit, at different `path` subdirectories.