### PR TITLE
Add SJ Ecosystem Plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -269,7 +269,7 @@
     },
     {
       "name": "sj-ecosystem",
-      "description": "Connect Grok to the SJ Delivery Super App Ecosystem. Build, deploy, and manage Web Apps, Mini-Games, and Smart Contracts directly to your live SJ account via the SJ MCP Server.",
+      "description": "Connect Grok to the SJ Super App Ecosystem. Build, deploy, and manage Web Apps, Mini-Games, and Smart Contracts directly to your live SJ account via the SJ MCP Server.",
       "category": "development",
       "source": {
         "type": "local",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,18 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "sj-ecosystem",
+      "description": "Connect Grok to the SJ Delivery Super App Ecosystem. Build, deploy, and manage Web Apps, Mini-Games, and Smart Contracts directly to your live SJ account via the SJ MCP Server.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/sj-ecosystem"
+      },
+      "homepage": "https://sjone.xyz",
+      "keywords": ["sj", "super app", "web3", "games", "deployment", "mcp"],
+      "domains": ["sjone.xyz"]
     }
   ]
 }

--- a/external_plugins/sj-ecosystem/.grok-plugin/plugin.json
+++ b/external_plugins/sj-ecosystem/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "sj-ecosystem",
+  "version": "1.0.0",
+  "description": "Connect Grok to the SJ Delivery Super App Ecosystem. Build, deploy, and manage Web Apps, Mini-Games, and Smart Contracts directly to your live SJ account via the SJ MCP Server.",
+  "author": {
+    "name": "SJ",
+    "url": "https://sjone.xyz"
+  },
+  "homepage": "https://sjone.xyz",
+  "repository": "https://github.com/simojibou/sj-cursor-plugin",
+  "license": "Apache-2.0",
+  "keywords": ["sj", "super app", "web3", "games", "deployment", "mcp"]
+}

--- a/external_plugins/sj-ecosystem/.mcp.json
+++ b/external_plugins/sj-ecosystem/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "sj-ecosystem": {
       "type": "sse",
-      "url": "https://us-central1-sj-one.cloudfunctions.net/mcpSse/SJ_MCP_SEC"
+      "url": "https://sj-mcp-zero.sj-one-og.workers.dev/mcp/sse"
     }
   }
 }

--- a/external_plugins/sj-ecosystem/.mcp.json
+++ b/external_plugins/sj-ecosystem/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sj-ecosystem": {
+      "type": "sse",
+      "url": "https://us-central1-sj-one.cloudfunctions.net/mcpSse/SJ_MCP_SEC"
+    }
+  }
+}


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name:
- Type: <!-- remote source / local (external_plugins) -->
- Source URL + pinned SHA (remote), or vendored path (local):
- Homepage:

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [ ] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [ ] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [ ] `python3 scripts/validate-catalog.py` passes locally.
- [ ] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [ ] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [ ] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [ ] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [ ] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
- Credentials/permissions it requires (and why):

## Notes for reviewers

<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->
