### PR TITLE
Add t2000 plugin — hire agents, earn USDC

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/mission69b/t2000-skills.git",
-        "sha": "14f842c3190d487518757d35b6720133e41fea5a"
+        "sha": "1c4de77f8484115aa6a502dd61a6c67cb27bf903"
       },
       "homepage": "https://t2000.ai",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "t2000",
-      "description": "Hire agents and earn USDC on the t2000 marketplace (Sui). Hosted Passport Connect MCP for hire, post Open jobs, claim work, and pay x402 APIs — plus Agent Wallet and Marketplace skills for terminal agents.",
+      "description": "Hire agents and earn USDC on t2000. Passport Connect MCP — post Open jobs, claim work, settle escrow, pay x402 APIs. Agent Wallet and Marketplace skills for terminal agents.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/mission69b/t2000-skills.git",
-        "sha": "7f56cec74be20f67d0c9195cfc17d1c2dbe60a80"
+        "sha": "14f842c3190d487518757d35b6720133e41fea5a"
       },
       "homepage": "https://t2000.ai",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,22 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "t2000",
+      "description": "Hire agents and earn USDC on the t2000 marketplace (Sui). Hosted Passport Connect MCP for hire, post Open jobs, claim work, and pay x402 APIs — plus Agent Wallet and Marketplace skills for terminal agents.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mission69b/t2000-skills.git",
+        "sha": "7f56cec74be20f67d0c9195cfc17d1c2dbe60a80"
+      },
+      "homepage": "https://t2000.ai",
+      "keywords": [
+        "t2000", "sui", "usdc", "agent-marketplace", "x402", "mcp",
+        "hire", "earn", "passport"
+      ],
+      "domains": ["t2000.ai", "mcp.t2000.ai", "docs.t2000.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -920,7 +920,7 @@
       }
     },
     "t2000": {
-      "sha": "7f56cec74be20f67d0c9195cfc17d1c2dbe60a80",
+      "sha": "14f842c3190d487518757d35b6720133e41fea5a",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -919,6 +919,60 @@
         ]
       }
     },
+    "t2000": {
+      "sha": "7f56cec74be20f67d0c9195cfc17d1c2dbe60a80",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "t2000",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "t2000-check-balance",
+            "description": "Check the t2000 Agent Wallet balance on Sui. Use when asked about wallet balance, how much USDC / USDsui / SUI is avail…"
+          },
+          {
+            "name": "t2000-connect",
+            "description": "Connect a t2000 Passport to Claude, Cursor, ChatGPT, Cline, Continue, or any MCP-compatible client. Use when asked to s…"
+          },
+          {
+            "name": "t2000-earn",
+            "description": "Earn USDC as a seller on the t2000 marketplace — claim open jobs, deliver, get paid — from Hermes or any terminal agent…"
+          },
+          {
+            "name": "t2000-job",
+            "description": "Escrow USDC for agent-to-agent deliverable work (A2A jobs). Use when hiring another agent for async work (research repo…"
+          },
+          {
+            "name": "t2000-pay",
+            "description": "Pay any x402-protected API endpoint with the t2000 wallet — a seller Service listed on the t2000 store, or any URL that…"
+          },
+          {
+            "name": "t2000-receive",
+            "description": "Generate a payment request for the t2000 Agent Wallet — print the wallet address, an ANSI QR code, and (via MCP) a Paym…"
+          },
+          {
+            "name": "t2000-send",
+            "description": "Send USDC, USDsui, or SUI from the t2000 Agent Wallet to another Sui address. Use when asked to pay someone, transfer f…"
+          },
+          {
+            "name": "t2000-services",
+            "description": "Discover Services in the t2000 A2A Marketplace — what agents actually sell. Use when the user asks \"what can I buy?\", \"…"
+          },
+          {
+            "name": "t2000-setup",
+            "description": "Set up a t2000 terminal Agent Wallet (`t2 init`) when the user needs a local CLI key file — not for Claude-only marketp…"
+          },
+          {
+            "name": "t2000-swap",
+            "description": "Swap tokens on Sui via Cetus Aggregator (20+ DEXs, best-route across SUI, USDC, USDsui, USDT, USDe, ETH, GOLD, NAVX, WA…"
+          }
+        ]
+      }
+    },
     "tavily": {
       "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -920,7 +920,7 @@
       }
     },
     "t2000": {
-      "sha": "14f842c3190d487518757d35b6720133e41fea5a",
+      "sha": "1c4de77f8484115aa6a502dd61a6c67cb27bf903",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the **t2000** plugin — hire agents, work, earn in USDC.

- Plugin name: `t2000`
- Type: remote source
- Source: `https://github.com/mission69b/t2000-skills.git` @ `1c4de77f8484115aa6a502dd61a6c67cb27bf903`
- Homepage: https://t2000.ai

Ships MCP (`.mcp.json` → `https://mcp.t2000.ai/mcp`) + Agent Wallet (6) and Agent Marketplace (4) skills.

## How Grok users connect

**Primary path — Passport Connect (MCP):** After `grok plugin install t2000 --trust`, Grok loads `.mcp.json` and connects to `https://mcp.t2000.ai/mcp`. First use triggers Google OAuth → a scoped Passport session (no API key in the client). Hire, claim Open jobs, deliver, settle, send/swap/pay all run through Connect tools under user-set limits.

**Not the Grok path:** The `@t2000/cli` (`t2 init`) terminal wallet is for Hermes/local agents only — not required for Grok marketplace users.

**Read-only discovery:** `api.t2000.ai/v1/*` is public JSON (services, jobs board) — useful for agents, not a user login surface.

## Ownership

I own this plugin. Source: `mission69b/t2000-skills` (sync from `mission69b/t2000` monorepo `t2000-skills/`).

## Checklist

- [x] One entry in `.grok-plugin/marketplace.json`
- [x] Pinned 40-char lowercase `sha`, public + reachable (matches mirror HEAD)
- [x] Regenerated `plugin-index.json`; validate + `--check` pass
- [x] README + `.grok-plugin/plugin.json` in source; MIT stated

## Security

- No curl|bash, postinstall RCE, or secret exfiltration from plugin bundle.
- Manifests + markdown skills only.

| Host | Why |
|------|-----|
| `mcp.t2000.ai` | Passport Connect MCP (OAuth-gated writes) |
| `api.t2000.ai` | Public discovery JSON |
| Sui mainnet gRPC | Balances / chain reads / signed txs |

OAuth (Google) → Passport at first MCP use. No API key in plugin. Optional `t2 init` is user-run CLI, not bundled exec.

## Notes

- Machine playbook: https://t2000.ai/llms.txt
- Connect setup + limits: https://docs.t2000.ai/passport-connect