### PR TITLE
Add Mida plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -282,13 +282,13 @@
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
     {
-      "name": "mida",
+      "name": "mida-abtesting",
       "description": "Mida A/B testing and personalization (MCP server + skills). Create experiments and goals, read results with Mida's own statistics, conclude tests, and serve winners on any site running the Mida tag.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/mida-so/mida-plugin.git",
-        "sha": "ca5dfee0aefff88681963cdc1ba7327cefd55181"
+        "sha": "52d696e34cf81874f82b0c134513a3325c70c42c"
       },
       "homepage": "https://www.mida.so/mcp",
       "keywords": ["mida", "mida ab test", "mida experiment", "mida personalization", "mida.so"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "mida",
+      "description": "Mida A/B testing and personalization (MCP server + skills). Create experiments and goals, read results with Mida's own statistics, conclude tests, and serve winners on any site running the Mida tag.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mida-so/mida-grok-plugin.git",
+        "sha": "f58506f82cad91ba762e2160fef6a63b97ff7ec8"
+      },
+      "homepage": "https://www.mida.so",
+      "keywords": ["mida", "mida ab test", "mida experiment", "mida personalization", "mida.so"],
+      "domains": ["mida.so", "www.mida.so", "app.mida.so"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -282,13 +282,13 @@
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
     {
-      "name": "mida-abtesting",
+      "name": "mida-so",
       "description": "Mida A/B testing and personalization (MCP server + skills). Create experiments and goals, read results with Mida's own statistics, conclude tests, and serve winners on any site running the Mida tag.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/mida-so/mida-plugin.git",
-        "sha": "52d696e34cf81874f82b0c134513a3325c70c42c"
+        "sha": "c32d84f482dea1cc7aa8b558c77ef2dc33279fbc"
       },
       "homepage": "https://www.mida.so/mcp",
       "keywords": ["mida", "mida ab test", "mida experiment", "mida personalization", "mida.so"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,9 +288,9 @@
       "source": {
         "source": "url",
         "url": "https://github.com/mida-so/mida-plugin.git",
-        "sha": "fadc108c043ff85e5174f0cc85d22b9da6ef1b86"
+        "sha": "ca5dfee0aefff88681963cdc1ba7327cefd55181"
       },
-      "homepage": "https://www.mida.so",
+      "homepage": "https://www.mida.so/mcp",
       "keywords": ["mida", "mida ab test", "mida experiment", "mida personalization", "mida.so"],
       "domains": ["mida.so", "www.mida.so", "app.mida.so"]
     }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -287,8 +287,8 @@
       "category": "development",
       "source": {
         "source": "url",
-        "url": "https://github.com/mida-so/mida-grok-plugin.git",
-        "sha": "f58506f82cad91ba762e2160fef6a63b97ff7ec8"
+        "url": "https://github.com/mida-so/mida-plugin.git",
+        "sha": "fadc108c043ff85e5174f0cc85d22b9da6ef1b86"
       },
       "homepage": "https://www.mida.so",
       "keywords": ["mida", "mida ab test", "mida experiment", "mida personalization", "mida.so"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,28 @@
         ]
       }
     },
+    "mida": {
+      "sha": "f58506f82cad91ba762e2160fef6a63b97ff7ec8",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mida",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mida",
+            "description": "Working with Mida — A/B testing, split tests, and personalization on a live website. Use whenever \"Mida\" is mentioned,…"
+          },
+          {
+            "name": "mida-experiments",
+            "description": "Build and launch a Mida A/B test end to end — writing the hypothesis, creating the experiment and its variants, attachi…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,7 +346,7 @@
       }
     },
     "mida": {
-      "sha": "f58506f82cad91ba762e2160fef6a63b97ff7ec8",
+      "sha": "fadc108c043ff85e5174f0cc85d22b9da6ef1b86",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
@@ -358,11 +358,11 @@
         "skills": [
           {
             "name": "mida",
-            "description": "Working with Mida — A/B testing, split tests, and personalization on a live website. Use whenever \"Mida\" is mentioned,…"
+            "description": "Working with Mida: A/B testing, split tests, and personalization on a live website. Use whenever \"Mida\" is mentioned, a…"
           },
           {
             "name": "mida-experiments",
-            "description": "Build and launch a Mida A/B test end to end — writing the hypothesis, creating the experiment and its variants, attachi…"
+            "description": "Build and launch a Mida A/B test end to end: writing the hypothesis, creating the experiment and its variants, attachin…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,9 +345,9 @@
         ]
       }
     },
-    "mida": {
-      "sha": "ca5dfee0aefff88681963cdc1ba7327cefd55181",
-      "version": "1.0.0",
+    "mida-abtesting": {
+      "sha": "52d696e34cf81874f82b0c134513a3325c70c42c",
+      "version": "1.0.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,7 +346,7 @@
       }
     },
     "mida": {
-      "sha": "fadc108c043ff85e5174f0cc85d22b9da6ef1b86",
+      "sha": "ca5dfee0aefff88681963cdc1ba7327cefd55181",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,9 +345,9 @@
         ]
       }
     },
-    "mida-abtesting": {
-      "sha": "52d696e34cf81874f82b0c134513a3325c70c42c",
-      "version": "1.0.1",
+    "mida-so": {
+      "sha": "c32d84f482dea1cc7aa8b558c77ef2dc33279fbc",
+      "version": "1.0.2",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

Adds **Mida**, an A/B testing and personalization platform. A JavaScript tag on the customer's site assigns visitors to variants and reports conversions; this plugin connects Grok Build to that account so the whole loop — build a test, launch it, read the result, conclude it, serve the winner — happens in one conversation.

- Plugin name: `mida`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/mida-so/mida-grok-plugin.git` @ `f58506f82cad91ba762e2160fef6a63b97ff7ec8`
- Homepage: https://www.mida.so

Components: 1 MCP server (hosted, OAuth) + 2 skills.

| Skill | Covers |
|---|---|
| `mida` | Project selection, reading Bayesian "chance to beat original" vs. frequentist p-values, and the order of operations for concluding a test and serving a winner |
| `mida-experiments` | The workflow: hypothesis → variants → goal → preview → launch → call the result |

The skills exist because a few Mida behaviours are easy to get wrong from the tool schemas alone — an experiment's display number is not its API id, a concluded test stops serving even while its status still reads active, and setting a test's status clears a conclusion written before it. Each is documented with the correct sequence.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`mida-so`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):** `https://mcp.mida.so/mcp` only — the hosted Mida MCP server. It reaches Mida's API server-side; the plugin itself contacts no other host.

**Credentials/permissions it requires (and why):** OAuth to the user's own Mida account, handled by the MCP client. No API keys, no environment variables, no local credential files. The server advertises spec-compliant discovery (`WWW-Authenticate` → `/.well-known/oauth-protected-resource/mcp`), dynamic client registration, and PKCE S256, so no pre-provisioning is needed on either side.

The plugin ships **no local execution** — no hooks, commands, or scripts. It is one remote MCP server plus Markdown skills.

## Notes for reviewers

`keywords` and `domains` are deliberately brand-scoped — `mida`, `mida ab test`, `mida experiment`, `mida personalization`, `mida.so`, and only domains Mida owns. Generic terms like "a/b test", "experiment", or "personalization" would mis-fire the CTA on unrelated requests, so they're left out.

Happy to adjust the `category` — Mida isn't really a development tool, but there's no experimentation/analytics category in the catalog yet, so `development` seemed the closest fit for discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
