### PR TITLE
Add doola plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "doola",
+      "description": "Form a Wyoming LLC end to end from a conversation: company name, industry, members, ownership, and filing with the Wyoming Secretary of State.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/doolahq/plugins.git",
+        "sha": "d332682bdc134fb424f429d29ccd5fac40c774c5",
+        "path": "doola"
+      },
+      "homepage": "https://mcp.doola.com",
+      "keywords": ["doola", "doola formation", "doola.com", "mcp.doola.com"],
+      "domains": ["doola.com", "mcp.doola.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,18 @@
         ]
       }
     },
+    "doola": {
+      "sha": "d332682bdc134fb424f429d29ccd5fac40c774c5",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "doola",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What

Adds `doola` to `.grok-plugin/marketplace.json` and regenerates `.grok-plugin/plugin-index.json`.

## Plugin

- **What it does:** Form a Wyoming LLC end to end from a conversation -- company name, industry, members, ownership, and filing with the Wyoming Secretary of State.
- **Source:** [`doolahq/plugins`](https://github.com/doolahq/plugins) (public, official doola org), subdirectory `doola`, pinned to commit `d332682bdc134fb424f429d29ccd5fac40c774c5`.
- **Components:** one MCP server (`doola`), hosted remotely at `https://mcp.doola.com`. No skills/commands/hooks in this version.
- **Auth:** OAuth on first tool call (sign in with a doola account); no API key needed. Declared in the plugin repo's [README](https://github.com/doolahq/plugins/blob/main/README.md#network-endpoint--credentials).
- **License:** MIT.

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` (`doola`) is kebab-case and unique.
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable (verified via `git ls-remote`).
- [x] `.grok-plugin/plugin-index.json` regenerated and committed (`generate-plugin-index.py --check` passes).
- [x] `homepage` (`https://mcp.doola.com`) and a clear `description`; brand-scoped `keywords`/`domains` (`doola`, `doola formation`, `doola.com`, `mcp.doola.com`).
- [x] Source repo has a `README.md` and a valid `.claude-plugin/plugin.json` manifest.
- [x] Plugin is MIT-licensed and the license is stated.
- [x] `python3 scripts/validate-catalog.py` and `python3 scripts/generate-plugin-index.py --check` both pass locally.

## Security expectations

No hooks, no shell execution, no filesystem access. The plugin's only capability is the one MCP server over HTTPS to `mcp.doola.com`. No telemetry beyond what the doola product itself already does for its own users.