### PR TITLE
Add Weavatrix Online plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -11,8 +11,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/sergii-ziborov/weavatrix-online.git",
-        "sha": "bc140c5220362e0d0631b7a620a1709e465b6a6d",
+        "url": "https://github.com/Weavatrix/weavatrix-online.git",
+        "sha": "64f3f93a5aea4ec73e32d5951976cdca9685eb68",
         "path": "plugins/weavatrix-online"
       },
       "homepage": "https://weavatrix.com",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,20 @@
   },
   "plugins": [
     {
+      "name": "weavatrix-online",
+      "description": "Guarded source-free repository workflows for endpoint status, dependency advisories, malware review, remote architecture contracts, and consent-gated graph sync.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sergii-ziborov/weavatrix-online.git",
+        "sha": "bc140c5220362e0d0631b7a620a1709e465b6a6d",
+        "path": "plugins/weavatrix-online"
+      },
+      "homepage": "https://weavatrix.com",
+      "keywords": ["weavatrix online", "weavatrix security", "weavatrix sync"],
+      "domains": ["weavatrix.com"]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1195,8 +1195,8 @@
       }
     },
     "weavatrix-online": {
-      "sha": "bc140c5220362e0d0631b7a620a1709e465b6a6d",
-      "version": "0.3.2",
+      "sha": "64f3f93a5aea4ec73e32d5951976cdca9685eb68",
+      "version": "0.3.4",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1176,6 +1176,24 @@
         ]
       }
     },
+    "weavatrix-online": {
+      "sha": "bc140c5220362e0d0631b7a620a1709e465b6a6d",
+      "version": "0.3.2",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "weavatrix-online",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "weavatrix-online",
+            "description": "Use Weavatrix Online only for configured Cloud or self-hosted endpoint status, current dependency advisory refresh, bou…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "abff05613bf82101095a96b43b033150bfd8e145",
       "version": "1.16.3",


### PR DESCRIPTION
## What this PR does

- Plugin name: weavatrix-online
- Type: remote source
- Source URL + pinned SHA: https://github.com/Weavatrix/weavatrix-online.git @ 64f3f93a5aea4ec73e32d5951976cdca9685eb68
- Homepage: https://weavatrix.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under the first-party Weavatrix organization.

## Validation

- [x] `scripts/validate-catalog.py` and `scripts/generate-plugin-index.py --check` pass locally.
- [x] Branch is up to date with upstream main; index regenerated, never hand-edited.