### PR TITLE
Add SQD blockchain data plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/subsquid-labs/portal-mcp-server.git",
-        "sha": "acf611b82a6a66f12d3341d76ecebebb645787da",
+        "sha": "2e6075674cf6b8d29e2ac7569a7b67dd43a9fec2",
         "path": "plugins/portal"
       },
       "homepage": "https://sqd.dev/portal/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "sqd",
-      "description": "Query blockchain data across 140+ networks with SQD Portal, including Ethereum, Base, Solana, Polkadot, Bitcoin, Tron, and Hyperliquid. The SQD plugin also includes Pipes SDK and Squid SDK skills for building, migrating, troubleshooting, and improving blockchain data projects.",
+      "description": "Explore blockchain data across 130+ networks with SQD Portal. Query Ethereum, Base, Solana, Polkadot, Bitcoin, Hyperliquid, and more, discover Tron metadata, and use bundled Portal, Pipes SDK, and Squid SDK skills.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/subsquid-labs/portal-mcp-server.git",
-        "sha": "abb417ae04778a4979a2b8f4fc85bf57aa36518a",
+        "sha": "cf52a3bc738ef984e61128d439b7bc88dea4f279",
         "path": "plugins/portal"
       },
       "homepage": "https://sqd.dev/portal/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/subsquid-labs/portal-mcp-server.git",
-        "sha": "9dd751169bce62814fda48182456dd8c84d150d7",
+        "sha": "acf611b82a6a66f12d3341d76ecebebb645787da",
         "path": "plugins/portal"
       },
       "homepage": "https://sqd.dev/portal/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "sqd",
-      "description": "SQD helps Grok find 130+ blockchain networks and explore the live and historical data available for each. Analyze wallets, transactions, token transfers, smart contracts, network activity, and markets across Ethereum, Base, Solana, Bitcoin, Polkadot, Hyperliquid, and many more, and check current Tron availability.",
+      "description": "Query blockchain data across 140+ networks with SQD Portal, including Ethereum, Base, Solana, Polkadot, Bitcoin, Tron, and Hyperliquid. The SQD plugin also includes Pipes SDK and Squid SDK skills for building, migrating, troubleshooting, and improving blockchain data projects.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/subsquid-labs/portal-mcp-server.git",
-        "sha": "2e6075674cf6b8d29e2ac7569a7b67dd43a9fec2",
+        "sha": "abb417ae04778a4979a2b8f4fc85bf57aa36518a",
         "path": "plugins/portal"
       },
       "homepage": "https://sqd.dev/portal/",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "sqd",
+      "description": "SQD helps Grok find 130+ blockchain networks and explore the live and historical data available for each. Analyze wallets, transactions, token transfers, smart contracts, network activity, and markets across Ethereum, Base, Solana, Bitcoin, Polkadot, Hyperliquid, and many more, and check current Tron availability.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/subsquid-labs/portal-mcp-server.git",
+        "sha": "9dd751169bce62814fda48182456dd8c84d150d7",
+        "path": "plugins/portal"
+      },
+      "homepage": "https://sqd.dev/portal/",
+      "keywords": ["sqd", "subsquid", "sqd blockchain", "sqd blockchain data", "sqd hyperliquid", "sqd tron", "sqd portal"],
+      "domains": ["sqd.dev", "portal.sqd.dev", "docs.sqd.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,36 @@
         ]
       }
     },
+    "sqd": {
+      "sha": "9dd751169bce62814fda48182456dd8c84d150d7",
+      "version": "0.8.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "SQD",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "migrate-to-portal",
+            "description": "Migrate an existing Squid SDK indexer (EVM or Solana) off the v2 gateway and onto the Portal data source. Covers the pa…"
+          },
+          {
+            "name": "pipes-sdk",
+            "description": "Build, configure, deploy, and troubleshoot durable blockchain indexers with the Subsquid Pipes SDK (EVM, Solana, Tron,…"
+          },
+          {
+            "name": "portal",
+            "description": "Query blockchain data across 140+ networks with SQD Portal, including EVM, Solana, Substrate, Bitcoin, Tron, and Hyperl…"
+          },
+          {
+            "name": "squid-perf",
+            "description": "Compare sync-time performance across one or more Squid SDK deployments. Fetches logs via sqd CLI, parses per-service pr…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
       "version": "0.6.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "sqd": {
-      "sha": "2e6075674cf6b8d29e2ac7569a7b67dd43a9fec2",
+      "sha": "abb417ae04778a4979a2b8f4fc85bf57aa36518a",
       "version": "0.8.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "sqd": {
-      "sha": "acf611b82a6a66f12d3341d76ecebebb645787da",
+      "sha": "2e6075674cf6b8d29e2ac7569a7b67dd43a9fec2",
       "version": "0.8.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,7 +788,7 @@
       }
     },
     "sqd": {
-      "sha": "9dd751169bce62814fda48182456dd8c84d150d7",
+      "sha": "acf611b82a6a66f12d3341d76ecebebb645787da",
       "version": "0.8.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -788,8 +788,8 @@
       }
     },
     "sqd": {
-      "sha": "abb417ae04778a4979a2b8f4fc85bf57aa36518a",
-      "version": "0.8.0",
+      "sha": "cf52a3bc738ef984e61128d439b7bc88dea4f279",
+      "version": "0.8.3",
       "components": {
         "mcpServers": [
           {
@@ -808,7 +808,7 @@
           },
           {
             "name": "portal",
-            "description": "Query blockchain data across 140+ networks with SQD Portal, including EVM, Solana, Substrate, Bitcoin, Tron, and Hyperl…"
+            "description": "Query blockchain data across 130+ networks with SQD Portal, including EVM, Solana, Substrate, Bitcoin, Tron, and Hyperl…"
           },
           {
             "name": "squid-perf",


### PR DESCRIPTION
## What this PR does

- Plugin name: SQD (`sqd`)
- Type: remote source
- Source URL + pinned SHA: `https://github.com/subsquid-labs/portal-mcp-server.git` at `cf52a3bc738ef984e61128d439b7bc88dea4f279`
- Release: `v0.8.3`
- Homepage: https://sqd.dev/portal/

Adds the official SQD plugin for exploring blockchain data across 130+ networks. The generated index includes the hosted MCP server and four official SQD skills for Portal, Pipes SDK, migration, and Squid performance.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with kebab-case `name`.
- [x] Remote source pins a full 40-character lowercase commit SHA, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` and clear `description` are set.
- [x] License is MIT.

## Security

- [x] No remote install scripts or post-install behavior.
- [x] No reading or sending secrets, tokens, `.env`, or environment variables.
- [x] No hooks. The MCP tools are read-only.
- Network endpoints: `https://portal.sqd.dev` for public SQD Portal data and MCP calls.
- Credentials or permissions: none for the public MCP endpoint.