### PR TITLE
Add knowz and knowzcode plugins

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "base44",
@@ -78,8 +100,17 @@
         "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
-      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
-      "domains": ["base44.com", "docs.base44.com"]
+      "keywords": [
+        "base44",
+        "base44 cli",
+        "base44 sdk",
+        "base44 app",
+        "base44 deploy"
+      ],
+      "domains": [
+        "base44.com",
+        "docs.base44.com"
+      ]
     },
     {
       "name": "mongodb",
@@ -92,8 +123,16 @@
         "path": "plugins/mongodb"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
-      "domains": ["mongodb.com"]
+      "keywords": [
+        "mongodb community",
+        "mongo",
+        "mongosh",
+        "mongodb local mcp",
+        "enterprise advanced"
+      ],
+      "domains": [
+        "mongodb.com"
+      ]
     },
     {
       "name": "mongodb-atlas",
@@ -106,8 +145,17 @@
         "path": "plugins/mongodb-atlas"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb atlas",
+        "atlas",
+        "mongodb",
+        "atlas cluster",
+        "atlas mcp"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -119,8 +167,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -131,8 +184,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "wix",
@@ -144,8 +206,18 @@
         "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
       },
       "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
-      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
+      "keywords": [
+        "wix",
+        "wix cli",
+        "wix mcp",
+        "wix apps",
+        "wix headless"
+      ],
+      "domains": [
+        "wix.com",
+        "dev.wix.com",
+        "manage.wix.com"
+      ]
     },
     {
       "name": "netlify",
@@ -157,12 +229,19 @@
         "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
       },
       "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
-      "domains": ["netlify.com", "app.netlify.com"]
+      "keywords": [
+        "netlify",
+        "netlify deploy",
+        "deploy to netlify"
+      ],
+      "domains": [
+        "netlify.com",
+        "app.netlify.com"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -170,8 +249,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -183,8 +268,14 @@
         "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -196,8 +287,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -209,8 +308,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -223,8 +331,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -237,12 +352,22 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -251,8 +376,17 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
     },
     {
       "name": "pstack",
@@ -265,11 +399,15 @@
         "path": "pstack"
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": ["pstack", "poteto-mode", "poteto"]
+      "keywords": [
+        "pstack",
+        "poteto-mode",
+        "poteto"
+      ]
     },
     {
       "name": "browser-use",
-      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",
       "source": {
         "source": "url",
@@ -278,35 +416,57 @@
         "path": "grok"
       },
       "homepage": "https://browser-use.com",
-      "keywords": ["browser use", "browser-use", "browser use cloud"],
-      "domains": ["browser-use.com", "cloud.browser-use.com"]
+      "keywords": [
+        "browser use",
+        "browser-use",
+        "browser use cloud"
+      ],
+      "domains": [
+        "browser-use.com",
+        "cloud.browser-use.com"
+      ]
     },
     {
       "name": "knowz",
-      "description": "Knowz team knowledge vaults over a hosted MCP server. Search, ask, save, browse, and amend the decisions, conventions, and prior art your team has already written down, so Grok answers from your own history instead of guessing. Authorize once with a Knowz account — no API keys in the package. Install KnowzCode separately for the TDD workflow.",
+      "description": "Knowz team knowledge vaults over a hosted MCP server. Search, ask, save, browse, and amend the decisions, conventions, and prior art your team has already written down, so Grok answers from your own history instead of guessing. Authorize once with a Knowz account \u2014 no API keys in the package. Install KnowzCode separately for the TDD workflow.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/knowz-io/cursor-knowz-plugin.git",
-        "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+        "sha": "38d5faf24c66ec1fa8fe29423b24f5d3765f8156",
         "path": "plugins/knowz"
       },
       "homepage": "https://knowz.io",
-      "keywords": ["knowz", "knowz vault", "knowz ai", "ask knowz", "save to knowz"],
-      "domains": ["knowz.io", "app.knowz.io", "mcp.knowz.io"]
+      "keywords": [
+        "knowz",
+        "knowz vault",
+        "knowz ai",
+        "ask knowz",
+        "save to knowz"
+      ],
+      "domains": [
+        "knowz.io",
+        "app.knowz.io",
+        "mcp.knowz.io"
+      ]
     },
     {
       "name": "knowzcode",
-      "description": "KnowzCode: structured TDD with quality gates, spec-driven phases, and local handoffs that survive a context clear. Optionally relays implementation to a Claude Code or Codex CLI you already have installed, while Grok plans, reviews, and finalizes. Ships no MCP server — install Knowz separately if you want team vaults.",
+      "description": "KnowzCode: structured TDD with quality gates, spec-driven phases, and local handoffs that survive a context clear. Optionally relays implementation to a Claude Code or Codex CLI you already have installed, while Grok plans, reviews, and finalizes. Ships no MCP server \u2014 install Knowz separately if you want team vaults.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/knowz-io/cursor-knowz-plugin.git",
-        "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+        "sha": "38d5faf24c66ec1fa8fe29423b24f5d3765f8156",
         "path": "plugins/knowzcode"
       },
       "homepage": "https://knowz.io",
-      "keywords": ["knowzcode", "knowz code", "knowzcode workflow", "knowzcode relay"]
+      "keywords": [
+        "knowzcode",
+        "knowz code",
+        "knowzcode workflow",
+        "knowzcode relay"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,33 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "knowz",
+      "description": "Knowz team knowledge vaults over a hosted MCP server. Search, ask, save, browse, and amend the decisions, conventions, and prior art your team has already written down, so Grok answers from your own history instead of guessing. Authorize once with a Knowz account — no API keys in the package. Install KnowzCode separately for the TDD workflow.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/knowz-io/cursor-knowz-plugin.git",
+        "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+        "path": "plugins/knowz"
+      },
+      "homepage": "https://knowz.io",
+      "keywords": ["knowz", "knowz vault", "knowz ai", "ask knowz", "save to knowz"],
+      "domains": ["knowz.io", "app.knowz.io", "mcp.knowz.io"]
+    },
+    {
+      "name": "knowzcode",
+      "description": "KnowzCode: structured TDD with quality gates, spec-driven phases, and local handoffs that survive a context clear. Optionally relays implementation to a Claude Code or Codex CLI you already have installed, while Grok plans, reviews, and finalizes. Ships no MCP server — install Knowz separately if you want team vaults.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/knowz-io/cursor-knowz-plugin.git",
+        "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+        "path": "plugins/knowzcode"
+      },
+      "homepage": "https://knowz.io",
+      "keywords": ["knowzcode", "knowz code", "knowzcode workflow", "knowzcode relay"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,104 @@
         ]
       }
     },
+    "knowz": {
+      "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+      "version": "0.1.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "knowz",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "knowz-amend",
+            "description": "Apply a targeted server-side edit to an existing Knowz vault item without retyping the whole entry. Use when the user d…"
+          },
+          {
+            "name": "knowz-ask",
+            "description": "Ask AI-powered questions against Knowz vaults. Use when the user asks about prior decisions, conventions, architecture,…"
+          },
+          {
+            "name": "knowz-auto",
+            "description": "Lightweight Knowz intent routing for Grok Bot and Cursor. Use when the user's message looks like a knowledge lookup, a…"
+          },
+          {
+            "name": "knowz-browse",
+            "description": "Browse Knowz vault contents, topics, and recent items. Use when the user wants to explore what exists in their vaults o…"
+          },
+          {
+            "name": "knowz-flush",
+            "description": "Flush idempotent queued knowledge operations (create, amend, update) from the project-root knowz-pending.md queue. Use…"
+          },
+          {
+            "name": "knowz-save",
+            "description": "Capture decisions, patterns, conventions, workarounds, and durable learnings to Knowz vaults. Use when the user shares…"
+          },
+          {
+            "name": "knowz-search",
+            "description": "Search Knowz vaults semantically. Use when the user wants prior art, related work, conventions, examples, or a broad se…"
+          },
+          {
+            "name": "knowz-setup",
+            "description": "Connect Knowz MCP and create vault routing files. Use after installing the Knowz plugin, for first-time vault mapping,…"
+          },
+          {
+            "name": "knowz-status",
+            "description": "Check Knowz MCP health, Authorize state, vault routing, and pending captures. Use for diagnostics, setup verification,…"
+          }
+        ]
+      }
+    },
+    "knowzcode": {
+      "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
+      "version": "0.2.0",
+      "components": {
+        "skills": [
+          {
+            "name": "continue",
+            "description": "Resume an interrupted KnowzCode workflow, including Grok-host process relay. Use when the user wants to continue an act…"
+          },
+          {
+            "name": "explore",
+            "description": "Research a codebase area before implementation. Use when the user wants investigation, architectural context, prior art…"
+          },
+          {
+            "name": "fix",
+            "description": "Apply a quick, targeted KnowzCode micro-fix. Use when the requested change is small, localized, and does not need the f…"
+          },
+          {
+            "name": "regroup",
+            "description": "Create a local KnowzCode handoff before clearing context. Use when the user wants to pause, wrap up, step away, clear c…"
+          },
+          {
+            "name": "regroup-trigger",
+            "description": "Detect pause, wrap-up, handoff, or clear-context intent and offer a KnowzCode regroup handoff. Triggers when the user s…"
+          },
+          {
+            "name": "relay",
+            "description": "Relay implementation from Grok Bot / Cursor to Claude Code or Codex while Grok plans, reviews, and finalizes. Use when…"
+          },
+          {
+            "name": "setup",
+            "description": "Initialize KnowzCode in a repository for Grok Bot and Cursor: framework files, project personalization, and the Cursor…"
+          },
+          {
+            "name": "start-work",
+            "description": "Route implementation intent into KnowzCode workflow mode. Use for 'start building', 'go ahead', 'implement this plan',…"
+          },
+          {
+            "name": "status",
+            "description": "Check KnowzCode project health, active work, pending captures, and Grok-host process relay configuration, readiness, an…"
+          },
+          {
+            "name": "work",
+            "description": "Start a structured KnowzCode workflow for feature work, multi-file changes, or meaningful refactors with TDD and qualit…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -14,31 +14,31 @@
         "skills": [
           {
             "name": "axiom-alerting",
-            "description": "Create and manage Axiom monitors and notifiers via the v2 public API. Use when building alerting, routing notifications…"
+            "description": "Create and manage Axiom monitors and notifiers via the v2 public API. Use when building alerting, routing notifications\u2026"
           },
           {
             "name": "axiom-sre",
-            "description": "Expert SRE investigator for incidents and debugging. Uses hypothesis-driven methodology and systematic triage. Can quer…"
+            "description": "Expert SRE investigator for incidents and debugging. Uses hypothesis-driven methodology and systematic triage. Can quer\u2026"
           },
           {
             "name": "building-dashboards",
-            "description": "Designs and builds Axiom dashboards via API. Covers chart types, APL and metrics/MPL query patterns, SmartFilters, layo…"
+            "description": "Designs and builds Axiom dashboards via API. Covers chart types, APL and metrics/MPL query patterns, SmartFilters, layo\u2026"
           },
           {
             "name": "controlling-costs",
-            "description": "Analyzes Axiom query patterns to find unused data, then builds dashboards and monitors for cost optimization. Use when…"
+            "description": "Analyzes Axiom query patterns to find unused data, then builds dashboards and monitors for cost optimization. Use when\u2026"
           },
           {
             "name": "query-metrics",
-            "description": "Runs metrics queries against Axiom MetricsDB via scripts. Discovers available metrics, tags, and tag values. Use when a…"
+            "description": "Runs metrics queries against Axiom MetricsDB via scripts. Discovers available metrics, tags, and tag values. Use when a\u2026"
           },
           {
             "name": "spl-to-apl",
-            "description": "Translates Splunk SPL queries to Axiom APL. Provides command mappings, function equivalents, and syntax transformations…"
+            "description": "Translates Splunk SPL queries to Axiom APL. Provides command mappings, function equivalents, and syntax transformations\u2026"
           },
           {
             "name": "writing-evals",
-            "description": "Scaffolds evaluation suites for the Axiom AI SDK. Generates eval files, scorers, flag schemas, and config from natural-…"
+            "description": "Scaffolds evaluation suites for the Axiom AI SDK. Generates eval files, scorers, flag schemas, and config from natural-\u2026"
           }
         ]
       }
@@ -50,23 +50,23 @@
         "skills": [
           {
             "name": "base44-cli",
-            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
+            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,\u2026"
           },
           {
             "name": "base44-remote-dev",
-            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t…"
+            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t\u2026"
           },
           {
             "name": "base44-sandbox",
-            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent — no local checkout and no deploy/push…"
+            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent \u2014 no local checkout and no deploy/push\u2026"
           },
           {
             "name": "base44-sdk",
-            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r…"
+            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r\u2026"
           },
           {
             "name": "base44-troubleshooter",
-            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls…"
+            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls\u2026"
           }
         ]
       }
@@ -84,7 +84,7 @@
         "skills": [
           {
             "name": "browser-use",
-            "description": "Browser Use — direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/…"
+            "description": "Browser Use \u2014 direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/\u2026"
           }
         ]
       }
@@ -102,27 +102,27 @@
         "skills": [
           {
             "name": "a11y-debugging",
-            "description": "Uses Chrome DevTools MCP for accessibility (a11y) debugging and auditing based on web.dev guidelines. Use when testing…"
+            "description": "Uses Chrome DevTools MCP for accessibility (a11y) debugging and auditing based on web.dev guidelines. Use when testing\u2026"
           },
           {
             "name": "chrome-devtools",
-            "description": "Uses Chrome DevTools via MCP for efficient debugging, troubleshooting and browser automation. Use when debugging web pa…"
+            "description": "Uses Chrome DevTools via MCP for efficient debugging, troubleshooting and browser automation. Use when debugging web pa\u2026"
           },
           {
             "name": "chrome-devtools-cli",
-            "description": "Use this skill to write shell scripts or run shell commands to automate tasks in the browser or otherwise use Chrome De…"
+            "description": "Use this skill to write shell scripts or run shell commands to automate tasks in the browser or otherwise use Chrome De\u2026"
           },
           {
             "name": "debug-optimize-lcp",
-            "description": "Guides debugging and optimizing Largest Contentful Paint (LCP) using Chrome DevTools MCP tools. Use this skill whenever…"
+            "description": "Guides debugging and optimizing Largest Contentful Paint (LCP) using Chrome DevTools MCP tools. Use this skill whenever\u2026"
           },
           {
             "name": "memory-leak-debugging",
-            "description": "Diagnoses and resolves memory leaks in JavaScript/Node.js applications. Use when a user reports high memory usage, OOM…"
+            "description": "Diagnoses and resolves memory leaks in JavaScript/Node.js applications. Use when a user reports high memory usage, OOM\u2026"
           },
           {
             "name": "troubleshooting",
-            "description": "Uses Chrome DevTools MCP and documentation to troubleshoot connection and target issues. Trigger this skill when list_p…"
+            "description": "Uses Chrome DevTools MCP and documentation to troubleshoot connection and target issues. Trigger this skill when list_p\u2026"
           }
         ]
       }
@@ -166,35 +166,35 @@
         "skills": [
           {
             "name": "agents-sdk",
-            "description": "Build AI agents on Cloudflare Workers using the Agents SDK. Load when creating stateful agents, durable workflows, real…"
+            "description": "Build AI agents on Cloudflare Workers using the Agents SDK. Load when creating stateful agents, durable workflows, real\u2026"
           },
           {
             "name": "cloudflare",
-            "description": "Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agent…"
+            "description": "Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agent\u2026"
           },
           {
             "name": "cloudflare-email-service",
-            "description": "Send and receive transactional emails with Cloudflare Email Service (Email Sending + Email Routing). Use when building…"
+            "description": "Send and receive transactional emails with Cloudflare Email Service (Email Sending + Email Routing). Use when building\u2026"
           },
           {
             "name": "durable-objects",
-            "description": "Create and review Cloudflare Durable Objects. Use when building stateful coordination (chat rooms, multiplayer games, b…"
+            "description": "Create and review Cloudflare Durable Objects. Use when building stateful coordination (chat rooms, multiplayer games, b\u2026"
           },
           {
             "name": "sandbox-sdk",
-            "description": "Build sandboxed applications for secure code execution. Load when building AI code execution, code interpreters, CI/CD…"
+            "description": "Build sandboxed applications for secure code execution. Load when building AI code execution, code interpreters, CI/CD\u2026"
           },
           {
             "name": "web-perf",
-            "description": "Analyzes web performance using Chrome DevTools MCP. Measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics…"
+            "description": "Analyzes web performance using Chrome DevTools MCP. Measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics\u2026"
           },
           {
             "name": "workers-best-practices",
-            "description": "Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing…"
+            "description": "Reviews and authors Cloudflare Workers code against production best practices. Load when writing new Workers, reviewing\u2026"
           },
           {
             "name": "wrangler",
-            "description": "Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI,…"
+            "description": "Cloudflare Workers CLI for deploying, developing, and managing Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI,\u2026"
           }
         ]
       }
@@ -218,7 +218,7 @@
         "skills": [
           {
             "name": "exa-search",
-            "description": "Deep research powered by Exa. Use for lead generation, literature reviews, deep dives, competitive analysis, or any que…"
+            "description": "Deep research powered by Exa. Use for lead generation, literature reviews, deep dives, competitive analysis, or any que\u2026"
           }
         ]
       }
@@ -236,51 +236,51 @@
         "skills": [
           {
             "name": "figma-code-connect",
-            "description": "Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user m…"
+            "description": "Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user m\u2026"
           },
           {
             "name": "figma-create-new-file",
-            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `create_new_file` tool call. NEVER call `create_ne…"
+            "description": "**MANDATORY prerequisite** \u2014 you MUST invoke this skill BEFORE every `create_new_file` tool call. NEVER call `create_ne\u2026"
           },
           {
             "name": "figma-design-to-code",
-            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE calling the `get_design_context` Figma MCP tool. You MUS…"
+            "description": "**MANDATORY prerequisite** \u2014 you MUST invoke this skill BEFORE calling the `get_design_context` Figma MCP tool. You MUS\u2026"
           },
           {
             "name": "figma-generate-design",
-            "description": "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layou…"
+            "description": "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layou\u2026"
           },
           {
             "name": "figma-generate-diagram",
-            "description": "MANDATORY prerequisite — load this skill BEFORE every `generate_diagram` tool call. NEVER call `generate_diagram` direc…"
+            "description": "MANDATORY prerequisite \u2014 load this skill BEFORE every `generate_diagram` tool call. NEVER call `generate_diagram` direc\u2026"
           },
           {
             "name": "figma-generate-library",
-            "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable…"
+            "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable\u2026"
           },
           {
             "name": "figma-implement-motion",
-            "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f…"
+            "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f\u2026"
           },
           {
             "name": "figma-swiftui",
-            "description": "SwiftUI ↔ Figma translation. Use whenever the user mentions Swift, SwiftUI, iOS, iPhone, or iPad — in EITHER direction…"
+            "description": "SwiftUI \u2194 Figma translation. Use whenever the user mentions Swift, SwiftUI, iOS, iPhone, or iPad \u2014 in EITHER direction\u2026"
           },
           {
             "name": "figma-use",
-            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` dire…"
+            "description": "**MANDATORY prerequisite** \u2014 you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` dire\u2026"
           },
           {
             "name": "figma-use-figjam",
-            "description": "This skill helps agents use Figma's use_figma MCP tool in the FigJam context. Can be used alongside figma-use which has…"
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the FigJam context. Can be used alongside figma-use which has\u2026"
           },
           {
             "name": "figma-use-motion",
-            "description": "Motion / animation context for the `use_figma` MCP tool — animating Figma nodes via manual keyframes, animation styles,…"
+            "description": "Motion / animation context for the `use_figma` MCP tool \u2014 animating Figma nodes via manual keyframes, animation styles,\u2026"
           },
           {
             "name": "figma-use-slides",
-            "description": "This skill helps agents use Figma's use_figma MCP tool in the Slides context. Can be used alongside figma-use which has…"
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the Slides context. Can be used alongside figma-use which has\u2026"
           }
         ]
       }
@@ -304,141 +304,145 @@
         "skills": [
           {
             "name": "firecrawl",
-            "description": "Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the w…"
+            "description": "Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the w\u2026"
           },
           {
             "name": "firecrawl-agent",
-            "description": "AI-powered autonomous data extraction that navigates complex sites and returns structured JSON. Use this skill when the…"
+            "description": "AI-powered autonomous data extraction that navigates complex sites and returns structured JSON. Use this skill when the\u2026"
           },
           {
             "name": "firecrawl-crawl",
-            "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac…"
+            "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac\u2026"
           },
           {
             "name": "firecrawl-download",
-            "description": "Download an entire website as local files — markdown, screenshots, or multiple formats per page. Use this skill when th…"
+            "description": "Download an entire website as local files \u2014 markdown, screenshots, or multiple formats per page. Use this skill when th\u2026"
           },
           {
             "name": "firecrawl-interact",
-            "description": "Control and interact with a live browser session on any scraped page — click buttons, fill forms, navigate flows, and e…"
+            "description": "Control and interact with a live browser session on any scraped page \u2014 click buttons, fill forms, navigate flows, and e\u2026"
           },
           {
             "name": "firecrawl-map",
-            "description": "Discover and list all URLs on a website, with optional search filtering. Use this skill when the user wants to find a s…"
+            "description": "Discover and list all URLs on a website, with optional search filtering. Use this skill when the user wants to find a s\u2026"
           },
           {
             "name": "firecrawl-monitor",
-            "description": "Detect when content on a website changes and get notified by webhook or email — no cron jobs, scrapers, or diff scripts…"
+            "description": "Detect when content on a website changes and get notified by webhook or email \u2014 no cron jobs, scrapers, or diff scripts\u2026"
           },
           {
             "name": "firecrawl-parse",
-            "description": "Efficiently extract and convert the contents of any local file—such as PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, or HTML—int…"
+            "description": "Efficiently extract and convert the contents of any local file\u2014such as PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, or HTML\u2014int\u2026"
           },
           {
             "name": "firecrawl-scrape",
-            "description": "Extract clean markdown from any URL, including JavaScript-rendered SPAs. Use this skill whenever the user provides a UR…"
+            "description": "Extract clean markdown from any URL, including JavaScript-rendered SPAs. Use this skill whenever the user provides a UR\u2026"
           },
           {
             "name": "firecrawl-search",
-            "description": "Web search with full page content extraction. Use this skill whenever the user asks to search the web, find articles, r…"
+            "description": "Web search with full page content extraction. Use this skill whenever the user asks to search the web, find articles, r\u2026"
           }
         ]
       }
     },
     "knowz": {
-      "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
-      "version": "0.1.1",
+      "sha": "38d5faf24c66ec1fa8fe29423b24f5d3765f8156",
+      "version": "0.1.2",
       "components": {
         "mcpServers": [
           {
             "name": "knowz",
-            "description": "http"
+            "description": "https://mcp.knowz.io/mcp \u2014 Grok Build: /mcps then i to OAuth; CLI preferred when installed"
           }
         ],
         "skills": [
           {
+            "name": "knowz-cli",
+            "description": "Prefer the knowz CLI for vault operations instead of MCP. Use when knowz is on PATH, Grok MCP OAuth is pending, or the user runs /knowz-cli."
+          },
+          {
             "name": "knowz-amend",
-            "description": "Apply a targeted server-side edit to an existing Knowz vault item without retyping the whole entry. Use when the user d…"
+            "description": "Apply a targeted server-side edit to an existing Knowz vault item without retyping the whole entry. Use when the user d\u2026"
           },
           {
             "name": "knowz-ask",
-            "description": "Ask AI-powered questions against Knowz vaults. Use when the user asks about prior decisions, conventions, architecture,…"
+            "description": "Ask AI-powered questions against Knowz vaults. Use when the user asks about prior decisions, conventions, architecture,\u2026"
           },
           {
             "name": "knowz-auto",
-            "description": "Lightweight Knowz intent routing for Grok Bot and Cursor. Use when the user's message looks like a knowledge lookup, a…"
+            "description": "Lightweight Knowz intent routing for Grok Bot and Cursor. Use when the user's message looks like a knowledge lookup, a\u2026"
           },
           {
             "name": "knowz-browse",
-            "description": "Browse Knowz vault contents, topics, and recent items. Use when the user wants to explore what exists in their vaults o…"
+            "description": "Browse Knowz vault contents, topics, and recent items. Use when the user wants to explore what exists in their vaults o\u2026"
           },
           {
             "name": "knowz-flush",
-            "description": "Flush idempotent queued knowledge operations (create, amend, update) from the project-root knowz-pending.md queue. Use…"
+            "description": "Flush idempotent queued knowledge operations (create, amend, update) from the project-root knowz-pending.md queue. Use\u2026"
           },
           {
             "name": "knowz-save",
-            "description": "Capture decisions, patterns, conventions, workarounds, and durable learnings to Knowz vaults. Use when the user shares…"
+            "description": "Capture decisions, patterns, conventions, workarounds, and durable learnings to Knowz vaults. Use when the user shares\u2026"
           },
           {
             "name": "knowz-search",
-            "description": "Search Knowz vaults semantically. Use when the user wants prior art, related work, conventions, examples, or a broad se…"
+            "description": "Search Knowz vaults semantically. Use when the user wants prior art, related work, conventions, examples, or a broad se\u2026"
           },
           {
             "name": "knowz-setup",
-            "description": "Connect Knowz MCP and create vault routing files. Use after installing the Knowz plugin, for first-time vault mapping,…"
+            "description": "Connect Knowz MCP and create vault routing files. Use after installing the Knowz plugin, for first-time vault mapping,\u2026"
           },
           {
             "name": "knowz-status",
-            "description": "Check Knowz MCP health, Authorize state, vault routing, and pending captures. Use for diagnostics, setup verification,…"
+            "description": "Check Knowz MCP health, Authorize state, vault routing, and pending captures. Use for diagnostics, setup verification,\u2026"
           }
         ]
       }
     },
     "knowzcode": {
-      "sha": "4b73397b3ec4de3c38c80e0e37be36c68281b16d",
-      "version": "0.2.0",
+      "sha": "38d5faf24c66ec1fa8fe29423b24f5d3765f8156",
+      "version": "0.2.1",
       "components": {
         "skills": [
           {
             "name": "continue",
-            "description": "Resume an interrupted KnowzCode workflow, including Grok-host process relay. Use when the user wants to continue an act…"
+            "description": "Resume an interrupted KnowzCode workflow, including Grok-host process relay. Use when the user wants to continue an act\u2026"
           },
           {
             "name": "explore",
-            "description": "Research a codebase area before implementation. Use when the user wants investigation, architectural context, prior art…"
+            "description": "Research a codebase area before implementation. Use when the user wants investigation, architectural context, prior art\u2026"
           },
           {
             "name": "fix",
-            "description": "Apply a quick, targeted KnowzCode micro-fix. Use when the requested change is small, localized, and does not need the f…"
+            "description": "Apply a quick, targeted KnowzCode micro-fix. Use when the requested change is small, localized, and does not need the f\u2026"
           },
           {
             "name": "regroup",
-            "description": "Create a local KnowzCode handoff before clearing context. Use when the user wants to pause, wrap up, step away, clear c…"
+            "description": "Create a local KnowzCode handoff before clearing context. Use when the user wants to pause, wrap up, step away, clear c\u2026"
           },
           {
             "name": "regroup-trigger",
-            "description": "Detect pause, wrap-up, handoff, or clear-context intent and offer a KnowzCode regroup handoff. Triggers when the user s…"
+            "description": "Detect pause, wrap-up, handoff, or clear-context intent and offer a KnowzCode regroup handoff. Triggers when the user s\u2026"
           },
           {
             "name": "relay",
-            "description": "Relay implementation from Grok Bot / Cursor to Claude Code or Codex while Grok plans, reviews, and finalizes. Use when…"
+            "description": "Relay implementation from Grok Bot / Cursor to Claude Code or Codex while Grok plans, reviews, and finalizes. Use when\u2026"
           },
           {
             "name": "setup",
-            "description": "Initialize KnowzCode in a repository for Grok Bot and Cursor: framework files, project personalization, and the Cursor…"
+            "description": "Initialize KnowzCode in a repository for Grok Bot and Cursor: framework files, project personalization, and the Cursor\u2026"
           },
           {
             "name": "start-work",
-            "description": "Route implementation intent into KnowzCode workflow mode. Use for 'start building', 'go ahead', 'implement this plan',…"
+            "description": "Route implementation intent into KnowzCode workflow mode. Use for 'start building', 'go ahead', 'implement this plan',\u2026"
           },
           {
             "name": "status",
-            "description": "Check KnowzCode project health, active work, pending captures, and Grok-host process relay configuration, readiness, an…"
+            "description": "Check KnowzCode project health, active work, pending captures, and Grok-host process relay configuration, readiness, an\u2026"
           },
           {
             "name": "work",
-            "description": "Start a structured KnowzCode workflow for feature work, multi-file changes, or meaningful refactors with TDD and qualit…"
+            "description": "Start a structured KnowzCode workflow for feature work, multi-file changes, or meaningful refactors with TDD and qualit\u2026"
           }
         ]
       }
@@ -456,31 +460,31 @@
         "skills": [
           {
             "name": "mongodb-atlas-stream-processing",
-            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
+            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,\u2026"
           },
           {
             "name": "mongodb-connection",
-            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
+            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi\u2026"
           },
           {
             "name": "mongodb-mcp-setup",
-            "description": "Guide users through configuring key MongoDB MCP server options. Use this skill when a user has the MongoDB MCP server i…"
+            "description": "Guide users through configuring key MongoDB MCP server options. Use this skill when a user has the MongoDB MCP server i\u2026"
           },
           {
             "name": "mongodb-natural-language-querying",
-            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
+            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte\u2026"
           },
           {
             "name": "mongodb-query-optimizer",
-            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
+            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do\u2026"
           },
           {
             "name": "mongodb-schema-design",
-            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
+            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL\u2026"
           },
           {
             "name": "mongodb-search-and-ai",
-            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
+            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid\u2026"
           }
         ]
       }
@@ -498,27 +502,27 @@
         "skills": [
           {
             "name": "mongodb-atlas-stream-processing",
-            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
+            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,\u2026"
           },
           {
             "name": "mongodb-connection",
-            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
+            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi\u2026"
           },
           {
             "name": "mongodb-natural-language-querying",
-            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
+            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte\u2026"
           },
           {
             "name": "mongodb-query-optimizer",
-            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
+            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do\u2026"
           },
           {
             "name": "mongodb-schema-design",
-            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
+            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL\u2026"
           },
           {
             "name": "mongodb-search-and-ai",
-            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
+            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid\u2026"
           }
         ]
       }
@@ -535,15 +539,15 @@
         "skills": [
           {
             "name": "neon",
-            "description": "Overview of the Neon platform for apps and agents, spanning Postgres, Auth, Data API, and the new services: Object Stor…"
+            "description": "Overview of the Neon platform for apps and agents, spanning Postgres, Auth, Data API, and the new services: Object Stor\u2026"
           },
           {
             "name": "neon-postgres",
-            "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autos…"
+            "description": "Guides and best practices for working with Neon Serverless Postgres. Covers setup, connection methods, branching, autos\u2026"
           },
           {
             "name": "neon-postgres-branches",
-            "description": "Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migr…"
+            "description": "Choose and create the right Neon branch type for testing and development. Use when users ask about Neon branching, migr\u2026"
           }
         ]
       }
@@ -561,63 +565,63 @@
         "skills": [
           {
             "name": "netlify-access-control",
-            "description": "Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call \"…"
+            "description": "Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call \"\u2026"
           },
           {
             "name": "netlify-agent-runner",
-            "description": "Run AI agent tasks remotely on Netlify using Claude, Codex, or Gemini. Use when the user wants to run an AI agent on th…"
+            "description": "Run AI agent tasks remotely on Netlify using Claude, Codex, or Gemini. Use when the user wants to run an AI agent on th\u2026"
           },
           {
             "name": "netlify-ai-gateway",
-            "description": "Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing pr…"
+            "description": "Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing pr\u2026"
           },
           {
             "name": "netlify-blobs",
-            "description": "Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/val…"
+            "description": "Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/val\u2026"
           },
           {
             "name": "netlify-caching",
-            "description": "Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add cachi…"
+            "description": "Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add cachi\u2026"
           },
           {
             "name": "netlify-config",
-            "description": "Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy cont…"
+            "description": "Configure Netlify projects via netlify.toml and the _headers/_redirects files \u2014 covering build settings and deploy cont\u2026"
           },
           {
             "name": "netlify-database",
-            "description": "Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing sche…"
+            "description": "Zero-config Postgres for Netlify apps via @netlify/database \u2014 querying data from Functions/Edge Functions, writing sche\u2026"
           },
           {
             "name": "netlify-deploy",
-            "description": "Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons,…"
+            "description": "Create and manage Netlify deploys \u2014 Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons,\u2026"
           },
           {
             "name": "netlify-edge-functions",
-            "description": "Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use wh…"
+            "description": "Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use wh\u2026"
           },
           {
             "name": "netlify-forms",
-            "description": "Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam,…"
+            "description": "Serverless form handling on Netlify-hosted sites \u2014 detects HTML forms at deploy time, stores submissions, filters spam,\u2026"
           },
           {
             "name": "netlify-frameworks",
-            "description": "Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and…"
+            "description": "Deploy and configure web frameworks on Netlify \u2014 build settings and SSR/edge adapters plus local platform emulation and\u2026"
           },
           {
             "name": "netlify-functions",
-            "description": "Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API…"
+            "description": "Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API\u2026"
           },
           {
             "name": "netlify-identity",
-            "description": "Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social log…"
+            "description": "Add authentication and user management to a Netlify site with @netlify/identity \u2014 signup/login/logout, OAuth social log\u2026"
           },
           {
             "name": "netlify-image-cdn",
-            "description": "Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use…"
+            "description": "Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use\u2026"
           },
           {
             "name": "netlify-mcp-servers",
-            "description": "Build, deploy, and secure Model Context Protocol (MCP) servers on Netlify. Use whenever the task involves creating an M…"
+            "description": "Build, deploy, and secure Model Context Protocol (MCP) servers on Netlify. Use whenever the task involves creating an M\u2026"
           }
         ]
       }
@@ -632,29 +636,29 @@
           },
           {
             "name": "poteto-agent",
-            "description": "Routing target for `/poteto-mode` and any request for poteto's style. Resume an existing `poteto-agent` for the convers…"
+            "description": "Routing target for `/poteto-mode` and any request for poteto's style. Resume an existing `poteto-agent` for the convers\u2026"
           }
         ],
         "skills": [
           {
             "name": "Poteto Mode",
-            "description": "poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified…"
+            "description": "poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified\u2026"
           },
           {
             "name": "architect",
-            "description": "Sketch types, signatures, and module structure before code, then stay in the loop while implementation fills in. Use fo…"
+            "description": "Sketch types, signatures, and module structure before code, then stay in the loop while implementation fills in. Use fo\u2026"
           },
           {
             "name": "arena",
-            "description": "Spawn N parallel candidates at the same task, pick a base, graft the strongest parts of the losers into it. Use for /ar…"
+            "description": "Spawn N parallel candidates at the same task, pick a base, graft the strongest parts of the losers into it. Use for /ar\u2026"
           },
           {
             "name": "automate-me",
-            "description": "Use for \\\"automate me\\\", \\\"create/update/refresh my -mode skill\\\", \\\"turn/capture my preferences or working style into…"
+            "description": "Use for \\\"automate me\\\", \\\"create/update/refresh my -mode skill\\\", \\\"turn/capture my preferences or working style into\u2026"
           },
           {
             "name": "blast-radius",
-            "description": "Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe becaus…"
+            "description": "Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe becaus\u2026"
           },
           {
             "name": "bro",
@@ -662,23 +666,23 @@
           },
           {
             "name": "create-verification-skill",
-            "description": "Generate a project-local verification skill that drives your app the way a user does — any language, framework, or plat…"
+            "description": "Generate a project-local verification skill that drives your app the way a user does \u2014 any language, framework, or plat\u2026"
           },
           {
             "name": "figure-it-out",
-            "description": "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a hu…"
+            "description": "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a hu\u2026"
           },
           {
             "name": "how",
-            "description": "Use for \\\"how does X work\\\", code walkthroughs before changing something, and placement / ownership / layering question…"
+            "description": "Use for \\\"how does X work\\\", code walkthroughs before changing something, and placement / ownership / layering question\u2026"
           },
           {
             "name": "interrogate",
-            "description": "Use for \\\"interrogate\\\", \\\"adversarial review\\\", \\\"multi-model review\\\", \\\"challenge this\\\", \\\"stress test this code\\\",…"
+            "description": "Use for \\\"interrogate\\\", \\\"adversarial review\\\", \\\"multi-model review\\\", \\\"challenge this\\\", \\\"stress test this code\\\",\u2026"
           },
           {
             "name": "maintain-verification-skill",
-            "description": "Periodic pass that keeps a project's verification skill and feature map honest: parallel source readers per feature, on…"
+            "description": "Periodic pass that keeps a project's verification skill and feature map honest: parallel source readers per feature, on\u2026"
           },
           {
             "name": "no-comments",
@@ -686,119 +690,119 @@
           },
           {
             "name": "principle-boundary-discipline",
-            "description": "Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, conf…"
+            "description": "Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, conf\u2026"
           },
           {
             "name": "principle-build-the-lever",
-            "description": "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or…"
+            "description": "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or\u2026"
           },
           {
             "name": "principle-encode-lessons-in-structure",
-            "description": "Apply when you catch yourself writing the same instruction a second time, or notice a recurring correction. Encode the…"
+            "description": "Apply when you catch yourself writing the same instruction a second time, or notice a recurring correction. Encode the\u2026"
           },
           {
             "name": "principle-exhaust-the-design-space",
-            "description": "Apply when facing a novel UI interaction or architectural decision with no precedent in the codebase. Build 2-3 competi…"
+            "description": "Apply when facing a novel UI interaction or architectural decision with no precedent in the codebase. Build 2-3 competi\u2026"
           },
           {
             "name": "principle-experience-first",
-            "description": "Apply when product, UX, or feature-scope tradeoffs come up. Choose user delight over implementation convenience; ship f…"
+            "description": "Apply when product, UX, or feature-scope tradeoffs come up. Choose user delight over implementation convenience; ship f\u2026"
           },
           {
             "name": "principle-fix-root-causes",
-            "description": "Apply when debugging. Trace each symptom to its root cause and fix it there; reproduce first, ask why until you reach i…"
+            "description": "Apply when debugging. Trace each symptom to its root cause and fix it there; reproduce first, ask why until you reach i\u2026"
           },
           {
             "name": "principle-foundational-thinking",
-            "description": "Apply before writing logic: choosing core types and data structures, sequencing scaffold-vs-feature work, asking what c…"
+            "description": "Apply before writing logic: choosing core types and data structures, sequencing scaffold-vs-feature work, asking what c\u2026"
           },
           {
             "name": "principle-guard-the-context-window",
-            "description": "Apply when context is filling up: large outputs, long files, repeated reads, fan-out planning. Route bulk to subagents;…"
+            "description": "Apply when context is filling up: large outputs, long files, repeated reads, fan-out planning. Route bulk to subagents;\u2026"
           },
           {
             "name": "principle-laziness-protocol",
-            "description": "Apply when refactoring, evaluating diff size, or tempted to add abstractions, layers, or signal threading. Bias toward…"
+            "description": "Apply when refactoring, evaluating diff size, or tempted to add abstractions, layers, or signal threading. Bias toward\u2026"
           },
           {
             "name": "principle-make-operations-idempotent",
-            "description": "Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Conve…"
+            "description": "Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Conve\u2026"
           },
           {
             "name": "principle-migrate-callers-then-delete-legacy-apis",
-            "description": "Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the…"
+            "description": "Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the\u2026"
           },
           {
             "name": "principle-minimize-reader-load",
-            "description": "Apply when reviewing or shaping code that's hard to trace. Count layers between question and answer, and hidden state i…"
+            "description": "Apply when reviewing or shaping code that's hard to trace. Count layers between question and answer, and hidden state i\u2026"
           },
           {
             "name": "principle-model-the-domain",
-            "description": "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the d…"
+            "description": "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the d\u2026"
           },
           {
             "name": "principle-never-block-on-the-human",
-            "description": "Apply when tempted to ask 'should I do X?' on reversible work. Proceed, present the result, let the human course-correc…"
+            "description": "Apply when tempted to ask 'should I do X?' on reversible work. Proceed, present the result, let the human course-correc\u2026"
           },
           {
             "name": "principle-outcome-oriented-execution",
-            "description": "Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't…"
+            "description": "Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't\u2026"
           },
           {
             "name": "principle-prove-it-works",
-            "description": "Apply after completing a task, before declaring done. Verify against the real artifact (run the feature, read the actua…"
+            "description": "Apply after completing a task, before declaring done. Verify against the real artifact (run the feature, read the actua\u2026"
           },
           {
             "name": "principle-redesign-from-first-principles",
-            "description": "Apply when integrating a new requirement into an existing design. Redesign as if the requirement had been a foundationa…"
+            "description": "Apply when integrating a new requirement into an existing design. Redesign as if the requirement had been a foundationa\u2026"
           },
           {
             "name": "principle-separate-before-serializing-shared-state",
-            "description": "Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; s…"
+            "description": "Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; s\u2026"
           },
           {
             "name": "principle-sequence-verifiable-units",
-            "description": "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work i…"
+            "description": "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work i\u2026"
           },
           {
             "name": "principle-subtract-before-you-add",
-            "description": "Apply when sequencing an addition, refactor, or rewrite. Remove dead weight, redundant validators, and stub references…"
+            "description": "Apply when sequencing an addition, refactor, or rewrite. Remove dead weight, redundant validators, and stub references\u2026"
           },
           {
             "name": "principle-type-system-discipline",
-            "description": "Apply when designing types, reviewing a function signature, or writing code in any statically-typed language. Make ille…"
+            "description": "Apply when designing types, reviewing a function signature, or writing code in any statically-typed language. Make ille\u2026"
           },
           {
             "name": "recall",
-            "description": "Reconstruct your recent working context from your own chat history, live state, and the shared record (user reports, pr…"
+            "description": "Reconstruct your recent working context from your own chat history, live state, and the shared record (user reports, pr\u2026"
           },
           {
             "name": "reflect",
-            "description": "Spawn three parallel review subagents over the active transcript, surface learnings, and route each to a concrete edit…"
+            "description": "Spawn three parallel review subagents over the active transcript, surface learnings, and route each to a concrete edit\u2026"
           },
           {
             "name": "setup-pstack",
-            "description": "Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overr…"
+            "description": "Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overr\u2026"
           },
           {
             "name": "show-me-your-work",
-            "description": "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, e…"
+            "description": "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, e\u2026"
           },
           {
             "name": "swarm",
-            "description": "Fan out N parallel workers, drain them, and return one report. Use for /swarm, 'swarm this', or parallel coverage, race…"
+            "description": "Fan out N parallel workers, drain them, and return one report. Use for /swarm, 'swarm this', or parallel coverage, race\u2026"
           },
           {
             "name": "tdd",
-            "description": "Use only when the user explicitly asks for TDD, a failing test, or a regression test, OR when the bug has an obvious ch…"
+            "description": "Use only when the user explicitly asks for TDD, a failing test, or a regression test, OR when the bug has an obvious ch\u2026"
           },
           {
             "name": "teach",
-            "description": "Explain a body of work plainly so a person actually understands it. Runs the `how` and `why` skills and weaves what the…"
+            "description": "Explain a body of work plainly so a person actually understands it. Runs the `how` and `why` skills and weaves what the\u2026"
           },
           {
             "name": "technical-writing",
-            "description": "Layered technical-writing standard: Diátaxis structure, Google developer style sentences, STE instruction rules, Global…"
+            "description": "Layered technical-writing standard: Di\u00e1taxis structure, Google developer style sentences, STE instruction rules, Global\u2026"
           },
           {
             "name": "typescript-best-practices",
@@ -810,7 +814,7 @@
           },
           {
             "name": "why",
-            "description": "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thres…"
+            "description": "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thres\u2026"
           }
         ]
       }
@@ -834,7 +838,7 @@
         "skills": [
           {
             "name": "use-railway",
-            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
+            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da\u2026"
           }
         ]
       }
@@ -852,35 +856,35 @@
         "skills": [
           {
             "name": "sentry-create-alert",
-            "description": "Create Sentry alerts using the workflow engine API. Use when asked to create alerts, set up notifications, configure is…"
+            "description": "Create Sentry alerts using the workflow engine API. Use when asked to create alerts, set up notifications, configure is\u2026"
           },
           {
             "name": "sentry-debug-issue",
-            "description": "Debug and fix a Sentry issue — find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, lo…"
+            "description": "Debug and fix a Sentry issue \u2014 find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, lo\u2026"
           },
           {
             "name": "sentry-fix-stack-traces",
-            "description": "Make Sentry stack traces readable — upload source maps for JavaScript/TypeScript, or debug files for native and mobile…"
+            "description": "Make Sentry stack traces readable \u2014 upload source maps for JavaScript/TypeScript, or debug files for native and mobile\u2026"
           },
           {
             "name": "sentry-get-started",
-            "description": "Guided entry point for using Sentry through your agent. Orients you to your current setup and, for a new project, sets…"
+            "description": "Guided entry point for using Sentry through your agent. Orients you to your current setup and, for a new project, sets\u2026"
           },
           {
             "name": "sentry-instrument",
-            "description": "Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any…"
+            "description": "Instrument an application with Sentry \u2014 detect the platform, install and initialize the SDK if needed, and wire up any\u2026"
           },
           {
             "name": "sentry-otel-exporter-setup",
-            "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us…"
+            "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us\u2026"
           },
           {
             "name": "sentry-setup-releases",
-            "description": "Set up Sentry releases and deploy tracking — tag events with a version and environment, create the release in CI with i…"
+            "description": "Set up Sentry releases and deploy tracking \u2014 tag events with a version and environment, create the release in CI with i\u2026"
           },
           {
             "name": "sentry-snapshots-cocoa",
-            "description": "Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to \"setup SnapshotPreviews\", \"setup Apple snapshot…"
+            "description": "Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to \"setup SnapshotPreviews\", \"setup Apple snapshot\u2026"
           }
         ]
       }
@@ -914,31 +918,31 @@
         "skills": [
           {
             "name": "connect-recommend",
-            "description": "Use this skill when the user asks about Stripe Connect configuration, charge patterns, Dashboard access, or how to get…"
+            "description": "Use this skill when the user asks about Stripe Connect configuration, charge patterns, Dashboard access, or how to get\u2026"
           },
           {
             "name": "connect-required-verification-information",
-            "description": "Use this skill when the user asks what information a Stripe Connect connected account must provide for verification, on…"
+            "description": "Use this skill when the user asks what information a Stripe Connect connected account must provide for verification, on\u2026"
           },
           {
             "name": "stripe-apps",
-            "description": "Use when building, modifying, or reviewing a Stripe App — or when the user describes something that implies one (e.g. \"…"
+            "description": "Use when building, modifying, or reviewing a Stripe App \u2014 or when the user describes something that implies one (e.g. \"\u2026"
           },
           {
             "name": "stripe-best-practices",
-            "description": "Guides Stripe integration decisions across API selection (Checkout Sessions vs PaymentIntents), Connect platform setup…"
+            "description": "Guides Stripe integration decisions across API selection (Checkout Sessions vs PaymentIntents), Connect platform setup\u2026"
           },
           {
             "name": "stripe-directory",
-            "description": "Finds trusted external providers, merchants, nonprofits, platforms, APIs, and software services that can help complete…"
+            "description": "Finds trusted external providers, merchants, nonprofits, platforms, APIs, and software services that can help complete\u2026"
           },
           {
             "name": "stripe-docs",
-            "description": "Use when the user or agent needs to read, search, or look up Stripe documentation or API reference. Prefer this over cu…"
+            "description": "Use when the user or agent needs to read, search, or look up Stripe documentation or API reference. Prefer this over cu\u2026"
           },
           {
             "name": "stripe-projects",
-            "description": "Use when the user wants to provision infrastructure or third-party services using Stripe Projects. Triggers: \"I need a…"
+            "description": "Use when the user wants to provision infrastructure or third-party services using Stripe Projects. Triggers: \"I need a\u2026"
           },
           {
             "name": "upgrade-stripe",
@@ -960,7 +964,7 @@
         "skills": [
           {
             "name": "brainstorming",
-            "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying…"
+            "description": "You MUST use this before any creative work - creating features, building components, adding functionality, or modifying\u2026"
           },
           {
             "name": "dispatching-parallel-agents",
@@ -976,7 +980,7 @@
           },
           {
             "name": "receiving-code-review",
-            "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or techn…"
+            "description": "Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or techn\u2026"
           },
           {
             "name": "requesting-code-review",
@@ -996,15 +1000,15 @@
           },
           {
             "name": "using-git-worktrees",
-            "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - e…"
+            "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - e\u2026"
           },
           {
             "name": "using-superpowers",
-            "description": "Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY resp…"
+            "description": "Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY resp\u2026"
           },
           {
             "name": "verification-before-completion",
-            "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verif…"
+            "description": "Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verif\u2026"
           },
           {
             "name": "writing-plans",
@@ -1030,35 +1034,35 @@
         "skills": [
           {
             "name": "academic-scientific-research",
-            "description": "Find, screen, and synthesize academic papers, scientific literature, technical reports, preprints, clinical or biomedic…"
+            "description": "Find, screen, and synthesize academic papers, scientific literature, technical reports, preprints, clinical or biomedic\u2026"
           },
           {
             "name": "investment-research-briefs",
-            "description": "Create concise investment research briefs, company memos, sector snapshots, portfolio monitoring updates, earnings/news…"
+            "description": "Create concise investment research briefs, company memos, sector snapshots, portfolio monitoring updates, earnings/news\u2026"
           },
           {
             "name": "product-competitor-intelligence",
-            "description": "Research competitor products, SKUs, pricing, packaging, positioning, feature comparisons, product catalogs, category pa…"
+            "description": "Research competitor products, SKUs, pricing, packaging, positioning, feature comparisons, product catalogs, category pa\u2026"
           },
           {
             "name": "sales-account-intelligence",
-            "description": "Build sales-ready account intelligence for companies, prospects, customers, partners, and target buyers. Use when the u…"
+            "description": "Build sales-ready account intelligence for companies, prospects, customers, partners, and target buyers. Use when the u\u2026"
           },
           {
             "name": "tavily-best-practices",
-            "description": "Build production-ready Tavily integrations with best practices baked in. Reference documentation for developers using c…"
+            "description": "Build production-ready Tavily integrations with best practices baked in. Reference documentation for developers using c\u2026"
           },
           {
             "name": "tavily-web",
-            "description": "Search and research the web with Tavily. Use for current information, source discovery, webpage extraction, site mappin…"
+            "description": "Search and research the web with Tavily. Use for current information, source discovery, webpage extraction, site mappin\u2026"
           },
           {
             "name": "threat-intelligence-enrichment",
-            "description": "Enrich threat intelligence from CVEs, IOCs, malware names, threat actors, vendor advisories, security incidents, exploi…"
+            "description": "Enrich threat intelligence from CVEs, IOCs, malware names, threat actors, vendor advisories, security incidents, exploi\u2026"
           },
           {
             "name": "vendor-risk-kyc-screening",
-            "description": "Screen vendors, merchants, suppliers, counterparties, companies, executives, and related entities for vendor risk, KYC,…"
+            "description": "Screen vendors, merchants, suppliers, counterparties, companies, executives, and related entities for vendor risk, KYC,\u2026"
           }
         ]
       }
@@ -1076,23 +1080,23 @@
         "skills": [
           {
             "name": "tinyfish-authenticated",
-            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta…"
+            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta\u2026"
           },
           {
             "name": "tinyfish-automation",
-            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site — clicking, filling…"
+            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site \u2014 clicking, filling\u2026"
           },
           {
             "name": "tinyfish-browser",
-            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow…"
+            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow\u2026"
           },
           {
             "name": "tinyfish-research",
-            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r…"
+            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r\u2026"
           },
           {
             "name": "tinyfish-web",
-            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
+            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web \u2014 searching, reading pages, extra\u2026"
           }
         ]
       }
@@ -1104,37 +1108,37 @@
         "agents": [
           {
             "name": "ai-architect",
-            "description": "Specializes in architecting AI-powered applications on Vercel — choosing between AI SDK patterns, configuring providers…"
+            "description": "Specializes in architecting AI-powered applications on Vercel \u2014 choosing between AI SDK patterns, configuring providers\u2026"
           },
           {
             "name": "deployment-expert",
-            "description": "Specializes in Vercel deployment strategies, CI/CD pipelines, preview URLs, production promotions, rollbacks, environme…"
+            "description": "Specializes in Vercel deployment strategies, CI/CD pipelines, preview URLs, production promotions, rollbacks, environme\u2026"
           },
           {
             "name": "performance-optimizer",
-            "description": "Specializes in optimizing Vercel application performance — Core Web Vitals, rendering strategies, caching, image optimi…"
+            "description": "Specializes in optimizing Vercel application performance \u2014 Core Web Vitals, rendering strategies, caching, image optimi\u2026"
           }
         ],
         "commands": [
           {
             "name": "_conventions",
-            "description": "Every slash command in this plugin follows a consistent structure so that the AI agent produces reliable, verifiable re…"
+            "description": "Every slash command in this plugin follows a consistent structure so that the AI agent produces reliable, verifiable re\u2026"
           },
           {
             "name": "bootstrap",
-            "description": "Bootstrap a repository with Vercel-linked resources by running preflight checks, provisioning integrations, verifying e…"
+            "description": "Bootstrap a repository with Vercel-linked resources by running preflight checks, provisioning integrations, verifying e\u2026"
           },
           {
             "name": "deploy",
-            "description": "Deploy the current project to Vercel. Pass \"prod\" or \"production\" as argument to deploy to production. Default is previ…"
+            "description": "Deploy the current project to Vercel. Pass \"prod\" or \"production\" as argument to deploy to production. Default is previ\u2026"
           },
           {
             "name": "env",
-            "description": "Manage Vercel environment variables. Commands include list, pull, add, remove, and diff. Use to sync environment variab…"
+            "description": "Manage Vercel environment variables. Commands include list, pull, add, remove, and diff. Use to sync environment variab\u2026"
           },
           {
             "name": "status",
-            "description": "Show the status of the current Vercel project — recent deployments, linked project info, and environment overview."
+            "description": "Show the status of the current Vercel project \u2014 recent deployments, linked project info, and environment overview."
           }
         ],
         "hooks": [
@@ -1155,51 +1159,51 @@
         "skills": [
           {
             "name": "access-protected-vercel-deployment",
-            "description": "Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection. Use when curl, ag…"
+            "description": "Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection. Use when curl, ag\u2026"
           },
           {
             "name": "ai-gateway",
-            "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu…"
+            "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu\u2026"
           },
           {
             "name": "ai-sdk",
-            "description": "Vercel AI SDK expert guidance. Use when building AI-powered features — chat interfaces, text generation, structured out…"
+            "description": "Vercel AI SDK expert guidance. Use when building AI-powered features \u2014 chat interfaces, text generation, structured out\u2026"
           },
           {
             "name": "auth",
-            "description": "Authentication integration guidance — Clerk (native Vercel Marketplace), Descope, and Auth0 setup for Next.js applicati…"
+            "description": "Authentication integration guidance \u2014 Clerk (native Vercel Marketplace), Descope, and Auth0 setup for Next.js applicati\u2026"
           },
           {
             "name": "bootstrap",
-            "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ…"
+            "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ\u2026"
           },
           {
             "name": "build-agents",
-            "description": "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or imp…"
+            "description": "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or imp\u2026"
           },
           {
             "name": "cdn-caching",
-            "description": "Debug Vercel CDN caching — cache hit rate, stale content, revalidation behavior, ISR + PPR, per-request cache reasons (…"
+            "description": "Debug Vercel CDN caching \u2014 cache hit rate, stale content, revalidation behavior, ISR + PPR, per-request cache reasons (\u2026"
           },
           {
             "name": "chat-sdk",
-            "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots — Slack, Telegram, Microsoft Teams, Discord…"
+            "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots \u2014 Slack, Telegram, Microsoft Teams, Discord\u2026"
           },
           {
             "name": "create-a-backend",
-            "description": "Backend architecture guidance. Use when planning, building, or migrating an API or backend; choosing between Functions,…"
+            "description": "Backend architecture guidance. Use when planning, building, or migrating an API or backend; choosing between Functions,\u2026"
           },
           {
             "name": "deployments-cicd",
-            "description": "Vercel deployment and CI/CD expert guidance. Use when deploying, promoting, rolling back, inspecting deployments, build…"
+            "description": "Vercel deployment and CI/CD expert guidance. Use when deploying, promoting, rolling back, inspecting deployments, build\u2026"
           },
           {
             "name": "env-vars",
-            "description": "Vercel environment variable expert guidance. Use when working with .env files, vercel env commands, OIDC tokens, or man…"
+            "description": "Vercel environment variable expert guidance. Use when working with .env files, vercel env commands, OIDC tokens, or man\u2026"
           },
           {
             "name": "eve",
-            "description": "eve framework guidance for durable AI agents and agent-powered applications. Use when creating, editing, or debugging a…"
+            "description": "eve framework guidance for durable AI agents and agent-powered applications. Use when creating, editing, or debugging a\u2026"
           },
           {
             "name": "knowledge-update",
@@ -1207,87 +1211,87 @@
           },
           {
             "name": "marketplace",
-            "description": "Vercel Marketplace expert guidance — discovering, installing, and managing third-party integrations via the `vercel int…"
+            "description": "Vercel Marketplace expert guidance \u2014 discovering, installing, and managing third-party integrations via the `vercel int\u2026"
           },
           {
             "name": "microfrontends",
-            "description": "Guide for building, configuring, and deploying microfrontends on Vercel. Use this skill when the user mentions microfro…"
+            "description": "Guide for building, configuring, and deploying microfrontends on Vercel. Use this skill when the user mentions microfro\u2026"
           },
           {
             "name": "next-cache-components",
-            "description": "Next.js 16 Cache Components guidance — PPR, use cache directive, cacheLife, cacheTag, updateTag, and migration from uns…"
+            "description": "Next.js 16 Cache Components guidance \u2014 PPR, use cache directive, cacheLife, cacheTag, updateTag, and migration from uns\u2026"
           },
           {
             "name": "next-forge",
-            "description": "next-forge expert guidance — production-grade Turborepo monorepo SaaS starter by Vercel. Use when working in a next-for…"
+            "description": "next-forge expert guidance \u2014 production-grade Turborepo monorepo SaaS starter by Vercel. Use when working in a next-for\u2026"
           },
           {
             "name": "next-upgrade",
-            "description": "Upgrade Next.js to the latest version following official migration guides and codemods. Use when upgrading Next.js vers…"
+            "description": "Upgrade Next.js to the latest version following official migration guides and codemods. Use when upgrading Next.js vers\u2026"
           },
           {
             "name": "nextjs",
-            "description": "Next.js App Router expert guidance. Use when building, debugging, or architecting Next.js applications — routing, Serve…"
+            "description": "Next.js App Router expert guidance. Use when building, debugging, or architecting Next.js applications \u2014 routing, Serve\u2026"
           },
           {
             "name": "react-best-practices",
-            "description": "React best-practices reviewer for TSX files. Triggers after editing multiple TSX components to run a condensed quality…"
+            "description": "React best-practices reviewer for TSX files. Triggers after editing multiple TSX components to run a condensed quality\u2026"
           },
           {
             "name": "routing-middleware",
-            "description": "Vercel Routing Middleware guidance — request interception before cache, rewrites, redirects, personalization. Works wit…"
+            "description": "Vercel Routing Middleware guidance \u2014 request interception before cache, rewrites, redirects, personalization. Works wit\u2026"
           },
           {
             "name": "runtime-cache",
-            "description": "Vercel Runtime Cache API guidance — ephemeral per-region key-value cache with tag-based invalidation. Shared across Fun…"
+            "description": "Vercel Runtime Cache API guidance \u2014 ephemeral per-region key-value cache with tag-based invalidation. Shared across Fun\u2026"
           },
           {
             "name": "shadcn",
-            "description": "shadcn/ui expert guidance — CLI, component installation, composition patterns, custom registries, theming, Tailwind CSS…"
+            "description": "shadcn/ui expert guidance \u2014 CLI, component installation, composition patterns, custom registries, theming, Tailwind CSS\u2026"
           },
           {
             "name": "turbopack",
-            "description": "Turbopack expert guidance. Use when configuring the Next.js bundler, optimizing HMR, debugging build issues, or underst…"
+            "description": "Turbopack expert guidance. Use when configuring the Next.js bundler, optimizing HMR, debugging build issues, or underst\u2026"
           },
           {
             "name": "vercel-agent",
-            "description": "Vercel Agent guidance — AI-powered code review, incident investigation, and SDK installation. Automates PR analysis and…"
+            "description": "Vercel Agent guidance \u2014 AI-powered code review, incident investigation, and SDK installation. Automates PR analysis and\u2026"
           },
           {
             "name": "vercel-cli",
-            "description": "Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, queryin…"
+            "description": "Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, queryin\u2026"
           },
           {
             "name": "vercel-connect",
-            "description": "Vercel Connect expert guidance — securely obtain scoped OAuth tokens for third-party services (Slack, GitHub, MCP serve…"
+            "description": "Vercel Connect expert guidance \u2014 securely obtain scoped OAuth tokens for third-party services (Slack, GitHub, MCP serve\u2026"
           },
           {
             "name": "vercel-firewall",
-            "description": "Vercel Firewall expert guidance — automatic DDoS mitigation, the Vercel WAF (custom rules, IP blocking, managed ruleset…"
+            "description": "Vercel Firewall expert guidance \u2014 automatic DDoS mitigation, the Vercel WAF (custom rules, IP blocking, managed ruleset\u2026"
           },
           {
             "name": "vercel-functions",
-            "description": "Vercel Functions expert guidance — Serverless Functions, Edge Functions, Fluid Compute, streaming, Cron Jobs, and runti…"
+            "description": "Vercel Functions expert guidance \u2014 Serverless Functions, Edge Functions, Fluid Compute, streaming, Cron Jobs, and runti\u2026"
           },
           {
             "name": "vercel-sandbox",
-            "description": "Vercel Sandbox guidance — ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge…"
+            "description": "Vercel Sandbox guidance \u2014 ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge\u2026"
           },
           {
             "name": "vercel-services",
-            "description": "Configure and troubleshoot Vercel Services for multiple frontends and backends in one project. Use when composing a pol…"
+            "description": "Configure and troubleshoot Vercel Services for multiple frontends and backends in one project. Use when composing a pol\u2026"
           },
           {
             "name": "vercel-storage",
-            "description": "Vercel storage expert guidance — Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch…"
+            "description": "Vercel storage expert guidance \u2014 Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch\u2026"
           },
           {
             "name": "verification",
-            "description": "Full-story verification — infers what the user is building, then verifies the complete flow end-to-end: browser → API →…"
+            "description": "Full-story verification \u2014 infers what the user is building, then verifies the complete flow end-to-end: browser \u2192 API \u2192\u2026"
           },
           {
             "name": "workflow",
-            "description": "Vercel Workflow SDK expert guidance. Use when building durable workflows, long-running tasks, API routes or agents that…"
+            "description": "Vercel Workflow SDK expert guidance. Use when building durable workflows, long-running tasks, API routes or agents that\u2026"
           }
         ]
       }
@@ -1305,39 +1309,39 @@
         "skills": [
           {
             "name": "replatform",
-            "description": "Routes RePlatform source-to-Wix migrations to the next workflow step by inspecting migration project artifacts. Use whe…"
+            "description": "Routes RePlatform source-to-Wix migrations to the next workflow step by inspecting migration project artifacts. Use whe\u2026"
           },
           {
             "name": "wix-app",
-            "description": "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Edito…"
+            "description": "Build and review Wix CLI app extensions \u2014 dashboard pages, modals, plugins, menu plugins, custom element widgets, Edito\u2026"
           },
           {
             "name": "wix-auth",
-            "description": "Authenticate with Wix to obtain an access token for calling Wix APIs. Use when an agent needs a valid Wix access token…"
+            "description": "Authenticate with Wix to obtain an access token for calling Wix APIs. Use when an agent needs a valid Wix access token\u2026"
           },
           {
             "name": "wix-base44-connector",
-            "description": "Build on Wix from the Base44 builder sandbox — this file is the complete guide (site context, doc discovery, API contra…"
+            "description": "Build on Wix from the Base44 builder sandbox \u2014 this file is the complete guide (site context, doc discovery, API contra\u2026"
           },
           {
             "name": "wix-design-system",
-            "description": "Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking prop…"
+            "description": "Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking prop\u2026"
           },
           {
             "name": "wix-docs",
-            "description": "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, o…"
+            "description": "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, o\u2026"
           },
           {
             "name": "wix-headless",
-            "description": "Connect Wix business services (Stores, Bookings, CMS, Blog, Events, Forms, and more) to a Wix Headless frontend — infer…"
+            "description": "Connect Wix business services (Stores, Bookings, CMS, Blog, Events, Forms, and more) to a Wix Headless frontend \u2014 infer\u2026"
           },
           {
             "name": "wix-manage",
-            "description": "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Rou…"
+            "description": "Wix business solution management recipes \u2014 REST API operations for configuring and managing Wix business solutions. Rou\u2026"
           },
           {
             "name": "wix-vibe-headless",
-            "description": "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vi…"
+            "description": "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vi\u2026"
           }
         ]
       }


### PR DESCRIPTION
## What this PR does

Adds **two** plugins from one source repo. They are deliberately separate listings and must not be merged: **Knowz** is a hosted-MCP knowledge plugin, **KnowzCode** is a skills-only TDD workflow that ships no MCP server. Users routinely want one without the other.

- Plugin names: `knowz`, `knowzcode`
- Type: remote `url` source with a `path` subdir
- Source URL + pinned SHA: `https://github.com/knowz-io/cursor-knowz-plugin.git` @ `7b783c8ea8ffdcb0eb96b5a0f01e7a077941d9b7` (`plugins/knowz`, `plugins/knowzcode`) — current `main` HEAD
- Homepage: https://knowz.io
- License: MIT (stated in each plugin's `LICENSE` and `README.md`)

| Plugin | Components (from regenerated index) |
|---|---|
| `knowz` v0.1.2 | skills + 1 MCP server (`http` → see mcp.json in plugin) |
| `knowzcode` v0.2.1 | skills only (incl. optional Grok-host relay to a user-installed Claude Code / Codex CLI), no MCP, no hooks |

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`knowz-io`), and this PR comes from the `knowz-io/plugin-marketplace` fork. Not a personal account.

## Checklist

- [x] Entries added to `.grok-plugin/marketplace.json` (valid JSON, kebab-case names, unique)
- [x] Both remote sources pin the same full 40-char lowercase commit `sha`; the repo is public and the commit is reachable
- [x] Regenerated `.grok-plugin/plugin-index.json`
- [x] `python3 scripts/validate-catalog.py` → Catalog OK
- [x] `python3 scripts/generate-plugin-index.py --check` → Plugin index OK
- [x] `homepage` + clear `description` set on both; brand-scoped keywords/domains
- [x] License stated (MIT)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. Neither plugin ships a script, binary, or install step — Markdown skills plus, for Knowz, one MCP server declaration.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. Neither plugin registers lifecycle hooks. Knowz declares exactly one scoped HTTP MCP server — no shell-exec server.

**Network endpoints:**

- Hosted Knowz MCP only (Knowz plugin) — searching/writing the user's own Knowz vaults. Exact URL is the single `http` entry in `plugins/knowz/mcp.json` at the pinned SHA.
- KnowzCode makes no network calls of its own.

**Credentials/permissions:**

- Knowz: interactive **Authorize** (OAuth) against a Knowz account. No API keys, `CLIENT_ID`, `bearer_token_env_var`, or `x-api-key` in the package.
- KnowzCode: none. No Authorize step.

## Notes for reviewers

**Two entries in one PR.** The template prefers one entry; these are two distinct products that share one source repo. Happy to split into two PRs if preferred.

**KnowzCode's optional relay, disclosed up front.** KnowzCode can hand implementation work to a **Claude Code or Codex CLI the user already installed**, while Grok plans, reviews, and finalizes. It never downloads or installs a binary — it detects an existing CLI on `PATH` and only runs when the user opts in. Native in-Grok implementation is the default.

**Rebased + pin-bumped 2026-09-19 ET** onto current `xai-org/plugin-marketplace` `main`. Diff is additive only: `knowz` + `knowzcode` in marketplace + regenerated index. Pin tracks `knowz-io/cursor-knowz-plugin` main including packaging PR #8 (`7b783c8`).
