### PR TITLE
Add deadsimple-email plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "deadsimple-email",
+      "description": "Give Grok its own email address. Dead Simple Email provisions agent-owned inboxes, sends and receives mail, replies in-thread, and pulls one-time codes and magic links out of signup email so a bot can finish an email verification on its own. 14 tools over a hosted MCP server, OAuth sign-in, no API key to paste.",
+      "category": "communication",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/deadsimple-email/deadsimple-plugins.git",
+        "sha": "114cc2ee9b7791402dac7f4c5066d5ae7263e3a8"
+      },
+      "homepage": "https://deadsimple.email",
+      "keywords": ["dead simple email", "deadsimple email", "deadsimple inbox", "deadsimple mcp"],
+      "domains": ["deadsimple.email"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,52 @@
         ]
       }
     },
+    "deadsimple-email": {
+      "sha": "114cc2ee9b7791402dac7f4c5066d5ae7263e3a8",
+      "version": "0.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "deadsimple",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agent-email-patterns",
+            "description": "Design and review agent systems that use email, covering safe topologies, the authorization model for consequential act…"
+          },
+          {
+            "name": "check-inbox",
+            "description": "Read, search, summarize, and triage Dead Simple Email inboxes through the connected MCP server. Use for ANY request to…"
+          },
+          {
+            "name": "deadsimple-mcp",
+            "description": "Connect, authenticate, and troubleshoot the Dead Simple Email MCP server. Use when the email tools are missing or greye…"
+          },
+          {
+            "name": "deadsimple-sdk",
+            "description": "Write application code against the Dead Simple Email REST API using the Python, TypeScript, or Go SDK. Use when buildin…"
+          },
+          {
+            "name": "deadsimple-webhooks",
+            "description": "Register and consume Dead Simple Email webhooks, and verify their signatures correctly. Use when building an endpoint t…"
+          },
+          {
+            "name": "manage-inboxes",
+            "description": "Create, list, and delete Dead Simple Email inboxes and check plan usage through the connected MCP server. Use when the…"
+          },
+          {
+            "name": "send-email",
+            "description": "Send new email, reply within a thread, and forward messages from Dead Simple Email inboxes through the connected MCP se…"
+          },
+          {
+            "name": "verification-codes",
+            "description": "Complete email verification, signup, and 2FA flows end to end using a Dead Simple Email inbox. Use whenever a task requ…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
Adds the official Dead Simple Email plugin (https://deadsimple.email) — an email API for AI agents.

**What the plugin provides**
- Hosted remote MCP server at `https://api.deadsimple.email/mcp` (Streamable HTTP, per-request bearer auth, no local process)
- 14 tools: inbox lifecycle, send, threaded reply, forward, thread reading, `wait_for_email`, and OTP / magic-link extraction for signup flows
- Three bundled skills (check-inbox, send-email, manage-inboxes) covering safe read/triage, sending, and inbox lifecycle workflows

**Checks**
- Source repo: https://github.com/deadsimple-email/deadsimple-plugins (MIT), pinned to commit `2240985`
- `scripts/generate-plugin-index.py` run; `scripts/validate-catalog.py` passes (Catalog OK)
- Endpoint verified with `grok mcp doctor`: handshake OK, 14 tools discovered

Free tier (5 inboxes, 5,000 emails/month) works without a card, so reviewers can test end-to-end.