### PR TITLE
Add ToolRouter plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "toolrouter",
+      "description": "ToolRouter is the OpenRouter for tools. Connect once over MCP and your agent can discover and call 250+ hosted specialist tools: web search, scraping, image and video generation, SEO, finance, property, compliance and more. Free tools work immediately; paid tools are pay per call.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Humanleap/toolrouter-grok-plugin.git",
+        "sha": "76414a0e8afed893afeb12d836a666a5feab861f"
+      },
+      "homepage": "https://toolrouter.com",
+      "keywords": ["toolrouter", "mcp", "mcp-server", "ai-tools", "agents", "tool-router", "web-search", "scraping", "image-generation", "video-generation", "seo"],
+      "domains": ["toolrouter.com", "api.toolrouter.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1122,6 +1122,24 @@
         ]
       }
     },
+    "toolrouter": {
+      "sha": "76414a0e8afed893afeb12d836a666a5feab861f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "toolrouter",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "toolrouter-catalog",
+            "description": "Discover and call tools through ToolRouter's hosted catalog. Use when the user explicitly asks for ToolRouter, referenc…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "dca8da784e876cbb8e81bd98cb5b2b87323449ca",
       "version": "0.49.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: toolrouter
- Type: remote source
- Source URL + pinned SHA: https://github.com/Humanleap/toolrouter-grok-plugin.git at 76414a0e8afed893afeb12d836a666a5feab861f
- Homepage: https://toolrouter.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with the unique kebab-case name `toolrouter`.
- [x] The remote source pins a reachable public 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, description, README, manifest, and license are present.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` behavior.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks or local execution; the skill limits itself to discovery, execution, async result retrieval, and balance readback.
- Network endpoints this plugin calls: `https://api.toolrouter.com/mcp`, the official hosted ToolRouter MCP endpoint for live catalog discovery and execution. Selected tools may call their documented providers server-side; no provider code executes locally.
- Credentials/permissions it requires: none. A free ToolRouter account is provisioned on first use; paid tools require credits and the skill directs the agent to confirm user intent before cost-bearing calls or account changes.

## Notes for reviewers

- The source is maintained under the official Humanleap organization and licensed MIT.
- The plugin contains one hosted HTTP MCP server and one scoped ToolRouter catalog skill, with no hooks, commands, install scripts, or filesystem permissions.
- The endpoint completed a live MCP `initialize` request using protocol version `2025-06-18` before submission.
