### PR TITLE
Add Beam Protocol plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,20 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "beam",
+      "description": "Beam Protocol integration for trusted agent-to-agent collaboration. Verify Beam IDs, inspect public trust metadata, and prepare approval-gated handoffs through a dedicated OAuth-protected MCP tenant.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Beam-directory/beam-protocol.git",
+        "sha": "bb84f274aa74d60f729525e5aebd505e12ec092f",
+        "path": "integrations/grok-build"
+      },
+      "homepage": "https://beam.directory",
+      "keywords": ["beam protocol", "beam id", "beam agent handoff", "beam mcp"],
+      "domains": ["beam.directory", "docs.beam.directory"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Beam-directory/beam-protocol.git",
-        "sha": "bb84f274aa74d60f729525e5aebd505e12ec092f",
+        "sha": "c3b3499852101d26e67c925f77c7bb6a8c805243",
         "path": "integrations/grok-build"
       },
       "homepage": "https://beam.directory",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -72,8 +72,8 @@
       }
     },
     "beam": {
-      "sha": "bb84f274aa74d60f729525e5aebd505e12ec092f",
-      "version": "1.0.0",
+      "sha": "c3b3499852101d26e67c925f77c7bb6a8c805243",
+      "version": "1.1.0",
       "components": {
         "commands": [
           {
@@ -90,7 +90,7 @@
         "skills": [
           {
             "name": "beam",
-            "description": "Use Beam to verify Beam IDs, inspect agent trust metadata, and prepare or send approval-gated agent handoffs through a…"
+            "description": "Use Beam for verified agent identity, contacts, direct and group conversations, presence, and approval-gated handoffs t…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,30 @@
         ]
       }
     },
+    "beam": {
+      "sha": "bb84f274aa74d60f729525e5aebd505e12ec092f",
+      "version": "1.0.0",
+      "components": {
+        "commands": [
+          {
+            "name": "beam-onboard",
+            "description": "Connect and verify a dedicated Beam MCP tenant"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "beam",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "beam",
+            "description": "Use Beam to verify Beam IDs, inspect agent trust metadata, and prepare or send approval-gated agent handoffs through a…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6",
       "version": "1.7.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `beam`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Beam-directory/beam-protocol.git` at `bb84f274aa74d60f729525e5aebd505e12ec092f`, path `integrations/grok-build`
- Homepage: https://beam.directory

This adds the Beam Protocol plugin for trusted agent-to-agent collaboration. It provides a Beam ID and trust lookup skill, a guided onboarding command, and a dedicated-tenant HTTP MCP configuration for approval-gated handoff previews.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The source is maintained in the public `Beam-directory` GitHub organization. Its plugin source PR passed the Beam repository CI matrix before merge: https://github.com/Beam-directory/beam-protocol/pull/202

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with the kebab-case name `beam`.
- [x] Remote source pins a full 40-character lowercase commit SHA, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` and a clear `description` are set; the remote plugin includes `README.md` and `.grok-plugin/plugin.json`.
- [x] License is stated as Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or unrelated environment variables. `BEAM_MCP_URL` is the only referenced variable; it is a non-secret connector URL expanded by Grok and is never read or transmitted by plugin code.
- [x] Hooks and MCP scope are least-privilege. The plugin has no hooks or executable helpers. Beam tenants default to the read-only `beam_status` and `beam_prepare_handoff` tools. The skill treats previews as not sent and requires exact human approval if an independently reviewed tenant exposes `beam_send`.
- Network endpoints this plugin calls: only the operator-supplied HTTPS endpoint in `BEAM_MCP_URL`. The remote Beam tenant may call `https://api.beam.directory` server-side for identity and trust lookup. The plugin deliberately has no shared default endpoint and cannot route users into the private COPPEN pilot.
- Credentials/permissions it requires: OAuth access to the selected dedicated Beam MCP tenant, managed by Grok. Read-only use requires `beam:read`; no static credential is included. A tenant may separately require `beam:send`, but only when its operator has enabled delivery and the user approves the exact payload.

## Notes for reviewers

- `grok plugin validate integrations/grok-build` passes with Grok 1.0.5.
- A clean temporary Grok home installed `beam` from this marketplace branch and `grok inspect --json` discovered version 1.0.0, one skill, one onboarding command, and one HTTP MCP server with the configured URL.
- The Beam MCP server is intentionally dedicated-tenant. The plugin does not bundle a shared Beam identity, signing key, API key, executable hook, telemetry, or installer.
- Beam is a third-party plugin maintained by the Beam project; its README explicitly does not claim xAI authorship, verification, or endorsement.
