### PR TITLE
Add zzaim plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "zzaim",
+      "description": "Korean lesson plan assistant. Search the national curriculum (2022 and 2024 revisions), draft and validate a lesson plan against the official form, and export it to HWPX for Hancom Office, DOCX, or PPTX.",
+      "category": "education",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/zzaim-app/zzaim-plugin.git",
+        "sha": "2b44fea5c79a7d104253b84e8007cfb8758fa0aa"
+      },
+      "homepage": "https://zzaim.vercel.app",
+      "keywords": ["zzaim", "zzaim lesson plan", "zzaim 지도안", "zzaim curriculum"],
+      "domains": ["zzaim.vercel.app"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,11 +288,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/zzaim-app/zzaim-plugin.git",
-        "sha": "2b44fea5c79a7d104253b84e8007cfb8758fa0aa"
+        "sha": "61d5260b4bb1c42cf2395c8276925c307f99f7c2"
       },
-      "homepage": "https://zzaim.vercel.app",
+      "homepage": "https://zzaim.jhlim.dev",
       "keywords": ["zzaim", "zzaim lesson plan", "zzaim 지도안", "zzaim curriculum"],
-      "domains": ["zzaim.vercel.app"]
+      "domains": ["zzaim.jhlim.dev", "zzaim.vercel.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1245,7 +1245,7 @@
       }
     },
     "zzaim": {
-      "sha": "2b44fea5c79a7d104253b84e8007cfb8758fa0aa",
+      "sha": "61d5260b4bb1c42cf2395c8276925c307f99f7c2",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1243,6 +1243,24 @@
           }
         ]
       }
+    },
+    "zzaim": {
+      "sha": "2b44fea5c79a7d104253b84e8007cfb8758fa0aa",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "zzaim",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "zzaim-lesson-plan",
+            "description": "Write, validate, and export a Korean school lesson plan (수업 지도안) using the national curriculum. Use when the user asks…"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds one new entry: **`zzaim`** — a Korean K-12 lesson plan assistant.

Korean schools submit lesson plans as HWPX (Hancom Office), not DOCX, so a plan an agent
cannot export to HWPX is not usable in a real school. This plugin connects Grok to the ZZAIM
MCP server so it can search the Korean national curriculum, draft a plan against the official
form, validate it, and export it to HWPX, DOCX, or PPTX.

- Plugin name: `zzaim`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/zzaim-app/zzaim-plugin.git` @ `61d5260b4bb1c42cf2395c8276925c307f99f7c2`
- Homepage: https://zzaim.jhlim.dev

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, covering this plugin repo — the hosted service has its own terms.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why)**

The plugin ships no executable code. The source repo is six files — one MCP config, one plugin
manifest, two Markdown documents, an MIT `LICENSE`, and a `.gitignore` — and it registers
exactly one remote MCP server.

| Host | Reached by | Why |
|---|---|---|
| `mcp.zzaim.jhlim.dev` | the MCP client | The MCP server itself (Streamable HTTP) |
| `ybdmskwkowiiblfuzzyp.supabase.co` | the browser, during sign-in | Our authorization server (OAuth) |
| `zzaim.jhlim.dev` | the MCP server | Our application API — documents, templates, export links |
| `lovelymango-zzaim-search.hf.space` | the MCP server | Our own curriculum search service |
| `*.supabase.co` | the MCP server | Our own managed Postgres |

No third-party analytics, error reporting, or telemetry SDKs.

**Credentials/permissions it requires (and why)**

OAuth 2.0 with PKCE and Dynamic Client Registration, requesting `openid`, `email`, `profile`.
The user approves on ZZAIM's own consent screen, which lists each capability before approval.
The plugin asks for no API key, reads no environment variable, and requires no filesystem or
shell access. There are no hooks.

## Notes for reviewers

**Where the tools are.** The endpoint is auth-first: an unauthenticated `initialize` or
`tools/list` returns `401` with an OAuth challenge, so tools cannot be enumerated anonymously.
For static review without signing in, the whole discovery chain is reachable anonymously — the
`401` itself carries the pointer:

```
POST https://mcp.zzaim.jhlim.dev/mcp-claude/v2
  → 401, WWW-Authenticate: Bearer realm="…", resource_metadata="…"

GET  https://mcp.zzaim.jhlim.dev/.well-known/oauth-protected-resource/mcp-claude/v2
  → scopes_supported: openid, email, profile
    authorization_servers: https://ybdmskwkowiiblfuzzyp.supabase.co/auth/v1

GET  https://ybdmskwkowiiblfuzzyp.supabase.co/auth/v1/.well-known/oauth-authorization-server
  → code_challenge_methods_supported (PKCE) and registration_endpoint (DCR)
```

The full tool list, argument contracts, and export rules are documented in the source repo's
[README](https://github.com/zzaim-app/zzaim-plugin/blob/61d5260b4bb1c42cf2395c8276925c307f99f7c2/README.md).

**On the org and the hostname.** `zzaim-app` is our org for this product; the GitHub handle
`zzaim` belongs to an unrelated account created in 2021, so we namespaced ours. The MCP
endpoint runs on a domain we control, served by a Hugging Face Space we operate
(`lovelymango/zzaim-mcp-hub`); that Space also answers on its default `*.hf.space` name, and
both names reach the same server. The source repo's README opens with a "Who operates this"
section tying the product, the endpoint, the Space, and this repo together.

**Category.** Marked `education`. It is a classroom tool for teachers rather than developer
infrastructure, so `keywords` and `domains` are scoped tightly to the product — every keyword is
`zzaim`-prefixed and the only domain is the one we operate — to keep the CTA from firing on
unrelated requests. One keyword is `zzaim 지도안` — 지도안 is Korean for "lesson plan", and that
is the phrase our users would actually type.

