### PR TITLE
feat(plugins): add dflow integration

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,10 +288,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/dflow-sh/plugin.git",
-        "sha": "e2e80c780a0b31aae44c88a6467fe5ceb6a65e27"
+        "sha": "3a7e112c8bbf4c1ff2fc5b1053399916da5a460f"
       },
       "homepage": "https://github.com/dflow-sh/plugin",
-      "keywords": ["dflow", "dflow.sh", "deployment", "infrastructure", "devops", "monitoring", "logging"],
+      "keywords": ["dflow", "dflow.sh"],
       "domains": ["dflow.sh", "app.dflow.sh"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "dflow",
+      "description": "dFlow platform integration. Create apps and environments, attach databases and services, manage domains and env vars, and trigger deploys on your own infrastructure from Grok.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dflow-sh/plugin.git",
+        "sha": "e2e80c780a0b31aae44c88a6467fe5ceb6a65e27"
+      },
+      "homepage": "https://github.com/dflow-sh/plugin",
+      "keywords": ["dflow", "dflow.sh", "deployment", "infrastructure", "devops", "monitoring", "logging"],
+      "domains": ["dflow.sh", "app.dflow.sh"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,18 @@
         ]
       }
     },
+    "dflow": {
+      "sha": "e2e80c780a0b31aae44c88a6467fe5ceb6a65e27",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "dflow",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,7 +200,7 @@
       }
     },
     "dflow": {
-      "sha": "e2e80c780a0b31aae44c88a6467fe5ceb6a65e27",
+      "sha": "3a7e112c8bbf4c1ff2fc5b1053399916da5a460f",
       "version": "0.1.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
Introduce the official dFlow plugin: a remote-source listing that connects Grok to the hosted dFlow MCP server (OAuth, no API keys) so agents can create apps, manage environments/services, and trigger deploys on the user's infrastructure.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

- Plugin name: `dflow`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): `https://github.com/dflow-sh/plugin.git` @ `e2e80c780a0b31aae44c88a6467fe5ceb6a65e27`
- Homepage: https://github.com/dflow-sh/plugin

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://app.dflow.sh/api/mcp` — official hosted MCP for dFlow Cloud (HTTP). No other endpoints. No stdio, hooks, or local binaries.
- Credentials/permissions it requires (and why): OAuth 2.0 only (browser consent). No API keys. Tenant-scoped to the organisation the user approves; same RBAC as the dFlow dashboard.

## Notes for reviewers

Official dFlow plugin from [`dflow-sh/plugin`](https://github.com/dflow-sh/plugin) (MIT). This is [dflow.sh](https://dflow.sh), an open-source PaaS — not the unrelated Solana “DFlow” project.

MCP-only listing (no skills/commands/hooks). README declares the endpoint and OAuth flow.