### PR TITLE
Add aeon plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,20 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "aeon",
+      "description": "Operator console for running an Aeon autonomous-agent instance from your coding agent: enable, schedule, and edit skills, wire secrets and channels, debug runs, and turn past coding-agent chats into scheduled skills. Aeon runs your own skills on a cron in GitHub Actions.",
+      "category": "automation",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/aeonfun/aeon.git",
+        "sha": "3da3b732fcb720c6d863cb0215727dab466da74f",
+        "path": "plugin"
+      },
+      "homepage": "https://aeon.fun",
+      "keywords": ["aeon", "aeon agent", "aeon skills", "aeon.fun"],
+      "domains": ["aeon.fun"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "aeon": {
+      "sha": "3da3b732fcb720c6d863cb0215727dab466da74f",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "aeon",
+            "description": "Set up and run an Aeon agent instance — get started from scratch, pick which skills to turn on or install more from pac…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the **aeon** plugin to the catalog. Aeon is an autonomous-agent framework that runs your own skills on a cron in GitHub Actions; this plugin ships the operator-console skill so you can set up, schedule, edit, and debug an instance from your coding agent. It is a Claude Code compatible plugin (`.claude-plugin/plugin.json` + a `skills/` dir), which this marketplace ingests natively.

- Plugin name: aeon
- Type: remote source
- Source URL + pinned SHA: `https://github.com/aeonfun/aeon.git` @ `3da3b732fcb720c6d863cb0215727dab466da74f`, subdir `plugin`
- Homepage: https://aeon.fun

## Ownership

I'm the owner/operator of Aeon (Aeon Inc, github.com/aeonfun). The source is pinned to our official org repo aeonfun/aeon, so first-party ownership is verifiable.

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (aeonfun/aeon).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in the plugin's `.claude-plugin/plugin.json` and LICENSE).

## Security

The plugin is a single operator-console skill (`plugin/skills/aeon`) plus reference docs and one Node helper script that mines local coding-agent chat history. No MCP server, no lifecycle hooks.

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (none declared).
- Network endpoints this plugin calls (and why): none of its own; the skill guides the user to operate their aeonfun/aeon instance via the `gh`/git tooling they already have.
- Credentials/permissions it requires (and why): none at install time. When operating an instance, the user wires their own GitHub Actions secrets in their own repo.

## Notes for reviewers

Source is our official org (aeonfun/aeon), pinned by SHA. The plugin also ships a Codex manifest (`.codex-plugin/plugin.json`) alongside the Claude one, so it works across ecosystems. Repo: https://github.com/aeonfun/aeon
