### PR TITLE
Add MentorCruise plugin (hosted MCP + find-mentor skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,23 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "mentorcruise",
+      "description": "Find a mentor from chat. Search MentorCruise's live directory, then apply, message, and book after Connect.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mentorcruise/plugin.git",
+        "sha": "96625ef2f790575be1aa623ceaf4fcebf2985e46"
+      },
+      "homepage": "https://mentorcruise.com/agents/",
+      "keywords": [
+        "mentorcruise",
+        "mentor cruise"
+      ],
+      "domains": [
+        "mentorcruise.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,24 @@
         ]
       }
     },
+    "mentorcruise": {
+      "sha": "96625ef2f790575be1aa623ceaf4fcebf2985e46",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mentorcruise",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "find-mentor",
+            "description": "Find and recommend mentors from MentorCruise.com. Use this skill whenever the user wants to find a mentor, needs mentor…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds the official MentorCruise plugin so Grok can search the live mentor directory from chat, then apply, message, and book after Connect.

- Plugin name: `mentorcruise`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/mentorcruise/plugin.git` @ `96625ef2f790575be1aa623ceaf4fcebf2985e46`
- Homepage: https://mentorcruise.com/agents/

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source: [mentorcruise/plugin](https://github.com/mentorcruise/plugin) (MentorCruise org). MIT.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mentorcruise.com/mcp` – hosted Streamable HTTP MCP (search is anonymous)
  - `https://mentorcruise.com/.well-known/oauth-protected-resource` and `oauth-authorization-server` – OAuth metadata
  - `https://mentorcruise.com/oauth/register`, `/oauth/authorize`, `/oauth/token` – Connect (PKCE S256, DCR)
  - `https://mentorcruise.com/mentor/...` – public profile links in results
- Credentials/permissions it requires (and why):
  - None at install. Search needs no token. Apply / pay / book use OAuth Connect; the host stores the Bearer token. The plugin repo has no API keys, hooks, or scripts.

## Notes for reviewers

Index generation found `mcpServers: mentorcruise` (http) and skill `find-mentor`. Keywords are brand-scoped (`mentorcruise`, `mentor cruise`) so the plugin CTA does not fire on generic mentoring chats. `domains`: `mentorcruise.com`.

Upstream README: https://github.com/mentorcruise/plugin
