### PR TITLE
add scrapfly pluging

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,7 +283,7 @@
     },
     {
       "name": "scrapfly",
-      "description": "Scrapfly web data platform integration (MCP Server + Skills). Scrape any site with anti-bot bypass and JS rendering, capture screenshots, extract structured data with AI, crawl entire sites, and drive cloud browsers. Connect with OAuth to the hosted Scrapfly MCP server, plus Python/TypeScript/Go/Rust SDK and CLI skills.",
+      "description": "Scrapfly is the web data and browser automation layer for agents working with live pages. Point it at any publicly accessible URL and get back clean, structured content, including from sites with no API and pages that are hard to retrieve reliably.",
       "category": "development",
       "source": {
         "source": "url",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "scrapfly",
+      "description": "Scrapfly web data platform integration (MCP Server + Skills). Scrape any site with anti-bot bypass and JS rendering, capture screenshots, extract structured data with AI, crawl entire sites, and drive cloud browsers. Connect with OAuth to the hosted Scrapfly MCP server, plus Python/TypeScript/Go/Rust SDK and CLI skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/scrapfly/skills.git",
+        "sha": "b055fe186873314052a6710e1192139832bd5c15"
+      },
+      "homepage": "https://scrapfly.io",
+      "keywords": ["scrapfly", "scrapfly scraper", "scrapfly extraction", "scrapfly cloud browser", "scrapfly mcp"],
+      "domains": ["scrapfly.io", "mcp.scrapfly.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -741,6 +741,68 @@
         ]
       }
     },
+    "scrapfly": {
+      "sha": "b055fe186873314052a6710e1192139832bd5c15",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "scrapfly",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "scrapfly-agent-rules",
+            "description": "Cross-tool golden rules for an autonomous Scrapfly web agent connected to the Scrapfly MCP server (web_scrape, screensh…"
+          },
+          {
+            "name": "scrapfly-alerting",
+            "description": "Threshold-based alerting on Scrapfly account metrics. Wire up rules like \"alert me when scrape success rate drops below…"
+          },
+          {
+            "name": "scrapfly-browser",
+            "description": "Automate cloud browsers using the Scrapfly Cloud Browser API with Python Playwright"
+          },
+          {
+            "name": "scrapfly-cli",
+            "description": "Use the Scrapfly CLI (`scrapfly`) to scrape web pages, capture screenshots, extract structured data with AI, crawl enti…"
+          },
+          {
+            "name": "scrapfly-crawler",
+            "description": "Crawl entire websites using the Scrapfly Crawler API with the Python SDK"
+          },
+          {
+            "name": "scrapfly-extraction",
+            "description": "Extract structured data from web content using the Scrapfly Extraction API with the Python SDK"
+          },
+          {
+            "name": "scrapfly-rpa",
+            "description": "Use the Scrapfly RPA API to run typed workflow graphs against managed cloud browsers, retrieve produced artifacts (HTML…"
+          },
+          {
+            "name": "scrapfly-scraper",
+            "description": "Web scraping using the Scrapfly Scraper API with the Python SDK"
+          },
+          {
+            "name": "scrapfly-screenshot",
+            "description": "Capture web page screenshots using the Scrapfly Screenshot API with the Python SDK"
+          },
+          {
+            "name": "scrapfly-sdk-go",
+            "description": "Web scraping from Go with the Scrapfly SDK (`github.com/scrapfly/go-scrapfly`). Use when the user asks to scrape a URL,…"
+          },
+          {
+            "name": "scrapfly-sdk-rust",
+            "description": "Web scraping from Rust with the Scrapfly SDK (`scrapfly-sdk` crate). Use when the user asks to scrape a URL, bypass ant…"
+          },
+          {
+            "name": "scrapfly-sdk-typescript",
+            "description": "Web scraping from TypeScript or JavaScript with the Scrapfly SDK (`scrapfly-sdk`). Use when the user asks to scrape a U…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
       "version": "1.3.2",


### PR DESCRIPTION
## What this PR does

Adds the **scrapfly** plugin — the Scrapfly web data platform (hosted MCP server + 12 agent skills).
New plugin, remote source, nothing vendored in this repo.

- Plugin name: `scrapfly`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): `https://github.com/scrapfly/skills.git` @ `b055fe186873314052a6710e1192139832bd5c15`
- Homepage: https://scrapfly.io

The pinned commit restructures `scrapfly/skills` into the standard plugin layout (skills under
`skills/`, root `.mcp.json`, `.grok-plugin/plugin.json`) so it can be consumed directly as a
remote source — matching `cloudflare/skills`, `axiomhq/skills`, and `wix/skills`.

Contents indexed at that SHA: **1 MCP server** (`scrapfly`, http, `https://mcp.scrapfly.io/mcp`)
and **12 skills** — `scrapfly-agent-rules`, `scrapfly-alerting`, `scrapfly-browser`,
`scrapfly-cli`, `scrapfly-crawler`, `scrapfly-extraction`, `scrapfly-rpa`, `scrapfly-scraper`,
`scrapfly-screenshot`, `scrapfly-sdk-go`, `scrapfly-sdk-rust`, `scrapfly-sdk-typescript`.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`github.com/scrapfly` is the official Scrapfly GitHub organization (owner type: Organization,
public repo). I'm submitting on behalf of Scrapfly.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [ ] License is stated.

**License is not yet stated** — `scrapfly/skills` currently has no `LICENSE` file
(GitHub reports `license: null`). Happy to add one and bump the pinned SHA before merge; say the
word if you want that resolved in this PR rather than a follow-up.

## Security

- [ ] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.scrapfly.io/mcp` — the hosted MCP server; the only endpoint the plugin's
    `.mcp.json` configures.
  - `https://api.scrapfly.io` — Scrapfly's REST API, called by the SDK/CLI skills when you run
    the documented code paths (scrape, screenshot, extract, crawl, RPA).
  - `https://scrapfly.io` — docs links, and the CLI/BYOP installer URLs referenced in skill docs.
  - `https://raw.githubusercontent.com/scrapfly/python-scrapfly/...` — doc links to SDK enum
    source in `scrapfly-screenshot`. Reference links only; nothing fetches them at runtime.
  - `https://web-scraping.dev`, `https://httpbin.dev`, `*.example.com` — scrape targets in
    example snippets.
- Credentials/permissions it requires (and why):
  - **MCP server: OAuth2.** First connection opens a browser to authorize against your Scrapfly
    account; tokens are stored and refreshed locally. No API key is written into the config.
  - **SDK/CLI skills: `SCRAPFLY_API_KEY`,** read from the environment and passed to Scrapfly's own
    API when you execute those code paths. This is the plugin's own credential going to its own
    first-party endpoint — it is never forwarded to a third party, written to disk, or logged.
    Nothing in the plugin reads `.env`, `~/.ssh`, or unrelated env vars.
  - No hooks, no `postinstall`, no bundled binaries, no lifecycle scripts of any kind — the repo
    at the pinned SHA contains only `SKILL.md` files, `.mcp.json`, and two plugin manifests.

### Disclosure: one `curl | sh` string in skill documentation

Leaving that checkbox unticked deliberately rather than glossing it. One occurrence, in
`skills/scrapfly-browser/SKILL.md:367`:

```sh
curl -fsSL "https://scrapfly.io/install/byop-connector.sh?api_key=YOUR_API_KEY" | sh
```

Context and why I think it's acceptable — your call:

- It **documents** how a customer installs the BYOP ("bring your own proxy") exit-peer connector.
  It is prose in a `SKILL.md`, not something the plugin executes at install time or that any hook
  triggers. There is no install step in this plugin at all.
- The URL is first-party (`scrapfly.io`), served by us over HTTPS — not a third-party host,
  gist, or shortener.
- The same section documents the non-piped equivalent immediately below it
  (`scrapfly exit-peer install`), so the CLI path is already the presented alternative.

If reviewers would rather this pattern not appear in a catalogued skill at all, I can drop the
one-liner and keep only the `scrapfly exit-peer install` form, then bump the pinned SHA. Happy to
do that proactively if it's a blocker.

## Notes for reviewers

- **Why remote rather than vendored:** this is a 1:1 copy of all 12 upstream skills, so per the
  guidance on the neon PR (#18) — *"if it were a 1:1 copy, I would suggest remote since it makes
  it easier to update, just bumping up a SHA"* — remote is the right fit. It also keeps the plugin
  inside the daily `bump-plugin-shas` automation, which local sources don't get. The upstream
  manifest sets `version: 1.0.0` so the version gate works.
- **Keywords are deliberately brand-scoped.** Scrapfly is in the same category as firecrawl/exa/
  tavily, and I saw #30 get sent back for generic terms firing the CTA on unrelated requests, so
  every keyword is `scrapfly`-prefixed rather than bare `scrape` / `crawl` / `extract`.
- **Upstream layout change is non-breaking for existing users.** Moving the 12 skill dirs under
  `skills/` was 12 pure renames, no content edits. `npx skills add scrapfly/skills` is unaffected:
  `discoverSkills()` in the `skills` CLI lists both the repo root and `skills/` as priority search
  dirs, and `skills/` is actually walked deeper (maxDepth 3 vs 1), with a depth-5 fallback behind
  it. Cross-skill links were relative siblings (`../scrapfly-x`) and moved together, so they still
  resolve. Verified 12/12 discovered post-move.
- **Preview:** ships an MCP server, so it's worth loading before merge —
  `branch = "refs/pull/<N>/merge"` on the `[[marketplace.sources]]` entry in `~/.grok/config.toml`,
  then refresh `/marketplaces`.
