### PR TITLE
feat: add PinchTab plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "pinchtab",
+      "description": "Browser control for AI agents via PinchTab. CLI skill plus MCP tools for navigation, page snapshots, interaction, and headed browser profiles.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/pinchtab/pinchtab.git",
+        "sha": "96d1508b44721674e3bff2f3bbd21401ec270a63",
+        "path": "plugins/grok"
+      },
+      "homepage": "https://pinchtab.com",
+      "keywords": ["pinchtab", "pinchtab browser", "pinchtab mcp"],
+      "domains": ["pinchtab.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,28 @@
         ]
       }
     },
+    "pinchtab": {
+      "sha": "96d1508b44721674e3bff2f3bbd21401ec270a63",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "pinchtab",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "pinchtab",
+            "description": "Use this skill when a task needs browser automation through PinchTab: open a website, inspect interactive elements, cli…"
+          },
+          {
+            "name": "pinchtab-mcp",
+            "description": "Use this skill when a task requires browser automation through PinchTab's MCP server connected to a remote browser inst…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official PinchTab plugin for browser automation through Grok Build. The remote source is pinned to the merge commit that introduced and validated the Grok plugin in the PinchTab repository.

- Plugin name: `pinchtab`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/pinchtab/pinchtab.git` at `96d1508b44721674e3bff2f3bbd21401ec270a63`, path `plugins/grok`
- Homepage: https://pinchtab.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of unrelated secrets, tokens, `.env`, or environment variables.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): the MCP adapter connects to the local PinchTab server at `http://127.0.0.1:9867` by default, or to the user-selected `PINCHTAB_SERVER`. The browser connects only to user-requested destinations permitted by PinchTab's domain policy.
- Credentials/permissions it requires (and why): none for the default local server. A protected or remote server may use an explicitly configured `PINCHTAB_TOKEN` or scoped `PINCHTAB_SESSION` solely to authenticate to that server. Grok trust is required to start the local `pinchtab mcp` process.

## Notes for reviewers

- The plugin contains two skills, one stdio MCP definition, and no lifecycle hooks.
- It does not bundle or install the PinchTab executable; `pinchtab` must already be installed on the user's `PATH`.
- The source includes an MIT license, end-user installation and verification instructions, and a dedicated trust/security guide.
- Upstream implementation and validation: https://github.com/pinchtab/pinchtab/pull/641
