### PR TITLE
Add skarn-guard (remote source)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "skarn-guard",
+      "description": "Skarn for Grok Build: a guard hook that inspects each pending tool call and prompt for leaked credentials, malicious package installs, and exfiltration and reports its verdict in audit mode, plus the skarn-audit skill and a local MCP server whose four read-only tools return redacted session scans and a vet of this machine's assistant configuration. On Grok Build 1.0.4 plugin hooks are not dispatched at session start; open /hooks and press r once per session, or install the hook with skarn setup --agent grok. The plugin carries no binary and makes no network call; install skarn separately.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/skarn-security/agent-guard.git",
+        "sha": "d556ee39d5088321e7912ef7a18a90f42f7361dc",
+        "path": "claude"
+      },
+      "homepage": "https://getskarn.com",
+      "keywords": ["skarn", "skarn guard", "getskarn"],
+      "domains": ["getskarn.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,46 @@
         ]
       }
     },
+    "skarn-guard": {
+      "sha": "d556ee39d5088321e7912ef7a18a90f42f7361dc",
+      "version": "0.25.0",
+      "components": {
+        "hooks": [
+          {
+            "name": "PermissionRequest",
+            "description": "Bash|WebFetch|WebSearch|Write|Edit|MultiEdit|NotebookEdit|mcp__.*"
+          },
+          {
+            "name": "PreToolUse",
+            "description": "Bash|WebFetch|WebSearch|Write|Edit|MultiEdit|NotebookEdit|mcp__.*"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "TaskCreated"
+          },
+          {
+            "name": "UserPromptExpansion"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "skarn",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "skarn-audit",
+            "description": "Audit this machine's AI coding sessions and assistant configs with skarn. Use when the user says scan this with skarn,…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "453dacd48aac27d751aa3cb7e410256efb3fcfca",
       "version": "0.5.4",


### PR DESCRIPTION
## What this PR does

Adds one entry for the Skarn guard plugin as a remote source.

- Plugin name: skarn-guard
- Type: remote source
- Source URL + pinned SHA: https://github.com/skarn-security/agent-guard.git at d556ee39d5088321e7912ef7a18a90f42f7361dc, subdirectory `claude`
- Homepage: https://getskarn.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`skarn-security` is Skarn's GitHub organization. The source repository is generated and pushed by Skarn's release pipeline at every release; it is not hand-edited.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The source repository is MIT. The Skarn binary the plugin invokes is a separate download under its own licence and is not carried here.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none. The pinned subdirectory carries one skill, an MCP declaration, and a hook configuration file, and nothing else. The `skarn` binary those invoke is installed separately by the user and makes no network call in the operations this plugin reaches.
- Credentials/permissions it requires (and why): none. The scan reads the session logs and assistant configuration already on the user's machine, returns redacted findings, and exposes no tool that writes.

## Notes for reviewers

The pinned subdirectory is the same unit Claude Code installs from the `skarn-security/agent-guard` marketplace; Grok Build reads the manifest, the skill and the MCP declaration natively, so no Grok-specific rendering is needed. Verified before opening this PR on Grok Build 1.0.4: `grok plugin validate` accepts the manifest, and after `grok plugin install skarn-guard@agent-guard --trust` from this marketplace, `grok inspect` lists the skill, the hook file, and the MCP server as loaded.

On 1.0.4 plugin hooks are not dispatched at session start (issue #236 on this repository) but are merged by the reload key in the `/hooks` tab. Verified in a live session after that reload: `/hooks-list` shows `plugin/skarn-guard/hooks:pre_tool_use[0]`, `user_prompt_submit[0]` and `stop[0]`, and the per-event hook counts on a real `echo probe` tool call rose by exactly those hooks. The entry description states the reload step and the `skarn setup --agent grok` alternative, which writes the same hook to `~/.grok/hooks/`.

The guard ships in audit mode, which reports its verdict and does not change what the agent does. Every hook entry that can carry a matcher carries one.
