### PR TITLE
Add speakai-mcp plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -292,7 +292,7 @@
         "path": "plugins/speakai-mcp"
       },
       "homepage": "https://docs.speakai.co/mcp",
-      "keywords": ["speak ai", "speakai", "meeting notes", "meeting recorder", "transcription", "voice survey", "video survey", "sales coaching", "research analysis"],
+      "keywords": ["speak ai", "speakai", "speak ai transcription", "speak ai meeting notes", "speak ai research analysis", "speak ai sales coaching", "speak ai voice survey", "speak ai video survey"],
       "domains": ["speakai.co"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "speakai-mcp",
+      "description": "Capture meetings, search thousands of recordings, run async voice and video surveys, create clips, and automate workflows with Speak AI directly from Grok — transcription, AI insights, and analysis across your recorded conversations.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/speakai/speakai-mcp.git",
+        "sha": "800644b262b3fe2260068890b56aed9f47c32c54",
+        "path": "plugins/speakai-mcp"
+      },
+      "homepage": "https://docs.speakai.co/mcp",
+      "keywords": ["speak ai", "speakai", "meeting notes", "meeting recorder", "transcription", "voice survey", "video survey", "sales coaching", "research analysis"],
+      "domains": ["speakai.co"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,48 @@
         ]
       }
     },
+    "speakai-mcp": {
+      "sha": "800644b262b3fe2260068890b56aed9f47c32c54",
+      "version": "1.21.2",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "speakai",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "automations-and-webhooks",
+            "description": "Build, test, and operate Speak AI automations and webhooks through MCP. Use this when the user wants recurring work to…"
+          },
+          {
+            "name": "clips-and-captions",
+            "description": "Turn Speak AI recordings into shareable output. Use this when someone asks for a highlight clip, a soundbite, a reel, s…"
+          },
+          {
+            "name": "dashboards-and-reporting",
+            "description": "Build, update, and share Speak AI analytics dashboards. Use this when someone asks for a dashboard, a recurring report,…"
+          },
+          {
+            "name": "getting-started",
+            "description": "Connect an agent to Speak AI and orient it in the workspace. Covers the remote OAuth connection, the local stdio connec…"
+          },
+          {
+            "name": "meeting-summaries",
+            "description": "Turn meetings recorded in Speak AI into decisions, action items, owners, and risks. Use this when the user asks you to…"
+          },
+          {
+            "name": "research-analysis",
+            "description": "Analyze interviews, user research calls, and customer conversations across many Speak AI recordings. Use this when you…"
+          },
+          {
+            "name": "surveys-and-recorders",
+            "description": "Run async voice and video surveys in Speak AI end to end. Use this when someone asks to collect recorded answers from c…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "453dacd48aac27d751aa3cb7e410256efb3fcfca",
       "version": "0.5.4",


### PR DESCRIPTION
## What this PR does

Adds Speak AI's MCP server + skills plugin to the marketplace: capture meetings, search thousands of recordings, run async voice and video surveys, create clips, and automate workflows across a Speak AI workspace.

- Plugin name: `speakai-mcp`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/speakai/speakai-mcp.git` @ `800644b262b3fe2260068890b56aed9f47c32c54` (path `plugins/speakai-mcp`)
- Homepage: https://docs.speakai.co/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`speakai/speakai-mcp`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; brand-scoped `keywords`.
- [x] License is stated (MIT, see `plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; MCP server exposes only Speak AI's own documented API surface).
- Network endpoints this plugin calls (and why): `https://api.speakai.co/v1/mcp` (Speak AI's own first-party API, remote MCP transport) — the only network endpoint. The vendored `.mcp.json` alternately runs `npx -y @speakai/mcp-server` locally over stdio, which also only talks to `https://api.speakai.co`.
- Credentials/permissions it requires (and why): Remote path uses OAuth 2.1 with Dynamic Client Registration (user approves once, no key ever stored in the plugin). Local stdio path collects a user-supplied Speak AI API key via `user_config` (`SPEAK_API_KEY`), scoped to the installing user's own Speak AI workspace.

## Notes for reviewers

Also published for other agent ecosystems (Claude Code, Codex) under the open [Agent Plugins](https://agent-plugins.org) standard — `plugin.json` is the portable manifest, `.claude-plugin/` and `.codex-plugin/` are each client's own convention. Full docs: https://docs.speakai.co/mcp/plugin