### PR TITLE
Add ClawCall phone-calling plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,20 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "clawcall",
+      "description": "ClawCall phone calling integration (hosted MCP server + skill). Place real US phone calls, handle phone menus and hold queues, bridge the user into a live call, and retrieve call results, transcripts, recordings, and history with OAuth.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ClawCall-Dev/ClawCall.git",
+        "sha": "d1abff3f2ef4e54b88cad8bc6c8a477f658a1360",
+        "path": "grok"
+      },
+      "homepage": "https://clawcall.dev",
+      "keywords": ["clawcall", "claw call", "clawcall phone", "clawcall mcp"],
+      "domains": ["clawcall.dev", "api.clawcall.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -127,6 +127,24 @@
         ]
       }
     },
+    "clawcall": {
+      "sha": "d1abff3f2ef4e54b88cad8bc6c8a477f658a1360",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "clawcall",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "clawcall",
+            "description": "Use when the user wants Grok to place a US phone call, call a business, handle hold or phone menus, confirm/reschedule/…"
+          }
+        ]
+      }
+    },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds ClawCall's official hosted MCP connector and calling workflow skill to the xAI plugin marketplace. It lets Grok Build place real US phone calls, navigate phone menus and hold queues, bridge the user into a live call, and retrieve call status, transcripts, recordings, history, balance, and the hosted calling guide.

- Plugin name: `clawcall`
- Type: remote source
- Source: `https://github.com/ClawCall-Dev/ClawCall.git`
- Pinned SHA: `d1abff3f2ef4e54b88cad8bc6c8a477f658a1360`
- Plugin path: `grok`
- Homepage: https://clawcall.dev

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The plugin source and MIT license are published under the official `ClawCall-Dev` organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] Remote source pins a public, reachable, full 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the remote plugin includes `README.md` and `.grok-plugin/plugin.json`.
- [x] The plugin is licensed under MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or environment variables.
- [x] No hooks or local executable code. The plugin contains metadata, documentation, a calling workflow skill, a logo, and an HTTP MCP configuration.
- [x] MCP scope is limited to ClawCall call operations.

Network endpoints:

- `https://api.clawcall.dev/mcp` — production Streamable HTTP MCP endpoint.
- `https://api.clawcall.dev/.well-known/*` and ClawCall's OAuth endpoints — discovery, authorization, dynamic client registration, token exchange, and revocation.
- OAuth discovery and authorization are published through the stable `api.clawcall.dev` origin.

Credentials and permissions:

- OAuth 2.1 sign-in on first connection; no API key is bundled or requested by the plugin.
- `calls:read` reads call status, transcripts, recordings, history, balance, and calling guides.
- `calls:write` places and ends calls.

## Notes for reviewers

The public artifact and plugin source are available at https://github.com/ClawCall-Dev/ClawCall/tree/d1abff3f2ef4e54b88cad8bc6c8a477f658a1360/grok.

The MCP endpoint was verified in production on 2026-08-25. Protected-resource and authorization-server discovery stay on the public `api.clawcall.dev` origin; unauthenticated MCP requests return `401` with the correct resource metadata; Cursor's exact native callback registers successfully; and unapproved custom schemes remain rejected.

Phone calls have real-world effects, so the bundled skill requires Grok to read the hosted calling guide and confirm consequential instructions and decision boundaries before calling. The connector currently supports US phone numbers only.
