### PR TITLE
Add claude plugin (community Claude Code companion)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "claude",
+      "description": "Use Claude Code from Grok Build to review code or delegate tasks. Community plugin that uses your local Claude Code login.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/AaronFaby/claude-plugin-grok.git",
+        "sha": "96e3babbec9529ab7fd3855e35e400e877fbe52f",
+        "path": "plugins/claude"
+      },
+      "homepage": "https://github.com/AaronFaby/claude-plugin-grok",
+      "keywords": ["claude", "claude code", "claude cli"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -127,6 +127,69 @@
         ]
       }
     },
+    "claude": {
+      "sha": "96e3babbec9529ab7fd3855e35e400e877fbe52f",
+      "version": "0.2.0",
+      "components": {
+        "agents": [
+          {
+            "name": "claude-rescue",
+            "description": "Proactively use when Grok is stuck, wants a second implementation or diagnosis pass, needs a deeper root-cause investig…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "adversarial-review",
+            "description": "Run a steerable Claude review that challenges the chosen implementation"
+          },
+          {
+            "name": "cancel",
+            "description": "Cancel an active background Claude job in this repository"
+          },
+          {
+            "name": "rescue",
+            "description": "Delegate investigation, an explicit fix request, or follow-up rescue work to the Claude rescue subagent"
+          },
+          {
+            "name": "result",
+            "description": "Show the stored final output for a finished Claude job in this repository"
+          },
+          {
+            "name": "review",
+            "description": "Run a Claude code review against local git state"
+          },
+          {
+            "name": "setup",
+            "description": "Check whether the local Claude Code CLI is ready and optionally toggle the stop-time review gate"
+          },
+          {
+            "name": "status",
+            "description": "Show active and recent Claude jobs for this repository, including review-gate status"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          }
+        ],
+        "skills": [
+          {
+            "name": "claude-cli-runtime",
+            "description": "Internal helper contract for calling the Claude companion runtime from Grok Build"
+          },
+          {
+            "name": "claude-result-handling",
+            "description": "Internal guidance for presenting Claude helper output back to the user"
+          }
+        ]
+      }
+    },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds a community Claude Code companion plugin so Grok Build can review git work and delegate tasks through the user's local `claude` CLI.

- Plugin name: `claude`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/AaronFaby/claude-plugin-grok.git` at `96e3babbec9529ab7fd3855e35e400e877fbe52f`, plugin root `plugins/claude`
- Homepage: https://github.com/AaronFaby/claude-plugin-grok

This is the Grok-side counterpart of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc): Grok stays in control, Claude Code runs as a second-agent pass. It is not an Anthropic product.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

There is no Anthropic-published Grok Build plugin. I maintain this as a community MIT-licensed companion at [AaronFaby/claude-plugin-grok](https://github.com/AaronFaby/claude-plugin-grok). The catalog name `claude` matches the plugin id and slash-command prefix (`/claude:review`, `/claude:rescue`, …). Happy to rename the catalog entry to `claude-code` or `claude-for-grok` if reviewers prefer that.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

Network endpoints this plugin calls (and why):

- The plugin scripts do **not** call remote HTTP APIs themselves.
- They spawn the local `claude` CLI, which talks to Anthropic (`api.anthropic.com` and related Claude Code endpoints) for reviews, rescue tasks, and the optional stop-time gate.
- `!claude auth login` may open a browser for one-time Claude Code authentication.
- No telemetry. No remote install scripts. Job state stays under `$GROK_PLUGIN_DATA`.

Credentials/permissions it requires (and why):

- **Claude CLI login** is enough. Optional `ANTHROPIC_API_KEY` (or a plugin key file) is injected only into the child `claude` process. Setup JSON and stdout never include the key or the Claude login email.
- Install with `--trust` because the plugin registers hooks:
  - `SessionStart` / `SessionEnd` (5s): clean up this plugin's jobs for the current Grok session only.
  - `Stop` (900s): optional review gate. It no-ops unless the user enables `stopReviewGate`. When enabled, missing Claude or a non-`ALLOW:` verdict blocks the stop.
- No MCP servers. No `--dangerously-skip-permissions`. Node ESM, no npm dependencies.

Read-only Claude argv (reviews, `--read-only` tasks, stop gate) restricts tools to Read/Glob/Grep and scoped `git` Bash rules, disables MCP tools, and empties `--setting-sources` so user/project allow rules cannot add Edit/Write.

## Notes for reviewers

**Components at the pinned SHA:** 7 commands (`setup`, `review`, `adversarial-review`, `rescue`, `status`, `result`, `cancel`), 1 agent (`claude-rescue`), 2 internal skills, 3 hooks. Version `0.2.0`.

**Keywords** are brand-scoped (`claude`, `claude code`, `claude cli`) so the plugin CTA fires on Claude Code requests, not generic “review” / “rescue” prompts. No `domains` — this plugin does not own anthropic.com or claude.ai.

**Docs:** README covers install, auth, network/credentials, permissions, and the stop-time gate. Upstream tests (`npm test`) use a fake Claude CLI and do not call Anthropic.