### PR TITLE
Add Jueban Buddhist Companion plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -261,7 +261,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/hunter548686-source/jueban-buddhist-companion.git",
-        "sha": "6f5e9d8df66e744d092a99220faca4a6767c34f3"
+        "sha": "da58831d749f00eadafe926b834afa4ebdb593f9"
       },
       "homepage": "https://jueban.online/",
       "keywords": ["jueban", "jueban buddhist companion", "jueban scripture"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -260,7 +260,7 @@
       "category": "education",
       "source": {
         "source": "url",
-        "url": "https://github.com/hunter548686-source/jueban-buddhist-companion.git",
+        "url": "https://github.com/assetgrid-llc/jueban-buddhist-companion.git",
         "sha": "da58831d749f00eadafe926b834afa4ebdb593f9"
       },
       "homepage": "https://jueban.online/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -253,6 +253,19 @@
       "homepage": "https://www.tinyfish.ai",
       "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
       "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "jueban-buddhist-companion",
+      "description": "Jueban Buddhist Companion integration for Grok Build. Search traceable Buddhist scripture, verify and explain passages, find source-backed passages relevant to a life situation, and create one-time read, listen, or view practices through Jueban's anonymous read-only MCP server.",
+      "category": "education",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/hunter548686-source/jueban-buddhist-companion.git",
+        "sha": "6f5e9d8df66e744d092a99220faca4a6767c34f3"
+      },
+      "homepage": "https://jueban.online/",
+      "keywords": ["jueban", "jueban buddhist companion", "jueban scripture"],
+      "domains": ["jueban.online"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -328,8 +328,8 @@
       }
     },
     "jueban-buddhist-companion": {
-      "sha": "6f5e9d8df66e744d092a99220faca4a6767c34f3",
-      "version": "1.0.0",
+      "sha": "da58831d749f00eadafe926b834afa4ebdb593f9",
+      "version": "1.0.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,24 @@
         ]
       }
     },
+    "jueban-buddhist-companion": {
+      "sha": "6f5e9d8df66e744d092a99220faca4a6767c34f3",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "jueban",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "jueban-buddhist-companion",
+            "description": "Use Jueban's traceable Buddhist canon and one-time practice tools whenever a user asks to find or source scripture, exp…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `jueban-buddhist-companion`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/assetgrid-llc/jueban-buddhist-companion.git` at `da58831d749f00eadafe926b834afa4ebdb593f9`
- Homepage: `https://jueban.online/`

Adds AssetGrid LLC’s official Jueban Buddhist Companion integration for Grok Build. The plugin connects to Jueban’s anonymous, read-only production MCP for traceable Buddhist scripture search, verified passage explanation, situation-based source-backed passage discovery, and one-time read/listen/view practice guidance.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one valid kebab-case entry to `.grok-plugin/marketplace.json`.
- [x] Remote source pins a public, reachable full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set.
- [x] Connector package license is Apache License 2.0; `NOTICE` states the connector-only scope and trademark boundary.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] MCP scope is least-privilege and exposes exactly four annotated read-only tools.
- Network endpoint: `https://jueban.online/mcp`, used only for the declared Buddhist scripture and one-time practice MCP calls.
- Credentials/permissions required: none. No Jueban account access, saved progress, payment access, or write capability.

## Notes for reviewers

The source is published by AssetGrid LLC under the official `assetgrid-llc` GitHub organization. The connector package is Apache-2.0 licensed; the Jueban product source, scripture corpus/databases, editorial/media content, server implementation, and trademarks are explicitly outside that connector license. The production MCP remains version 1.0.0 and exposes only the four declared anonymous read-only tools.