### PR TITLE
Add socialrobot plugin (SocialRobot MCP server + post-scheduling skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "socialrobot",
+      "description": "Schedule and analyze social media posts across 9 platforms (Instagram, LinkedIn, X, TikTok, Facebook, Threads, Pinterest, Bluesky, Mastodon) directly from Grok. Remote OAuth MCP server with 17 tools: connected accounts, post creation and scheduling, media upload, analytics, follower demographics, and platform extras. Free on every plan.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/socialrobot-io/socialrobot-mcp.git",
+        "sha": "45ed60cbbfc24d3926db92927afcaf8160d046c2"
+      },
+      "homepage": "https://socialrobot.io",
+      "keywords": ["socialrobot", "socialrobot mcp", "socialrobot scheduler", "social robot"],
+      "domains": ["socialrobot.io", "www.socialrobot.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -888,6 +888,23 @@
         ]
       }
     },
+    "socialrobot": {
+      "sha": "45ed60cbbfc24d3926db92927afcaf8160d046c2",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "socialrobot",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "socialrobot-post-scheduling",
+            "description": "Schedule and analyze social media posts with SocialRobot. Use whenever the user wants to create, schedule, or publish s…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "68382523846ea5bfad75ba1ef58dc5db031d0a5a",
       "version": "0.6.4",


### PR DESCRIPTION
## What this PR does

- Plugin name: `socialrobot`
- Type: remote source
- Source URL + pinned SHA: https://github.com/socialrobot-io/socialrobot-mcp.git @ 45ed60cbbfc24d3926db92927afcaf8160d046c2
- Homepage: https://socialrobot.io

Adds the SocialRobot MCP server to the marketplace. The plugin ships a remote OAuth MCP server (https://socialrobot.io/api/mcp, 17 tools for scheduling and analyzing social media posts across Instagram, LinkedIn, X, TikTok, Facebook, Threads, Pinterest, Bluesky, Mastodon) plus a `socialrobot-post-scheduling` skill that guides agents through connect, adapt-per-platform, schedule, and analyze workflows.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`socialrobot-io`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- Network endpoints this plugin calls (and why): `https://socialrobot.io/api/mcp` — the hosted MCP server itself (remote OAuth with PKCE, per-tool scopes, rate-limited per plan). Declared in the source repo's README.
- Credentials/permissions it requires (and why): browser OAuth sign-in on first connection (or API key for non-browser clients). Publishing and media are separate OAuth scopes from analytics-only access.

## Notes for reviewers

SocialRobot (socialrobot.io) is a social media scheduling SaaS. The MCP server is already listed on Smithery, Glama, and in the Cursor Marketplace (`.cursor-plugin/plugin.json` + `mcp.json` in the source repo); this PR adds the Grok Build `.mcp.json` and a skill so Grok Build users get the same integration.
