### PR TITLE
Add monaco plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "monaco",
+      "description": "Monaco AI sales platform integration (MCP Server). Search and update contacts, accounts, opportunities, tasks, and meetings; build audiences and enroll them in sequences and campaigns; run pipeline hygiene and revenue analytics on live CRM data.",
+      "category": "sales",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/monacoinc/agent-plugins.git",
+        "sha": "e130ed02aad16123bbefdf4949fda13b418c6a4d"
+      },
+      "homepage": "https://docs.monaco.com/mcp/overview",
+      "keywords": ["monaco", "monaco crm", "monaco sales", "monaco mcp"],
+      "domains": ["monaco.com", "docs.monaco.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "monaco": {
+      "sha": "e130ed02aad16123bbefdf4949fda13b418c6a4d",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "monaco",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds the **monaco** plugin (MCP Server) to the marketplace catalog as a remote source.

- Plugin name: `monaco`
- Type: remote source
- Source URL + pinned SHA: https://github.com/monacoinc/agent-plugins @ `e130ed02aad16123bbefdf4949fda13b418c6a4d`
- Homepage: https://docs.monaco.com/mcp/overview

Monaco is an AI sales platform. The plugin ships a single remote MCP server config pointing at Monaco's hosted server, plus the Monaco logo and a README. No skills, hooks, commands, or scripts.

Per review feedback, switched from a vendored local plugin to a remote source published under our org (`monacoinc/agent-plugins`), rebased on current main.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, in the source repo)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.monaco.com/mcp` only — Monaco's hosted MCP server (Streamable HTTP), the sole component of the plugin.
- Credentials/permissions it requires (and why): OAuth 2.0, handled by the MCP client on first connection. No keys or tokens are stored in the plugin. Every tool call runs as the logged-in user under their existing Monaco permissions; writes/deletes prompt for confirmation by default.

## Notes for reviewers

I'm an engineer at Monaco; the source repo is under our official org. Docs for the MCP server, including the full tool list: https://docs.monaco.com/mcp/overview
