### PR TITLE
Add Postiz plugin (social media scheduling across 28+ platforms)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "postiz",
+      "description": "Postiz social media automation. Schedule posts, manage integrations, upload media, and track analytics across 28+ platforms including X, LinkedIn, Reddit, YouTube, TikTok, and Instagram.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/gitroomhq/postiz-agent.git",
+        "sha": "6d3be9c0aec768075e91b4a29b04fb624d72d942"
+      },
+      "homepage": "https://postiz.com",
+      "keywords": ["postiz", "social media scheduler", "social media agentic scheduler", "schedule social media posts", "social media automation"],
+      "domains": ["postiz.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,24 @@
         ]
       }
     },
+    "postiz": {
+      "sha": "6d3be9c0aec768075e91b4a29b04fb624d72d942",
+      "version": "2.0.17",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "postiz",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "postiz",
+            "description": "Postiz is a tool to schedule social media and chat posts to 28+ channels X, LinkedIn, LinkedIn Page, Reddit, Instagram,…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "fd878692de15a3069c21c8f429eb0b9f2fe178fa",
       "components": {


### PR DESCRIPTION
## What this PR does

New plugin: adds Postiz, a social media automation skill + hosted MCP server for scheduling posts, managing integrations, uploading media, and tracking analytics across 28+ platforms (X, LinkedIn, Reddit, YouTube, TikTok, Instagram, and more).

- Plugin name: postiz
- Type: remote source
- Source URL + pinned SHA (remote): https://github.com/gitroomhq/postiz-agent.git @ `6d3be9c0aec768075e91b4a29b04fb624d72d942` (v2.0.17)
- Homepage: https://postiz.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (AGPL-3.0, declared in the plugin's `plugin.json` and repo `LICENSE`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): the plugin declares one MCP server via `mcpServers` in its `.grok-plugin/plugin.json` — `https://mcp.postiz.com/mcp-oauth-dynamic` (streamable HTTP, OAuth; the user signs in to Postiz on first connection, nothing runs locally and no token is stored by the plugin). In addition, the skill drives the open-source `postiz` CLI (installed from npm), which calls the Postiz public API — `https://api.postiz.com` by default, or a user-configured self-hosted instance via `POSTIZ_API_URL` — to schedule posts, upload media, and read analytics. Media uploads resolve to `https://uploads.postiz.com` URLs.
- Credentials/permissions it requires (and why): for the MCP server, an OAuth login to the user's own Postiz account (scoped to their workspace); for the CLI path, a Postiz API key provided by the user. No other credentials are read or stored by the plugin.

## Notes for reviewers

Postiz is an open-source social media scheduling platform (https://github.com/gitroomhq/postiz-app, ~20k+ stars). The plugin repo is under our official gitroomhq org, and I'm the founder/maintainer. The plugin is a single skill that wraps our published npm CLI (`postiz`), plus the official hosted Postiz MCP server declared in the manifest.

**Update (2026-09-01):** rebased onto `main` to resolve conflicts in `marketplace.json` / `plugin-index.json`, and bumped the pin to `6d3be9c` (v2.0.17), which adds the MCP server to the Grok manifest. Index regenerated and both validators re-run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TiYYYHs7du33PtpSXhBuf

