### PR TITLE
Add Oz MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "oz",
+      "description": "Oz by Anyreach: an AI teammate for researching, organizing, and executing work across connected business tools through a scoped, auditable MCP server. Sign in with OAuth; no API key is bundled.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/anyreachai/oz-mcp-plugin.git",
+        "sha": "0ca06ba5d70a3b4bcf61d6df340553b25b2f0056"
+      },
+      "homepage": "https://oz.anyreach.ai",
+      "keywords": ["oz", "anyreach", "oz ai teammate", "anyreach mcp"],
+      "domains": ["oz.anyreach.ai", "api-oz.anyreach.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -506,6 +506,18 @@
         ]
       }
     },
+    "oz": {
+      "sha": "0ca06ba5d70a3b4bcf61d6df340553b25b2f0056",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "oz",
+            "description": "streamable-http"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",


### PR DESCRIPTION
## What this PR does

- Plugin name: `oz`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/anyreachai/oz-mcp-plugin.git` @ `0ca06ba5d70a3b4bcf61d6df340553b25b2f0056`
- Homepage: `https://oz.anyreach.ai`

Adds Oz by Anyreach to the xAI plugin marketplace as a remote, SHA-pinned MCP plugin. The public source repo contains only platform manifests, a Streamable HTTP MCP configuration, documentation, and no credentials or local code execution.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the official Anyreach organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description set; source repo includes README and manifests.
- [x] License is stated in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, or environment variables.
- [x] No hooks or local executable components.
- [x] MCP scope is delegated to Oz's existing OAuth, scopes, audit trail, and approval controls.

Network endpoint:

- `https://api-oz.anyreach.ai/mcp` — Oz's production Streamable HTTP MCP endpoint.
- `https://api-oz.anyreach.ai/.well-known/oauth-protected-resource/mcp` — protected-resource discovery.
- `https://api-oz.anyreach.ai/.well-known/oauth-authorization-server/mcp` — authorization-server discovery.

Credentials/permissions:

- Users authenticate with Oz OAuth in the host client; no API key is bundled or requested by the plugin.
- Oz's existing principal scopes and approval policy govern tool access and consequential writes.

## Notes for reviewers

The live MCP endpoint and both OAuth discovery documents were checked on 2026-08-21. The live public catalog reports 416 derived tools and endpoint `https://api-oz.anyreach.ai/mcp`.
