### PR TITLE
Add Weavatrix Refactor plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/sergii-ziborov/weavatrix-refactor.git",
-        "sha": "f3aa028ef81e741aad25a5581911f9a62b4e0dbd",
+        "sha": "fb7089a32325e79ef42c470d8d366261d0f00dd6",
         "path": "plugins/weavatrix-refactor"
       },
       "homepage": "https://weavatrix.com",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,20 @@
   },
   "plugins": [
     {
+      "name": "weavatrix-refactor",
+      "description": "Transactional refactoring with 11 evidence-backed methods for exact previews, plan-bound confirmation, guarded multi-file writes, and drift-safe rollback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sergii-ziborov/weavatrix-refactor.git",
+        "sha": "f3aa028ef81e741aad25a5581911f9a62b4e0dbd",
+        "path": "plugins/weavatrix-refactor"
+      },
+      "homepage": "https://weavatrix.com",
+      "keywords": ["weavatrix refactor", "weavatrix transactional refactoring", "weavatrix rename"],
+      "domains": ["weavatrix.com"]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -11,8 +11,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/sergii-ziborov/weavatrix-refactor.git",
-        "sha": "fb7089a32325e79ef42c470d8d366261d0f00dd6",
+        "url": "https://github.com/Weavatrix/weavatrix-refactor.git",
+        "sha": "139f6ba40b3724ead90ae16ca6ca19e4410a1212",
         "path": "plugins/weavatrix-refactor"
       },
       "homepage": "https://weavatrix.com",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1176,6 +1176,24 @@
         ]
       }
     },
+    "weavatrix-refactor": {
+      "sha": "f3aa028ef81e741aad25a5581911f9a62b4e0dbd",
+      "version": "1.0.7",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "weavatrix-refactor",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "weavatrix-refactor",
+            "description": "Use Weavatrix Refactor only when the user explicitly requests repository source changes that benefit from a proven refa…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "abff05613bf82101095a96b43b033150bfd8e145",
       "version": "1.16.3",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1195,8 +1195,8 @@
       }
     },
     "weavatrix-refactor": {
-      "sha": "fb7089a32325e79ef42c470d8d366261d0f00dd6",
-      "version": "1.0.8",
+      "sha": "139f6ba40b3724ead90ae16ca6ca19e4410a1212",
+      "version": "1.0.11",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1177,8 +1177,8 @@
       }
     },
     "weavatrix-refactor": {
-      "sha": "f3aa028ef81e741aad25a5581911f9a62b4e0dbd",
-      "version": "1.0.7",
+      "sha": "fb7089a32325e79ef42c470d8d366261d0f00dd6",
+      "version": "1.0.8",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: weavatrix-refactor
- Type: remote source
- Source URL + pinned SHA: https://github.com/Weavatrix/weavatrix-refactor.git @ 139f6ba40b3724ead90ae16ca6ca19e4410a1212 (weavatrix-refactor 1.0.11)
- Homepage: https://weavatrix.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the first-party Weavatrix organization.

## Validation

- [x] `scripts/validate-catalog.py` and `scripts/generate-plugin-index.py --check` pass locally.
- [x] Branch is up to date with upstream main; index regenerated, never hand-edited.