### PR TITLE
Add deja plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,19 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "deja",
+      "description": "Recall what you already did in your other coding agents. deja indexes the session transcripts Claude Code, Codex, Cursor, opencode, Zed and fifteen more already write to disk, including work from before it was installed, and answers from them locally.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vshulcz/deja-vu.git",
+        "path": "extensions/grok",
+        "sha": "342bdd2422631f1f85971a6b9627b95423442992"
+      },
+      "homepage": "https://github.com/vshulcz/deja-vu",
+      "keywords": ["deja", "recall past sessions", "what did I do before", "search my agent history", "session memory"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -181,6 +181,35 @@
         ]
       }
     },
+    "deja": {
+      "sha": "342bdd2422631f1f85971a6b9627b95423442992",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "recall",
+            "description": "Search this machine's past AI coding sessions (deja-vu)"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "deja",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "deja-history",
+            "description": "Search the user's past AI coding sessions. Use when they say things like 'didn't we fix this before', 'what did we deci…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
deja indexes the session transcripts coding agents already write to disk — Claude Code, Codex, Cursor, opencode, Zed and fifteen more — including sessions from before it was installed, and answers from them locally. BM25 over those files: no model, no embeddings, nothing leaves the machine, and credentials are redacted as the index is built.

Inside Grok the plugin adds the MCP server (`recall`, `recall_context`, `blame`, `fix`, `how`, `remember`), the `deja-history` skill, `/deja:recall`, and a `UserPromptSubmit` hook that searches this machine's history for what the prompt is about and stays silent when nothing matches.

Remote source, pinned to `342bdd2` with `path: extensions/grok` — the plugin lives in the deja repository beside the packages for the other harnesses, so one repository stays the source of truth for all of them. Ran `scripts/validate-catalog.py` (Catalog OK) and `scripts/generate-plugin-index.py`; the index entry is in this PR.

One note worth your eyes: the plugin's `.mcp.json` and `hooks/hooks.json` both address files through `GROK_PLUGIN_ROOT`. The plugin guide documents that variable for hook commands, and this is the first use I am sure about; whether it is expanded for MCP server arguments I could not verify here — the `grok` on this machine is the community CLI that shares the name and the `~/.grok` directory, not Grok Build. If MCP arguments are not expanded, say so and I will switch that entry to whatever form you prefer rather than guess.

deja is MIT, and the plugin stands down where a user has already wired deja through its own CLI, so installing both does not list every tool twice.
