### PR TITLE
Add Famulor Assistants & History read-only plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,19 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "famulor-assistants-history",
+      "description": "Review Famulor assistant configurations, versions, catalogs, and omnichannel call, messaging, and email history through an OAuth-secured, read-only 11-tool MCP profile.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/bekservice/Famulor-Skill.git",
+        "sha": "7acc654427795caff6ab9404b3c8be16ad50e3ef",
+        "path": "claude-store"
+      },
+      "homepage": "https://docs.famulor.io/en/mcp/client",
+      "keywords": ["famulor", "famulor assistants", "famulor history", "famulor mcp"],
+      "domains": ["famulor.io", "app.famulor.io", "docs.famulor.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -205,6 +205,24 @@
         ]
       }
     },
+    "famulor-assistants-history": {
+      "sha": "7acc654427795caff6ab9404b3c8be16ad50e3ef",
+      "version": "2.0.2",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "famulor",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "famulor-assistants-history",
+            "description": "Read Famulor assistant configurations, versions, catalogs, and omnichannel conversation history through the restricted…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3",
       "version": "2.2.96",


### PR DESCRIPTION
## What this PR does

- Plugin name: `famulor-assistants-history`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/bekservice/Famulor-Skill.git` at `7acc654427795caff6ab9404b3c8be16ad50e3ef`, path `claude-store`
- Homepage: https://docs.famulor.io/en/mcp/client

This replaces the earlier broad proposal on this PR with the marketplace-specific Assistant & History package.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official BEK Service organization. BEK Service GmbH develops and operates Famulor.

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] The remote source pins a public, reachable, full 40-character commit SHA and narrows installation to `claude-store`.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and a precise description are set; the remote package includes `README.md` and a valid `.claude-plugin/plugin.json` manifest.
- [x] The packaged plugin and Skill source state their MIT license.

## Security

- [x] No remote-code download/exec, postinstall script, or local executable.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or environment variables.
- [x] No hooks. MCP scope is least-privilege and read-only.
- Network endpoint: `https://app.famulor.io/mcp?profile=assistant-history` — the hosted Famulor MCP endpoint used to review assistants and authenticated workspace history.
- Credentials/permissions: Famulor OAuth on first use; the server requests `assistants:read` and `calls:read`. No API key is bundled or requested by the plugin.

## Notes for reviewers

The profile exposes exactly 11 read-only tools for assistant configuration, versions, catalogs, and omnichannel call, messaging, and email history. It cannot create or change assistants, send messages, place calls, run campaigns, buy phone numbers, access billing, or perform administrative actions. Messaging records can include Instagram or Messenger when available and may be previews rather than complete transcripts.

The MIT license applies to the packaged plugin and Skill source. The remotely hosted Famulor MCP service is governed separately by Famulor terms and privacy policies.