### PR TITLE
Add thatseoagent, an SEO plugin backed by a remote MCP server

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "thatseoagent",
+      "description": "SEO analysis for sites you own, through the That SEO Agent remote MCP server: Google Search Console and GA4 reporting, PageSpeed and Core Web Vitals, full site and page audits, crawlability, canonical and schema checks, and AI-visibility scoring. Seven bundled skills sequence the tools into workflows. Remote HTTPS server with OAuth \u2014 no API key to paste.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/thatseoagent/skills.git",
+        "sha": "8d315570d2eaff129371a9b87e46836dfe5d1a31"
+      },
+      "homepage": "https://thatseoagent.com",
+      "keywords": ["that seo agent", "thatseoagent"],
+      "domains": ["thatseoagent.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -965,6 +965,48 @@
         ]
       }
     },
+    "thatseoagent": {
+      "sha": "8d315570d2eaff129371a9b87e46836dfe5d1a31",
+      "version": "1.5.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "thatseoagent",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ai-visibility",
+            "description": "Improve how a brand appears in AI-generated answers (ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini). Use whe…"
+          },
+          {
+            "name": "audit-cadence",
+            "description": "A repeatable 14-day SEO monitoring cadence that catches ranking drops, index-coverage errors, cannibalization, and traf…"
+          },
+          {
+            "name": "content-audit",
+            "description": "Audit and improve page-level SEO — on-page signals (title, meta, headings, canonical), content quality and readability,…"
+          },
+          {
+            "name": "content-checklist",
+            "description": "A pre-publish checklist verifying an article, blog post, or landing page meets SEO, content-quality, schema, and copy s…"
+          },
+          {
+            "name": "gsc-insights",
+            "description": "Extract insights from Google Search Console — quick wins, traffic-drop diagnosis, keyword trends, cannibalization, feat…"
+          },
+          {
+            "name": "site-audit",
+            "description": "Run a full multi-dimension SEO site audit, generate a shareable client report, and manage SEO tasks. Use when the user…"
+          },
+          {
+            "name": "technical-seo",
+            "description": "Diagnose and fix technical SEO — crawlability, indexing and coverage, canonical tags, redirect chains, robots.txt, href…"
+          }
+        ]
+      }
+    },
     "tinyfish": {
       "sha": "89457fba3fa44c7b2227807948628011983ab668",
       "version": "1.0.0",


### PR DESCRIPTION
One catalog entry, remote source, nothing vendored. The plugin lives at github.com/thatseoagent/skills under MIT and bundles seven skills plus a pointer at a hosted MCP server; the server itself is not in that repo and is not installed by anything here.

Pinned to 8d315570d2eaff129371a9b87e46836dfe5d1a31, the current HEAD of that repo's master.

Category is `marketing` rather than one of the five already in the catalog. The plugin reports on a site's search and analytics data; filing it under `development` next to Postgres and Sentry would misdescribe it and mis-fire the CTA. The validator does not constrain the field.

Keywords are brand-scoped for the same reason CONTRIBUTING.md asks for: `seo`, `analytics` and `pagespeed` were the obvious terms and are exactly the generic ones that would suggest this plugin during unrelated work. `domains` lists only the host the vendor owns.

`generate-plugin-index.py` resolves the pinned commit to seven skills and one http MCP server, and `validate-catalog.py` with `generate-plugin-index.py --check` both pass.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name: `thatseoagent`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/thatseoagent/skills.git` @ `8d315570d2eaff129371a9b87e46836dfe5d1a31`
- Homepage: https://thatseoagent.com

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
- Credentials/permissions it requires (and why):

## Notes for reviewers

<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->
The source repo is markdown and JSON: seven `SKILL.md` files, four manifests
(Claude, Cursor, Agent Plugins, MCP Registry) and a README. The one executable is
`validate-skills.sh`, a development tool that lints the skills' frontmatter
against the Agent Skills spec; nothing installs or invokes it.

`skills/` in that repo is seven symlinks to folders at the repo root. The folders
predate the `skills/` convention and the Claude manifest points at them directly,
so moving them would have broken that install path.

The server is also listed on the official MCP Registry as `com.thatseoagent/seo`,
verified by DNS TXT on the domain.