### PR TITLE
Add VersionPill hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "versionpill",
+      "description": "Product memory for coding agents. Hosted VersionPill board via MCP — vision, work, and a public version customers understand.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/versionpill/mcp.git",
+        "sha": "b0dbcec3a9076e3b1afc824ff894195d2c24c48d"
+      },
+      "homepage": "https://versionpill.com",
+      "keywords": ["versionpill", "version pill", "versionpill board", "versionpill mcp"],
+      "domains": ["versionpill.com", "mcp.versionpill.com", "www.versionpill.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1194,6 +1194,24 @@
         ]
       }
     },
+    "versionpill": {
+      "sha": "b0dbcec3a9076e3b1afc824ff894195d2c24c48d",
+      "version": "6.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "versionpill",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "versionpill",
+            "description": "Use the hosted VersionPill MCP board for product memory while coding. Triggers: board, pulse, ship, vision, \"what's nex…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e",
       "version": "1.17.0",


### PR DESCRIPTION
## Summary
- Adds `versionpill` to the Grok Build marketplace as a remote source.
- Source is the public metadata repo [versionpill/mcp](https://github.com/versionpill/mcp) pinned to `b0dbcec3a9076e3b1afc824ff894195d2c24c48d`.
- Plugin is hosted Streamable HTTP MCP only (`https://mcp.versionpill.com/mcp`) plus a short skill. No local shell, hooks, or postinstall.

## Test plan
- [x] `python3 scripts/validate-catalog.py`
- [x] plugin-index regenerated from the pinned SHA
- [ ] Grok Build `/marketplace` shows VersionPill after merge
- [ ] Install uses OAuth against mcp.versionpill.com


Made with [Cursor](https://cursor.com)