### PR TITLE
Add gmaa-grok third-party plugin (remote pin)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "gmaa-grok",
+      "description": "Grok TUI harness for GMAA. Skills, commands, agents, hooks. Fetches the sealed companion engine zip into ~/Downloads; on adopt copies it into ~/Code/<project>/ still zipped. Spine stays in the engine zip.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/GMAA-AI/gmaa.git",
+        "sha": "c3d8d1d8f84a7432711bec53dd1e3a60bf5d71bf",
+        "path": "grok/gmaa-grok-plugin"
+      },
+      "homepage": "https://gmaa.ai",
+      "keywords": ["gmaa", "gmaa-grok"],
+      "domains": ["gmaa.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,81 @@
         ]
       }
     },
+    "gmaa-grok": {
+      "sha": "c3d8d1d8f84a7432711bec53dd1e3a60bf5d71bf",
+      "components": {
+        "agents": [
+          {
+            "name": "architect",
+            "description": "HOW-class Product Architect seat — the autonomous adjudicator. Reads the whole repo at HEAD + worktrees READ-ONLY; rati…"
+          },
+          {
+            "name": "build-worker",
+            "description": "Worker for {{PROJECT_NAME}} (greenfield apparatus) work-packages. Executes one WP per spawn on its own branch; emits ar…"
+          },
+          {
+            "name": "canvas-monitor",
+            "description": "Monitors Cowork canvas-surface outputs (close-outs, PRE-STEP captures) and flags drift, contradictions with the main tr…"
+          },
+          {
+            "name": "dispatch-executor",
+            "description": "Executor for dispatch-track iter dispatches. Reads dispatch files from `dispatch/iter-NNN.md`, runs PASS 0–N against di…"
+          },
+          {
+            "name": "docs-resolver",
+            "description": "Resolves live-doc lookup requests from Dispatch Executor or Orchestrator. Invoked via Task tool when calling agent need…"
+          },
+          {
+            "name": "general-purpose",
+            "description": "General-purpose build/research/validation worker for foundation fan-out. Spawned by the foundation seat to run a BOUNDE…"
+          },
+          {
+            "name": "orc",
+            "description": "Role-neutral orchestrator seat. Identity, authority, state map, and memory all resolve from the WORKTREE (_boot/CHARTER…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "gmaa-adopt",
+            "description": "Start chat-first GMAA adoption (assess, gate, fills). Instantiation is later vanilla grok."
+          },
+          {
+            "name": "gmaa-fetch",
+            "description": "Download the sealed Grok engine zip into ~/Downloads and verify sha256. Does not unzip or instantiate."
+          },
+          {
+            "name": "gmaa-place",
+            "description": "After adopt-yes, create ~/Code/<project> and copy the sealed engine zip from Downloads. Does not unpack."
+          },
+          {
+            "name": "restart",
+            "description": "Externalize this lane (LATEST + session_state.json + MEMORY) then orc-restart --force."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PreToolUse",
+            "description": "Bash|run_terminal_command"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          }
+        ],
+        "skills": [
+          {
+            "name": "gmaa-adopt",
+            "description": "Chat-first GMAA adoption. Use when starting a project in chat, asking if GMAA fits, writing fills, or following ADOPTIO…"
+          },
+          {
+            "name": "restart",
+            "description": "B6 restart pickup. Use when the user runs /restart, says restart, or I need to restart. Write lane-local pointers, then…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds **gmaa-grok** as a third-party remote catalog entry. Remote source only (no files vendored). No `plugins/` or `external_plugins/` files are added.

- Plugin name: `gmaa-grok`
- Type: remote source
- Source URL: https://github.com/GMAA-AI/gmaa.git
- Pinned SHA: `c3d8d1d8f84a7432711bec53dd1e3a60bf5d71bf`
- Path: `grok/gmaa-grok-plugin`
- Homepage: https://gmaa.ai
- License: Apache-2.0 with Commons Clause on the engine; plugin lives in that tree (`grok/gmaa-grok-plugin/LICENSE.md`)

xAI does not author or verify third-party plugins.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`GMAA-AI/gmaa`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally (exit 0).
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (exit 0).
- [x] `homepage` + clear `description` set.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): GitHub (`GMAA-AI/gmaa`) to fetch the sealed companion engine zip into `~/Downloads`; on adopt it copies that zip into `~/Code/<project>/` still zipped. Spine stays in the engine zip.
- Credentials/permissions it requires (and why): none for catalog install; fetch writes the sealed zip to `~/Downloads`.

## Notes for reviewers

Official org source (`GMAA-AI/gmaa`). Catalog pin is remote-only: url `https://github.com/GMAA-AI/gmaa.git`, sha `c3d8d1d8f84a7432711bec53dd1e3a60bf5d71bf`, path `grok/gmaa-grok-plugin`. Keywords are brand-scoped (`gmaa`, `gmaa-grok`). `generate-plugin-index.py` and `validate-catalog.py` were run; `generate-plugin-index.py --check` matches the committed index.