### PR TITLE
Add selat plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,20 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "selat",
+      "description": "Discover and pay for tools your agent does not have built in. Search is free. Paid calls settle from the user's own Circle Agent Wallet (self-custody). No vendor API key.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/SELAT-AI/selat-plugins.git",
+        "sha": "064fd3b83e7d10a50888dc2c34295e6bccd5e8c7",
+        "path": "plugins/selat"
+      },
+      "homepage": "https://selat.ai",
+      "keywords": ["selat", "x402", "circle", "agent wallet", "usdc"],
+      "domains": ["selat.ai", "catalog.selat.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -723,6 +723,34 @@
         ]
       }
     },
+    "selat": {
+      "sha": "064fd3b83e7d10a50888dc2c34295e6bccd5e8c7",
+      "version": "0.1.9",
+      "components": {
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Bash|WebFetch|WebSearch|mcp__.*"
+          },
+          {
+            "name": "PreToolUse",
+            "description": "Bash"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "selat-discovery",
+            "description": "Use the moment you're about to tell the user you can't do something — or about to suggest they sign up for, get an API…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
       "version": "1.3.2",


### PR DESCRIPTION
## What this PR does

Adds one remote catalog entry for **selat**: discover and pay for tools the agent does not have built in. Search is free. Paid calls settle from the user's own Circle Agent Wallet (self-custody). No vendor API key.

- Plugin name: `selat`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/SELAT-AI/selat-plugins.git` @ `064fd3b83e7d10a50888dc2c34295e6bccd5e8c7`, path `plugins/selat`
- Homepage: https://selat.ai

This is the no-vendor-key / pay-from-wallet row. SELAT is not a Tavily replacement.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is `SELAT-AI/selat-plugins` under our official org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: Apache-2.0 (Copyright 2026 SELAT AI Labs, Inc.), in `LICENSE` at the pinned commit.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `catalog.selat.ai` for free discovery/search; Circle Agent Wallet / Gateway APIs via the Circle CLI for wallet status, email-OTP session, and settlement; federated x402 / MPP provider endpoints only when the user explicitly approves a paid call; npm registry for the SessionStart hook's reviewed pin+lock install (`npm ci --ignore-scripts`).
- Credentials/permissions it requires (and why): no vendor API key. Paid calls settle from the user's own Circle Agent Wallet after explicit approval and an armed session budget. Wallet login uses the user's Circle email + OTP (relayed by the user; SELAT does not hold keys or funds). Read-only discovery (`selat search`, `selat skill list`, `selat doctor`) needs no wallet.

Components at the pinned SHA (from `scripts/generate-plugin-index.py`): skill `selat-discovery`; hooks `SessionStart`, `UserPromptSubmit`, `PreToolUse` (Bash), `PostToolUse`. No MCP servers or LSP servers in the Grok plugin. Version `0.1.9`.

## Notes for reviewers

SELAT Grok support is in `plugins/selat` at `064fd3b83e7d10a50888dc2c34295e6bccd5e8c7`. The catalog description is the no-vendor-key / pay-from-wallet positioning: search is free; spend is opt-in from the user's self-custody Circle Agent Wallet.