### PR TITLE
feat(plugins): add agentplaybooks

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,20 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "agentplaybooks",
+      "description": "Audit and sync portable agent playbooks: skills, MCP configs, and instructions across Claude Code, Cursor, Codex, and Grok.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/matebenyovszky/agentplaybooks.git",
+        "sha": "9c0aff06748556e60e9b2bfdc7585207374c3e0e",
+        "path": "packages/cli"
+      },
+      "homepage": "https://agentplaybooks.ai",
+      "keywords": ["agentplaybooks", "agent playbooks"],
+      "domains": ["agentplaybooks.ai", "apbks.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,40 @@
 {
   "version": 1,
   "plugins": {
+    "agentplaybooks": {
+      "sha": "9c0aff06748556e60e9b2bfdc7585207374c3e0e",
+      "version": "0.3.0-beta.0",
+      "components": {
+        "commands": [
+          {
+            "name": "connect",
+            "description": "Connect this project to a hosted playbook's MCP endpoint — plan first, apply on approval"
+          },
+          {
+            "name": "doctor",
+            "description": "Audit agent configuration health (instructions, skills, MCP, secrets, drift)"
+          },
+          {
+            "name": "pull",
+            "description": "Pull a remote playbook's skills from agentplaybooks.ai into this project"
+          },
+          {
+            "name": "push",
+            "description": "Push local skills and the playbook manifest to agentplaybooks.ai"
+          },
+          {
+            "name": "sync",
+            "description": "Sync the playbook manifest and platform files across agent tools — plan first, apply on approval"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agentplaybooks",
+            "description": "Audit, synchronize, and share portable agent configuration (instructions, Agent Skills, MCP servers) with the AgentPlay…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `agentplaybooks`
- Type: third-party remote pin of `matebenyovszky/agentplaybooks@9c0aff06748556e60e9b2bfdc7585207374c3e0e`
- Path: `packages/cli`
- Homepage: https://agentplaybooks.ai
- License: MIT (stated in `packages/cli/LICENSE` and `packages/cli/.claude-plugin/plugin.json`)

Adds one catalog entry so Grok Build can install AgentPlaybooks from this marketplace. Public product repo. Plugin root is `packages/cli` (Claude-ecosystem `plugin.json`; CONTRIBUTING accepts that).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under an official GitHub org.

Source is the public personal account `matebenyovszky/agentplaybooks`. There is no AgentPlaybooks GitHub organization. I am the author (Máté Benyovszky). Brand/homepage: https://agentplaybooks.ai. If this personal-account source is a blocker, stop — we will not move the repo for this listing.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a public, reachable full 40-char commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` was run as part of preparing this branch.
- [x] Homepage and description set; keywords brand-scoped.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or postinstall RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- No hooks or MCP servers in the plugin root.
- Components from `packages/cli`: skill `agentplaybooks`; commands `connect`, `doctor`, `pull`, `push`, `sync`.
- Network: agentplaybooks.ai for pull/push/sync when those commands are used. Marketplace install does not require credentials.
