### PR TITLE
Add AirOps plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "airops",
+      "description": "Access your AirOps workspaces, Brand Kits, and AEO (AI Engine Optimization) analytics. Monitor your brand's performance in AI search results, analyze citation rates, and optimize your content strategy.\n\nYou can use AirOps to:\n\nBrand Performance Analysis:\n\"Show me my brand's citation rate and share of voice for the last 30 days\"\n\nContent Optimization:\n\"What are the top questions citing my website and how can I improve my answers?\"\n\nCompetitive Intelligence:\n\"Compare my brand's AI search performance against my top 3 competitors\"\n\nUse your Brand Kit to create content:\n\"Write a blog post about the product described in the attached document\"",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/airopshq/airops-grok-plugin.git",
+        "sha": "4d7ef52617828d5af960a6a0f84e5af572c09bdd"
+      },
+      "homepage": "https://www.airops.com",
+      "keywords": ["airops", "airops mcp", "airops brand kit", "airops aeo"],
+      "domains": ["airops.com", "app.airops.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "airops": {
+      "sha": "4d7ef52617828d5af960a6a0f84e5af572c09bdd",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airops",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the official AirOps plugin to the Grok plugin marketplace.

AirOps provides authenticated access to workspaces, Brand Kits, and AEO analytics through its hosted MCP server. Users can monitor citation rates and share of voice, identify content opportunities, compare competitor performance, and create content using their Brand Kit.

- Plugin name: `airops`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/airopshq/airops-grok-plugin.git` @ `4d7ef52617828d5af960a6a0f84e5af572c09bdd`
- Homepage: https://www.airops.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The plugin is maintained by AirOps under the official `airopshq` GitHub organization.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a full 40-character lowercase commit SHA, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] License is stated as Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or environment variables.
- [x] MCP scope is least-privilege.

- Network endpoint: `https://app.airops.com/mcp` — the hosted AirOps MCP server.
- Credentials/permissions: browser-based OAuth using an AirOps account. No API key or embedded credentials are required.
- Access is limited by the authenticated user's AirOps workspace permissions.
- The plugin contains no lifecycle hooks, scripts, skills, commands, agents, or executable code.

## Notes for reviewers

The plugin was tested locally with Grok Build, including manifest validation, local installation, MCP discovery, browser OAuth, and live MCP access.

The source is published under the official AirOps organization. Keywords and domains are scoped to the AirOps brand.
