### PR TITLE
Add quawd plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "quawd",
+      "description": "Research, backtest and validate rule-based trading strategies. Scan a condition for predictive power before building anything, compose entry/exit/gate cards, run historical backtests on equity and crypto spot data, and check robustness with walk-forward and spend-once holdout validation.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/QuawdBot/plugins.git",
+        "sha": "1bf50ba6fc8ef597956ec4c24acb46752241cee5"
+      },
+      "homepage": "https://quawd.bot",
+      "keywords": ["quawd", "quawd backtest", "quawd strategy"],
+      "domains": ["quawd.bot", "mcp.quawd.bot"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -717,6 +717,24 @@
         ]
       }
     },
+    "quawd": {
+      "sha": "1bf50ba6fc8ef597956ec4c24acb46752241cee5",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "quawd",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "teach",
+            "description": "Explain a trading concept — a strategy family, an ideology, an unfamiliar term — by mapping it onto what Quawd can actu…"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",


### PR DESCRIPTION
## What this PR does

- Plugin name: `quawd`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/QuawdBot/plugins.git` @ `1bf50ba6fc8ef597956ec4c24acb46752241cee5`
- Homepage: https://quawd.bot

Adds a catalog entry for Quawd — research, backtesting and validation of rule-based trading strategies through a hosted MCP server. Ships the MCP server plus one skill.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`QuawdBot` is our organisation, and both `quawd.bot` and `mcp.quawd.bot` are verified domains on it — the org carries GitHub's Verified badge. MIT licensed.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: MIT (Copyright 2026 Quawd), in `LICENSE`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): exactly one host — `https://mcp.quawd.bot/mcp`, over HTTPS. That is the hosted Quawd MCP server; every tool call goes there. No other host is contacted.
- Credentials/permissions it requires (and why): **none at install time.** Authentication happens on first use, via OAuth 2.1 with PKCE (metadata at `https://mcp.quawd.bot/.well-known/oauth-authorization-server`, and RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource`), or a user-generated API key as a bearer token for headless agents. Scopes are `read` and `write`.

## Notes for reviewers

**Components:** one HTTP MCP server and one skill (`teach`). No hooks, no agents, no LSP servers, no scripts, no bundled binaries — the skill is Markdown and the server is hosted.

**On shipping only one skill.** Three further candidates were written and A/B tested against an uninstructed agent on the same tasks, and dropped because they changed nothing: the server's tool descriptions already carry the workflow, and capability facts (what the engine refuses, dataset extent) are returned in the `instructions` field on the initialize handshake, so they reach every client rather than only plugin installers. `teach` was kept because it measurably closed two gaps — an uninstructed agent explained a concept without ever offering to build one, and named a condition type it had never discovered. We would rather ship one skill that earns its tokens than pad the count.

**Scope:** Quawd is research and simulation. It does not route live orders, custody funds, or give personalized investment advice. Equity and crypto spot only.