### PR TITLE
Add Savee (hosted MCP for visual inspiration)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "savee",
+      "description": "Read your Savee saves, boards and home feed, and search its public library of curated design inspiration. Read-only hosted MCP.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/saveeit/savee-mcp-server.git",
+        "sha": "2eeeb9f17fdfc7e0fa1d4e365dbe6e3e4d5b76af"
+      },
+      "homepage": "https://savee.com",
+      "keywords": ["savee", "savee.com", "savee boards", "savee moodboard"],
+      "domains": ["savee.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -741,6 +741,18 @@
         ]
       }
     },
+    "savee": {
+      "sha": "2eeeb9f17fdfc7e0fa1d4e365dbe6e3e4d5b76af",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "savee",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
       "version": "1.3.2",


### PR DESCRIPTION
## What this PR does

Adds the Savee hosted MCP server to the plugin marketplace.

- Plugin name: savee
- Type: remote source
- Source URL + pinned SHA: https://github.com/saveeit/savee-mcp-server.git @ 2eeeb9f17fdfc7e0fa1d4e365dbe6e3e4d5b76af
- Homepage: https://savee.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (saveeit).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://mcp.savee.com/mcp - hosted Streamable HTTP MCP server for read-only access to Savee data (saves, boards, home feed, and public library search)
- Credentials/permissions it requires (and why): OAuth 2.1 with PKCE for user authentication. Read-only access to user's Savee data. No API key required.

## Notes for reviewers

- Official source from saveeit organization
- MIT licensed
- Hosted MCP server at https://mcp.savee.com/mcp using Streamable HTTP transport
- OAuth 2.1 + PKCE authentication, no API key needed
- Read-only tools for accessing Savee content
- Documentation available at https://docs.savee.com/mcp
- Plugin index regenerated with official script
- All validation checks pass (validate-catalog + generate-plugin-index --check)