### PR TITLE
Add Wingify MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -275,7 +275,7 @@
         "type": "local",
         "path": "./external_plugins/wingify"
       },
-      "homepage": "https://developers.vwo.com/v2/docs/fme-mcp-server",
+      "homepage": "https://vwo.com/ai",
       "keywords": ["wingify", "wingify mcp", "vwo", "vwo mcp", "feature management and experimentation"],
       "domains": ["wingify.com", "vwo.com", "mcp.wingify.ai", "developers.vwo.com"]
     }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,18 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "wingify",
+      "description": "Wingify helps teams analyze experimentation performance, review behavior insights, and manage testing campaigns directly from Grok. Create and manage A/B and split URL campaigns, feature flags and rules, calculate sample sizes, and fetch campaign reports and FME metrics.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/wingify"
+      },
+      "homepage": "https://developers.vwo.com/v2/docs/fme-mcp-server",
+      "keywords": ["wingify", "wingify mcp", "vwo", "vwo mcp", "feature management and experimentation"],
+      "domains": ["wingify.com", "vwo.com", "mcp.wingify.ai", "developers.vwo.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1176,6 +1176,17 @@
         ]
       }
     },
+    "wingify": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wingify",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "abff05613bf82101095a96b43b033150bfd8e145",
       "version": "1.16.3",

--- a/external_plugins/wingify/.grok-plugin/plugin.json
+++ b/external_plugins/wingify/.grok-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "wingify",
+  "version": "1.0.0",
+  "description": "Wingify helps teams analyze experimentation performance, review behavior insights, and manage testing campaigns directly from Grok. Create and manage A/B and split URL campaigns, feature flags and rules, calculate sample sizes, and fetch campaign reports and FME metrics.",
+  "author": {
+    "name": "Wingify",
+    "url": "https://wingify.com"
+  },
+  "homepage": "https://developers.vwo.com/v2/docs/fme-mcp-server",
+  "license": "Proprietary",
+  "keywords": ["wingify", "wingify mcp", "vwo", "vwo mcp", "feature management and experimentation"]
+}

--- a/external_plugins/wingify/.grok-plugin/plugin.json
+++ b/external_plugins/wingify/.grok-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Wingify",
     "url": "https://wingify.com"
   },
-  "homepage": "https://developers.vwo.com/v2/docs/fme-mcp-server",
+  "homepage": "https://vwo.com/ai",
   "license": "Proprietary",
   "keywords": ["wingify", "wingify mcp", "vwo", "vwo mcp", "feature management and experimentation"]
 }

--- a/external_plugins/wingify/.mcp.json
+++ b/external_plugins/wingify/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "wingify": {
+      "type": "http",
+      "url": "https://mcp.wingify.ai/mcp"
+    }
+  }
+}

--- a/external_plugins/wingify/README.md
+++ b/external_plugins/wingify/README.md
@@ -8,8 +8,8 @@ reports and Feature Management & Experimentation (FME) metrics — all with natu
 queries, no manual exporting or copy/pasting required.
 
 - MCP server: `https://mcp.wingify.ai/mcp` (OAuth)
-- API docs: https://developers.vwo.com/v2/docs/fme-mcp-server
-- Setup guide: https://help.wingify.com/hc/en-us/articles/58792565345305-Connect-Wingify-with-AI-Tools-using-Wingify-s-MCP-Server
+- Homepage: https://vwo.com/ai
+- API docs: https://help.wingify.com/hc/en-us/articles/58792565345305-Connect-Wingify-with-AI-Tools-using-Wingify-s-MCP-Server
 
 ## Network endpoints
 

--- a/external_plugins/wingify/README.md
+++ b/external_plugins/wingify/README.md
@@ -1,0 +1,17 @@
+# Wingify
+
+Optimize Digital Experiences. Official Wingify MCP server integration — connects Grok to your
+Wingify (VWO) account so you can analyze experimentation performance, review behavior insights,
+and manage testing campaigns directly from your agent: create and manage A/B and split URL
+campaigns, create and toggle feature flags and rules, calculate sample sizes, and fetch campaign
+reports and Feature Management & Experimentation (FME) metrics — all with natural-language
+queries, no manual exporting or copy/pasting required.
+
+- MCP server: `https://mcp.wingify.ai/mcp` (OAuth)
+- API docs: https://developers.vwo.com/v2/docs/fme-mcp-server
+- Setup guide: https://help.wingify.com/hc/en-us/articles/58792565345305-Connect-Wingify-with-AI-Tools-using-Wingify-s-MCP-Server
+
+## Network endpoints
+
+This plugin only connects to the Wingify-hosted MCP endpoint above. Authentication is handled via
+OAuth when the connector is first used; no credentials are stored in this repo.


### PR DESCRIPTION
## Summary
- Adds the Wingify MCP server (`https://mcp.wingify.ai/mcp`) to the catalog as a local plugin under `external_plugins/wingify/`.
- Wingify (VWO) lets teams analyze experimentation performance, review behavior insights, and manage A/B/split-URL campaigns, feature flags & rules, sample size calculations, and campaign/FME reports directly from Grok via natural-language queries.
- Auth is OAuth, handled by the connector on first use — no credentials vendored here.

## Test plan
- [x] `python3 scripts/validate-catalog.py` passes
- [x] `python3 scripts/generate-plugin-index.py --check` passes (index regenerated and committed)
- [x] Valid JSON, `name` is kebab-case and unique
- [x] Local plugin includes `README.md` and `.grok-plugin/plugin.json`