### PR TITLE
Add String Web Access plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
+        "sha": "9c9c7e98401687f07ff41c76181079556a41f9c6"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
+        "sha": "27404899e31e93b65103c699f0da4b7883861597"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "3cef3e98a20ad83deb3976af24c01ba1f9632166"
+        "sha": "29d957637d0ee14e5438bd5653b77ec0c6581444"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "9c9c7e98401687f07ff41c76181079556a41f9c6"
+        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "27404899e31e93b65103c699f0da4b7883861597"
+        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "string-web-access",
+      "description": "String Web Access fetches, searches and maps any website as clean, LLM-ready Markdown. It handles proxy rotation, anti-bot protection, CAPTCHAs and JavaScript rendering, so Grok gets the page instead of a block screen. Use it for sites that rate-limit, geo-gate or block automated traffic.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/usestring/string-grok-plugin.git",
+        "sha": "1a65005a6d6333dbd43dd251b39480eac1c180e8"
+      },
+      "homepage": "https://usestring.ai",
+      "keywords": ["string web access", "usestring"],
+      "domains": ["usestring.ai", "portal.usestring.ai", "mcp.usestring.ai", "request.usestring.ai"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
+        "sha": "3cef3e98a20ad83deb3976af24c01ba1f9632166"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/usestring/string-grok-plugin.git",
-        "sha": "1a65005a6d6333dbd43dd251b39480eac1c180e8"
+        "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75"
       },
       "homepage": "https://usestring.ai",
       "keywords": ["string web access", "usestring"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,46 @@
         ]
       }
     },
+    "string-web-access": {
+      "sha": "1a65005a6d6333dbd43dd251b39480eac1c180e8",
+      "version": "1.0.0",
+      "components": {
+        "commands": [
+          {
+            "name": "string-setup",
+            "description": "Set up String Web Access — check the connection and confirm all three tools respond."
+          },
+          {
+            "name": "web-research",
+            "description": "Research a topic on the live web — search, read the best sources, and report with citations."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "string-web-access",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "string-fetch",
+            "description": "Fetch any web page and get clean, LLM-ready Markdown back, via String Web Access. Use when the user gives you a URL, as…"
+          },
+          {
+            "name": "string-search",
+            "description": "Search the web with String Web Access and get structured Google results back. Use when the user wants to search the web…"
+          },
+          {
+            "name": "string-sitemap",
+            "description": "Discover every URL on a website with String Web Access. Use when the user wants a site's full URL list, asks to crawl o…"
+          },
+          {
+            "name": "string-web-access",
+            "description": "Best practices for getting web content with String Web Access. Load this before any multi-step web task — research, com…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "453dacd48aac27d751aa3cb7e410256efb3fcfca",
       "version": "0.5.4",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "string-web-access": {
-      "sha": "3cef3e98a20ad83deb3976af24c01ba1f9632166",
+      "sha": "29d957637d0ee14e5438bd5653b77ec0c6581444",
       "version": "1.0.0",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,13 +788,13 @@
       }
     },
     "string-web-access": {
-      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
+      "sha": "3cef3e98a20ad83deb3976af24c01ba1f9632166",
       "version": "1.0.0",
       "components": {
         "commands": [
           {
             "name": "string-setup",
-            "description": "Check that String Web Access is connected and all three tools respond"
+            "description": "Check that String Web Access is connected and its read tools respond"
           },
           {
             "name": "web-research",
@@ -811,6 +811,10 @@
           {
             "name": "string-fetch",
             "description": "Fetch any web page and get clean, LLM-ready Markdown back, via String Web Access. Use when the user gives you a URL, as…"
+          },
+          {
+            "name": "string-request",
+            "description": "Send a POST, PUT or PATCH with a body to a URL, through String Web Access. Use when the user wants to submit something…"
           },
           {
             "name": "string-search",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "string-web-access": {
-      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
+      "sha": "9c9c7e98401687f07ff41c76181079556a41f9c6",
       "version": "1.0.0",
       "components": {
         "commands": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,13 +788,13 @@
       }
     },
     "string-web-access": {
-      "sha": "27404899e31e93b65103c699f0da4b7883861597",
+      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
       "version": "1.0.0",
       "components": {
         "commands": [
           {
             "name": "string-setup",
-            "description": "Check that String Web Access is connected and its read tools respond"
+            "description": "Check that String Web Access is connected and all three tools respond"
           },
           {
             "name": "web-research",
@@ -811,10 +811,6 @@
           {
             "name": "string-fetch",
             "description": "Fetch any web page and get clean, LLM-ready Markdown back, via String Web Access. Use when the user gives you a URL, as…"
-          },
-          {
-            "name": "string-request",
-            "description": "Send a POST, PUT or PATCH with a body to a URL, through String Web Access. Use when the user wants to submit something…"
           },
           {
             "name": "string-search",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,13 +788,13 @@
       }
     },
     "string-web-access": {
-      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
+      "sha": "27404899e31e93b65103c699f0da4b7883861597",
       "version": "1.0.0",
       "components": {
         "commands": [
           {
             "name": "string-setup",
-            "description": "Check that String Web Access is connected and all three tools respond"
+            "description": "Check that String Web Access is connected and its read tools respond"
           },
           {
             "name": "web-research",
@@ -811,6 +811,10 @@
           {
             "name": "string-fetch",
             "description": "Fetch any web page and get clean, LLM-ready Markdown back, via String Web Access. Use when the user gives you a URL, as…"
+          },
+          {
+            "name": "string-request",
+            "description": "Send a POST, PUT or PATCH with a body to a URL, through String Web Access. Use when the user wants to submit something…"
           },
           {
             "name": "string-search",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,17 +788,17 @@
       }
     },
     "string-web-access": {
-      "sha": "1a65005a6d6333dbd43dd251b39480eac1c180e8",
+      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
       "version": "1.0.0",
       "components": {
         "commands": [
           {
             "name": "string-setup",
-            "description": "Set up String Web Access — check the connection and confirm all three tools respond."
+            "description": "Check that String Web Access is connected and all three tools respond"
           },
           {
             "name": "web-research",
-            "description": "Research a topic on the live web — search, read the best sources, and report with citations."
+            "description": "Research a topic on the live web and report with citations"
           }
         ],
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "string-web-access": {
-      "sha": "9c9c7e98401687f07ff41c76181079556a41f9c6",
+      "sha": "e9c57ed5e7aef472a36cf224557164b81cc13a75",
       "version": "1.0.0",
       "components": {
         "commands": [


### PR DESCRIPTION
## What this PR does

Adds the official String Web Access plugin to the Grok plugin marketplace.

String Web Access fetches, searches and maps any website as clean, LLM-ready Markdown. Proxy rotation, session handling and JavaScript rendering happen server-side, so Grok receives usable page content rather than an error page. It is aimed at sites that rate-limit or geo-gate automated traffic, where a plain request returns an interstitial instead of content.

- Plugin name: `string-web-access`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/usestring/string-grok-plugin.git` @ `29d957637d0ee14e5438bd5653b77ec0c6581444`
- Homepage: https://usestring.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The plugin is maintained by String under the official `usestring` GitHub organization.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated as MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.usestring.ai/v1/mcp` — the hosted String Web Access MCP server, over streamable HTTP. It is the only endpoint the plugin contacts. Tools are discovered dynamically from it.
- Credentials/permissions it requires (and why): a String API key supplied by the user as `STRING_API_KEY` and sent as a bearer token, so the hosted service can attribute and bill the user's own requests. No credentials are embedded in the plugin. The configured server exposes four tools. Three are read-only — `web_access_fetch`, `web_access_search` and `web_access_sitemap`. One writes: `web_access_request` sends a POST, PUT or PATCH body to a URL the caller names, and refuses GET. The write is deliberately a separate tool rather than a `method` parameter on the fetch tool, precisely so the three read tools can be declared read-only and only the write prompts the user. It has no default target, writes only where the user directs it, and the `string-request` skill documents it as a write.

The plugin ships no hooks, no scripts and no executable code — five skills, three reference documents, two commands and one security rule, all Markdown, plus the MCP server declaration.

## Notes for reviewers

Tested locally with Grok Build: manifest validation, plugin installation, MCP discovery and live tool calls against the hosted server.

The source repo is published under the official `usestring` organization, alongside our other public repos (`string-ai-mcp`, `powhttp-mcp`, `gqlcrawl`).

One deliberate naming choice worth flagging: the plugin is `string-web-access` rather than the bare product name `string`, and the keywords are scoped to `string web access` and `usestring`. The bare term would mis-fire the plugin CTA on any mention of a string in code, which is most coding sessions. The `domains` list covers only hosts String owns.

The bundled rule instructs the agent to treat all fetched web content as untrusted data and never to act on instructions found inside a fetched page.
