### PR TITLE
Add municibid plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "municibid",
+      "description": "Search public government surplus auctions on Municibid. Review listing details, sold comps, informational market-value ranges, and public agency summaries. Read-only — no bids, payments, or listings.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Municibid/botplugin.git",
+        "sha": "16ee114e8ccfe88c4327641950a742a1a09b9b9e"
+      },
+      "homepage": "https://www.municibid.com",
+      "keywords": ["municibid", "municibid auctions", "municibid surplus"],
+      "domains": ["municibid.com", "www.municibid.com", "ai.municibid.com", "info.municibid.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -425,6 +425,24 @@
         ]
       }
     },
+    "municibid": {
+      "sha": "16ee114e8ccfe88c4327641950a742a1a09b9b9e",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "municibid",
+            "description": "streamable-http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "municibid",
+            "description": "Search public Municibid government surplus auctions, open listing details, review sold comps, estimate informational ma…"
+          }
+        ]
+      }
+    },
     "neon": {
       "version": "1.0.0",
       "components": {


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

Adds the official Municibid plugin as a remote catalog entry.

- Plugin name: municibid
- Type: remote source
- Source URL + pinned SHA: https://github.com/Municibid/botplugin.git @ `16ee114e8ccfe88c4327641950a742a1a09b9b9e`
- Homepage: https://www.municibid.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source: [Municibid/botplugin](https://github.com/Municibid/botplugin) (MIT). Municibid is the government surplus auction marketplace; this plugin wraps the hosted read-only MCP at `https://ai.municibid.com/mcp`.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://ai.municibid.com/mcp` (Streamable HTTP). Read-only public auction discovery — search, listing details, sold comps, informational market-value ranges, agency summaries. No other plugin-initiated endpoints.
- Credentials/permissions it requires (and why): none. Public read-only MCP. No auth, bids, payments, listings, or account changes.

## Notes for reviewers

Companion to the [Municibid ChatGPT app](https://info.municibid.com/municibid-chatgpt-app). Same five read-only tools; all bidding and payments stay on municibid.com.

Index generation recorded MCP server `municibid` (streamable-http) and skill `municibid` at the pinned SHA.