### PR TITLE
Add Weavatrix plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -7,12 +7,12 @@
   "plugins": [
     {
       "name": "weavatrix",
-      "description": "Native read-only repository intelligence with 43 evidence-backed methods for code graphs, impact, architecture, APIs, Git history, search, and quality analysis.",
+      "description": "Native read-only repository intelligence with 44 evidence-backed methods for code graphs, impact, architecture, APIs, Git history, search, and quality analysis.",
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/sergii-ziborov/weavatrix.git",
-        "sha": "46fd148f1c2ea8f45fa770c9d71bd0296e0a6266",
+        "url": "https://github.com/Weavatrix/weavatrix.git",
+        "sha": "afd051775d3c3d4228f3a7fa8f58c72ef081cabd",
         "path": "plugins/weavatrix"
       },
       "homepage": "https://weavatrix.com",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,20 @@
   },
   "plugins": [
     {
+      "name": "weavatrix",
+      "description": "Native read-only repository intelligence with 43 evidence-backed methods for code graphs, impact, architecture, APIs, Git history, search, and quality analysis.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sergii-ziborov/weavatrix.git",
+        "sha": "46fd148f1c2ea8f45fa770c9d71bd0296e0a6266",
+        "path": "plugins/weavatrix"
+      },
+      "homepage": "https://weavatrix.com",
+      "keywords": ["weavatrix", "weavatrix code graph", "weavatrix mcp"],
+      "domains": ["weavatrix.com"]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Weavatrix/weavatrix.git",
-        "sha": "afd051775d3c3d4228f3a7fa8f58c72ef081cabd",
+        "sha": "a4b7c65ede091f691874cb0eadefdd2f47c6392c",
         "path": "plugins/weavatrix"
       },
       "homepage": "https://weavatrix.com",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1176,6 +1176,24 @@
         ]
       }
     },
+    "weavatrix": {
+      "sha": "46fd148f1c2ea8f45fa770c9d71bd0296e0a6266",
+      "version": "1.9.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "weavatrix",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "weavatrix",
+            "description": "Use the Weavatrix MCP when a repository task benefits from indexed evidence: codebase orientation, symbol/source search…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "abff05613bf82101095a96b43b033150bfd8e145",
       "version": "1.16.3",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1195,7 +1195,7 @@
       }
     },
     "weavatrix": {
-      "sha": "afd051775d3c3d4228f3a7fa8f58c72ef081cabd",
+      "sha": "a4b7c65ede091f691874cb0eadefdd2f47c6392c",
       "version": "1.10.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1195,8 +1195,8 @@
       }
     },
     "weavatrix": {
-      "sha": "46fd148f1c2ea8f45fa770c9d71bd0296e0a6266",
-      "version": "1.9.0",
+      "sha": "afd051775d3c3d4228f3a7fa8f58c72ef081cabd",
+      "version": "1.10.0",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: weavatrix
- Type: remote source
- Source URL + pinned SHA: https://github.com/Weavatrix/weavatrix.git @ a4b7c65ede091f691874cb0eadefdd2f47c6392c (weavatrix 1.10.0, 44 read-only MCP tools)
- Homepage: https://weavatrix.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the first-party Weavatrix organization.

## Validation

- [x] `scripts/validate-catalog.py` and `scripts/generate-plugin-index.py --check` pass locally.
- [x] Branch is up to date with upstream main; index regenerated, never hand-edited.