### PR TITLE
feat: add AgentLed Grok Build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,20 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "agentled",
+      "description": "Build, validate, and operate AgentLed workflows from Grok Build with the AgentLed MCP server and workflow-authoring skills. Authenticate with your own AgentLed CLI profile, then begin with read-only discovery.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Agentled/mcp-server.git",
+        "sha": "0fd2c8a34a650adffe55508e82e69a64a6f920b4",
+        "path": "plugins/agentled"
+      },
+      "homepage": "https://www.agentled.ai/en/developers",
+      "keywords": ["agentled", "agentled workflows", "agentled mcp"],
+      "domains": ["agentled.ai", "agentled.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,43 @@
 {
   "version": 1,
   "plugins": {
+    "agentled": {
+      "sha": "0fd2c8a34a650adffe55508e82e69a64a6f920b4",
+      "version": "0.19.3",
+      "components": {
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Bash|apply_patch|Edit|Write"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "agentled",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agentled",
+            "description": "Build, manage, and execute Agentled AI workflows via MCP tools. Use when the user asks to create workflows, automate ta…"
+          },
+          {
+            "name": "linkedin-assistant",
+            "description": "Use when tracking LinkedIn activity, connection quotas, replies, meetings, follow-ups, or approval-ready LinkedIn actio…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `agentled`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Agentled/mcp-server.git` @ `0fd2c8a34a650adffe55508e82e69a64a6f920b4`, path `plugins/agentled`
- Homepage: https://www.agentled.ai/en/developers

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the official Agentled org.

## Checklist

- [x] Added exactly one kebab-case catalog entry.
- [x] Pinned a public, full 40-character SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [ ] The full `generate-plugin-index.py --check` exceeded the local command time limit while refetching third-party sources; CI should run the authoritative check.
- [x] Homepage, description, brand-scoped keywords/domains, and license are present.

## Security

- [x] No credentials, workspace IDs, customer data, or secrets are contained in the plugin source.
- [x] The plugin starts the published `@agentled/mcp-server@0.19.3` local stdio server through the existing `.mcp.json`; users authenticate with their own Agentled CLI profile.
- Network endpoint: `mcp.agentled.app` only after a user-authenticated Agentled action; package retrieval uses the npm registry.
- Credentials/permissions: an explicit local Agentled CLI profile; no credential is bundled.

## Notes for reviewers

Grok Build is the documented plugin distribution path. The related Grok Bot launch remains beta until a separate disposable-workspace, read-only OAuth/tool-discovery proof is observed.