### PR TITLE
Add Memlane plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -266,6 +266,23 @@
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "memlane",
+      "description": "Memlane relationship manager synced with Apple Contacts. Search and update contacts, read and add notes, move people on Lanes, work the Queue, log promises, and more through 50 MCP tools. OAuth or token auth. Needs Memlane Pro and iCloud. Destructive tools ask for a second yes.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ONLYHUMN/memlane-agent-plugin.git",
+        "sha": "9dfd7ae6321db46fb506d633e9066719a79e2635"
+      },
+      "homepage": "https://memlane.app/developers",
+      "keywords": [
+        "memlane"
+      ],
+      "domains": [
+        "memlane.app"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -327,6 +327,18 @@
         ]
       }
     },
+    "memlane": {
+      "sha": "9dfd7ae6321db46fb506d633e9066719a79e2635",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "memlane",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## Summary

Adds Memlane to the xAI plugin marketplace catalog as a remote third-party plugin sourced from ONLYHUMN.

- **Plugin:** `memlane`
- **Source:** https://github.com/ONLYHUMN/memlane-agent-plugin (pinned SHA)
- **MCP:** `https://memlane.app/api/mcp/v1` (OAuth; Streamable HTTP)
- **Homepage:** https://memlane.app/developers
- **Privacy:** https://memlane.app/privacy
- **Support:** support@memlane.app

Memlane is a relationship manager synced with Apple Contacts. The MCP server exposes 50 tools for contacts, dossiers, Lanes, Queue, promises, Meetups, and Map. Destructive tools require a second user confirmation. Requires Memlane Pro and iCloud.

## Checklist

- [x] Catalog entry added to `.grok-plugin/marketplace.json`
- [x] Remote source pinned to full 40-char SHA
- [x] `plugin-index.json` regenerated
- [x] `python3 scripts/validate-catalog.py` passes
- [x] `python3 scripts/generate-plugin-index.py --check` passes
- [x] Source from official org (`ONLYHUMN/memlane-agent-plugin`)
- [x] Brand-scoped keywords (`memlane`) and domains (`memlane.app`)

## Test account

We can provide a dedicated Memlane Pro reviewer account with iCloud connected on request.