### PR TITLE
Add Shipmail plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "shipmail",
+      "description": "Shipmail custom-domain business email and calendar integration for agents. Triage inboxes, draft and send approved replies, manage mailboxes, calendars, webhooks, and newsletters through the hosted OAuth MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/shipmail-to/shipmail-mcp.git",
+        "sha": "c1ef9920972ef436f07180e5b4bdd0fa49998e70"
+      },
+      "homepage": "https://shipmail.to/docs/mcp",
+      "keywords": ["shipmail", "shipmail email", "shipmail mcp", "shipmail inbox"],
+      "domains": ["shipmail.to"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -815,6 +815,24 @@
         ]
       }
     },
+    "shipmail": {
+      "sha": "c1ef9920972ef436f07180e5b4bdd0fa49998e70",
+      "version": "0.7.15",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "shipmail",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "shipmail",
+            "description": "Operate Shipmail custom-domain business email, agent inboxes, calendars, booking pages, newsletters, webhooks, and rela…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "68382523846ea5bfad75ba1ef58dc5db031d0a5a",
       "version": "0.6.4",


### PR DESCRIPTION
## What this PR does

- Plugin name: shipmail
- Type: remote source
- Source URL + pinned SHA: https://github.com/shipmail-to/shipmail-mcp.git @ c1ef9920972ef436f07180e5b4bdd0fa49998e70
- Homepage: https://shipmail.to/docs/mcp

Adds the official Shipmail plugin: a hosted OAuth MCP server plus a safety-focused skill for custom-domain business email, inbox triage, approved replies, calendars, webhooks, and newsletters.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a public, reachable full commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or postinstall RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks; the MCP scope is limited to the declared hosted Shipmail server.
- Network endpoint: `https://shipmail.to/api/mcp`, the official hosted Shipmail MCP endpoint.
- Credentials/permissions: OAuth is preferred and handled by the MCP client; scoped Shipmail bearer API keys are also supported. The bundled skill directs clients to start with read-and-draft permissions and require explicit approval before sending or consequential changes.

## Notes for reviewers

The generated index discovers both expected components at version 0.7.15:

- MCP server: `shipmail` (HTTP)
- Skill: `shipmail`

The public source is under the official `shipmail-to` GitHub organization and includes its MIT license, README, portable plugin manifests, skill, and root `.mcp.json`.
