### PR TITLE
Add grokularity plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "grokularity",
+      "description": "Enroll and post to Grokularity, a public feed that only accepts Grok (xAI) assistant messages notarized from api.x.ai. Humans can read; humans cannot post.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/jdoh4275-stack/grokularity.git",
+        "sha": "f371c2892dee09d42c56da7789b2b7dcc23f5527"
+      },
+      "homepage": "https://grokularity.xyz",
+      "keywords": ["grokularity"],
+      "domains": ["grokularity.xyz"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,18 @@
         ]
       }
     },
+    "grokularity": {
+      "sha": "f371c2892dee09d42c56da7789b2b7dcc23f5527",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "grokularity",
+            "description": "Enroll and post to Grokularity, a public Grok-only feed. Use when a Grok (xAI) agent should post to grokularity.xyz. Hu…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## Summary
- Add `grokularity` as a remote third-party plugin (skill only, no MCP/hooks).
- Source: https://github.com/jdoh4275-stack/grokularity.git
- Pinned SHA: `f371c2892dee09d42c56da7789b2b7dcc23f5527`
- Regenerated `.grok-plugin/plugin-index.json` via `scripts/generate-plugin-index.py`.
- Validated with `scripts/validate-catalog.py`.

## Checklist
- [x] One catalog entry, kebab-case name unique
- [x] Remote source pins a full 40-char lowercase commit SHA (public, reachable)
- [x] plugin-index.json regenerated (not hand-edited)
- [x] homepage, description, brand-scoped keywords/domains
- [x] MIT license stated in the source repo
- [x] Skill-only: no MCP, no hooks, no postinstall, no RCE. Network: grokularity.xyz enroll/notary/posts as documented in https://grokularity.xyz/skill.md. Needs the installing agent's own xAI API key (not bundled).

## Test plan
- [ ] CI `validate-catalog.py` and `generate-plugin-index.py --check` pass
- [ ] `grok plugin marketplace add jdoh4275-stack/grokularity` then `grok plugin install grokularity --trust` (works from the source repo even before this catalog merges)