### PR TITLE
Add askgrokwallet plugin (AskGrokWallet)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "6d5536961981fdf67f81d204afb4c62916ce8cb8"
+        "sha": "edd0d35fabefb2d82e245cfb7118a758c84d706d"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "a9fe7ed320504ea7481a49def3fbb9361ee567df"
+        "sha": "c5b169ed123ce1f8d285edbe35f478827aec4587"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "fb80eb50931bb237f51654e984847425eaa83ea5"
+        "sha": "90931963d35c41818ca95aab55f3b242ea8bc614"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "90931963d35c41818ca95aab55f3b242ea8bc614"
+        "sha": "b81a091bec2b5a54a0613e282fac35e4f13b7223"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "8413c581e5c20738d5501a326caf54a594b746da"
+        "sha": "bc46298b059352171490390584fd895d92649a48"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -274,7 +274,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "197c433199767892984f73151c6f66d7c380bea8"
+        "sha": "f5ea8c67f3ef157b8ec884e5984cf4541fa38a5d"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "c5b169ed123ce1f8d285edbe35f478827aec4587"
+        "sha": "fb80eb50931bb237f51654e984847425eaa83ea5"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -268,16 +268,16 @@
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
     {
-      "name": "ask-wallet",
-      "description": "A governed wallet for AI agents: plain-English policies, a human approval inbox, and signed receipts for every spend.",
+      "name": "askgrokwallet",
+      "description": "A governed wallet for Grok agents (and any AI agent): plain-English policies, a human approval inbox, and signed receipts for every spend.",
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/richard7463/ask-wallet.git",
-        "sha": "2ad21c955fab35f45c64fe5e2f77f8b07a6169e8"
+        "url": "https://github.com/askgrokwallet/askgrokwallet.git",
+        "sha": "197c433199767892984f73151c6f66d7c380bea8"
       },
-      "homepage": "https://github.com/richard7463/ask-wallet",
-      "keywords": ["ask-wallet", "governed wallet", "agent approval", "human in the loop", "policy engine"]
+      "homepage": "https://github.com/askgrokwallet/askgrokwallet",
+      "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "6a80a82c0ee8e45b0b6ae9b4163e4aa9404a6822"
+        "sha": "8413c581e5c20738d5501a326caf54a594b746da"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -268,16 +268,16 @@
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
     {
-      "name": "agent-gate",
-      "description": "Governed spending and actions for AI agents: plain-English policies, a human approval inbox, and signed receipts for every outcome.",
+      "name": "ask-wallet",
+      "description": "A governed wallet for AI agents: plain-English policies, a human approval inbox, and signed receipts for every spend.",
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/richard7463/agent-gate.git",
-        "sha": "e8bbd4af0706c7dc9cb7d5fdb43d726ff37fb4a3"
+        "url": "https://github.com/richard7463/ask-wallet.git",
+        "sha": "2ad21c955fab35f45c64fe5e2f77f8b07a6169e8"
       },
-      "homepage": "https://github.com/richard7463/agent-gate",
-      "keywords": ["agent-gate", "governed spending", "agent approval", "human in the loop", "policy engine"]
+      "homepage": "https://github.com/richard7463/ask-wallet",
+      "keywords": ["ask-wallet", "governed wallet", "agent approval", "human in the loop", "policy engine"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "dbe5638ec34db05e4d808a174943a0d762fa8e61"
+        "sha": "6a80a82c0ee8e45b0b6ae9b4163e4aa9404a6822"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "8a8dc2aa9ba7f6cb56a2a27a3bfaabb001572e44"
+        "sha": "2e2b5a334cbcd7d04ed357b50f3acac9af89ad2c"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "2d3fb0cb209777a1bb89147ab6d5570f300f897e"
+        "sha": "dbe5638ec34db05e4d808a174943a0d762fa8e61"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "b81a091bec2b5a54a0613e282fac35e4f13b7223"
+        "sha": "fda28dc0a925be96e26e38ae64f51dab256a7b07"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "fda28dc0a925be96e26e38ae64f51dab256a7b07"
+        "sha": "8e2cf59bdbfca875a52b62b8e5903c8c19184738"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "00f3a2bc2116bfeb3fa4d89b3084de18b58008cd"
+        "sha": "8a8dc2aa9ba7f6cb56a2a27a3bfaabb001572e44"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,18 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "agent-gate",
+      "description": "Governed spending and actions for AI agents: plain-English policies, a human approval inbox, and signed receipts for every outcome.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/richard7463/agent-gate.git",
+        "sha": "e8bbd4af0706c7dc9cb7d5fdb43d726ff37fb4a3"
+      },
+      "homepage": "https://github.com/richard7463/agent-gate",
+      "keywords": ["agent-gate", "governed spending", "agent approval", "human in the loop", "policy engine"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -287,10 +287,10 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "96f0305b2c67f8ea2eeed2465d59efaf8ca07215"
+        "url": "https://github.com/richard7463/askgrokwallet.git",
+        "sha": "a9fe7ed320504ea7481a49def3fbb9361ee567df"
       },
-      "homepage": "https://github.com/askgrokwallet/askgrokwallet",
+      "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "edd0d35fabefb2d82e245cfb7118a758c84d706d"
+        "sha": "00f3a2bc2116bfeb3fa4d89b3084de18b58008cd"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "2e2b5a334cbcd7d04ed357b50f3acac9af89ad2c"
+        "sha": "65ad5db393c249416cfb3a41b4821d767fcdefda"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "65ad5db393c249416cfb3a41b4821d767fcdefda"
+        "sha": "96f0305b2c67f8ea2eeed2465d59efaf8ca07215"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "aaaace17af497f54f241753feedcd299fb7bc00c"
+        "sha": "6d5536961981fdf67f81d204afb4c62916ce8cb8"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -274,7 +274,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/askgrokwallet/askgrokwallet.git",
-        "sha": "f5ea8c67f3ef157b8ec884e5984cf4541fa38a5d"
+        "sha": "aaaace17af497f54f241753feedcd299fb7bc00c"
       },
       "homepage": "https://github.com/askgrokwallet/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/richard7463/askgrokwallet.git",
-        "sha": "8e2cf59bdbfca875a52b62b8e5903c8c19184738"
+        "sha": "2d3fb0cb209777a1bb89147ab6d5570f300f897e"
       },
       "homepage": "https://github.com/richard7463/askgrokwallet",
       "keywords": ["askgrokwallet", "governed wallet", "grok wallet", "agent approval", "human in the loop", "policy engine"]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "00f3a2bc2116bfeb3fa4d89b3084de18b58008cd",
+      "sha": "8a8dc2aa9ba7f6cb56a2a27a3bfaabb001572e44",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "8e2cf59bdbfca875a52b62b8e5903c8c19184738",
+      "sha": "2d3fb0cb209777a1bb89147ab6d5570f300f897e",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "65ad5db393c249416cfb3a41b4821d767fcdefda",
+      "sha": "96f0305b2c67f8ea2eeed2465d59efaf8ca07215",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "6a80a82c0ee8e45b0b6ae9b4163e4aa9404a6822",
+      "sha": "8413c581e5c20738d5501a326caf54a594b746da",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "8413c581e5c20738d5501a326caf54a594b746da",
+      "sha": "bc46298b059352171490390584fd895d92649a48",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "8a8dc2aa9ba7f6cb56a2a27a3bfaabb001572e44",
+      "sha": "2e2b5a334cbcd7d04ed357b50f3acac9af89ad2c",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "dbe5638ec34db05e4d808a174943a0d762fa8e61",
+      "sha": "6a80a82c0ee8e45b0b6ae9b4163e4aa9404a6822",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "aaaace17af497f54f241753feedcd299fb7bc00c",
+      "sha": "6d5536961981fdf67f81d204afb4c62916ce8cb8",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "96f0305b2c67f8ea2eeed2465d59efaf8ca07215",
+      "sha": "a9fe7ed320504ea7481a49def3fbb9361ee567df",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "b81a091bec2b5a54a0613e282fac35e4f13b7223",
+      "sha": "fda28dc0a925be96e26e38ae64f51dab256a7b07",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "f5ea8c67f3ef157b8ec884e5984cf4541fa38a5d",
+      "sha": "aaaace17af497f54f241753feedcd299fb7bc00c",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "6d5536961981fdf67f81d204afb4c62916ce8cb8",
+      "sha": "edd0d35fabefb2d82e245cfb7118a758c84d706d",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "fda28dc0a925be96e26e38ae64f51dab256a7b07",
+      "sha": "8e2cf59bdbfca875a52b62b8e5903c8c19184738",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "197c433199767892984f73151c6f66d7c380bea8",
+      "sha": "f5ea8c67f3ef157b8ec884e5984cf4541fa38a5d",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "2e2b5a334cbcd7d04ed357b50f3acac9af89ad2c",
+      "sha": "65ad5db393c249416cfb3a41b4821d767fcdefda",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "edd0d35fabefb2d82e245cfb7118a758c84d706d",
+      "sha": "00f3a2bc2116bfeb3fa4d89b3084de18b58008cd",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
   "plugins": {
-    "agent-gate": {
-      "sha": "e8bbd4af0706c7dc9cb7d5fdb43d726ff37fb4a3",
+    "ask-wallet": {
+      "sha": "2ad21c955fab35f45c64fe5e2f77f8b07a6169e8",
       "version": "0.1.0",
       "components": {
         "skills": [
           {
-            "name": "agent-gate",
-            "description": "Governed spending and actions for AI agents. Enforce budgets, allowlists, operator modes, and human approval before mon…"
+            "name": "ask-wallet",
+            "description": "A governed wallet for AI agents. Enforce budgets, allowlists, operator modes, and human approval before money or conseq…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "fb80eb50931bb237f51654e984847425eaa83ea5",
+      "sha": "90931963d35c41818ca95aab55f3b242ea8bc614",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "c5b169ed123ce1f8d285edbe35f478827aec4587",
+      "sha": "fb80eb50931bb237f51654e984847425eaa83ea5",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,14 +1,14 @@
 {
   "version": 1,
   "plugins": {
-    "ask-wallet": {
-      "sha": "2ad21c955fab35f45c64fe5e2f77f8b07a6169e8",
+    "askgrokwallet": {
+      "sha": "197c433199767892984f73151c6f66d7c380bea8",
       "version": "0.1.0",
       "components": {
         "skills": [
           {
-            "name": "ask-wallet",
-            "description": "A governed wallet for AI agents. Enforce budgets, allowlists, operator modes, and human approval before money or conseq…"
+            "name": "askgrokwallet",
+            "description": "A governed wallet for Grok agents (and any AI agent). Enforce budgets, allowlists, operator modes, and human approval b…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "a9fe7ed320504ea7481a49def3fbb9361ee567df",
+      "sha": "c5b169ed123ce1f8d285edbe35f478827aec4587",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "agent-gate": {
+      "sha": "e8bbd4af0706c7dc9cb7d5fdb43d726ff37fb4a3",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "agent-gate",
+            "description": "Governed spending and actions for AI agents. Enforce budgets, allowlists, operator modes, and human approval before mon…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "90931963d35c41818ca95aab55f3b242ea8bc614",
+      "sha": "b81a091bec2b5a54a0613e282fac35e4f13b7223",
       "version": "0.1.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "askgrokwallet": {
-      "sha": "2d3fb0cb209777a1bb89147ab6d5570f300f897e",
+      "sha": "dbe5638ec34db05e4d808a174943a0d762fa8e61",
       "version": "0.1.0",
       "components": {
         "skills": [


### PR DESCRIPTION
## What this PR does

Adds `askgrokwallet` (AskGrokWallet) as a third-party plugin so Grok agents
(and any AI agent) get a governed wallet: plain-English policies, a human
approval inbox, and signed receipts before money or consequential actions
move.

- Plugin name: `askgrokwallet`
- Type: remote source
- Source URL + pinned SHA:
  `https://github.com/askgrokwallet/askgrokwallet.git` @ `197c433199767892984f73151c6f66d7c380bea8`
- Homepage: https://github.com/askgrokwallet/askgrokwallet

## Ownership

- [x] I own this plugin and have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): the skill calls the
  self-hosted AgentGate approval API (`/api/approvals`, `/approvals`) that the
  operator runs, to submit and decide approval requests; no external SaaS
  endpoint.
- Credentials/permissions it requires (and why): none at install time; the
  skill never requests keys or passwords, and policy/budget/allowlist are
  operator-defined.

## Notes for reviewers

- Independent open-source project (not affiliated with xAI or Cursor); there
  is no official org because this is an indie project.
- The same repository is also submitted to the Cursor Marketplace (Grok Bot
  app-in-marketplace); it carries both `.grok-plugin` and `.cursor-plugin`
  manifests and is MIT licensed.
- The plugin ships a single `SKILL.md` at the repo root (declared via
  `"skills": "."`), with no MCP servers, hooks, or agents — minimal
  supply-chain surface.
