### PR TITLE
add whop plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "whop",
+      "description": "Run a business on Whop from Grok Build. Launch a website on *.whop.app, create products and checkout, take payments and payouts, manage members, run Meta and TikTok ads, form an LLC, and read your stats.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/whopio/plugins.git",
+        "sha": "c804aa9f7597ed6f2de0289c28d80882da05b79c",
+        "path": "dist/grok/whop"
+      },
+      "homepage": "https://docs.whop.com/",
+      "keywords": ["whop", "sell online", "accept payments", "online store", "memberships", "run ads"],
+      "domains": ["whop.com", "docs.whop.com", "whop.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1194,6 +1194,32 @@
         ]
       }
     },
+    "whop": {
+      "sha": "c804aa9f7597ed6f2de0289c28d80882da05b79c",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "whop",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "whop",
+            "description": "Run a business on Whop: websites on *.whop.app, products, checkout, payments, payouts, memberships, ads, LLC/C-corp for…"
+          },
+          {
+            "name": "whop-connect",
+            "description": "Connect and verify this workspace's Whop account"
+          },
+          {
+            "name": "whop-mcp-safety",
+            "description": "The required protocol for any Whop MCP tool call that changes state: the prepare-and-confirm handshake with mcp_confirm…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e",
       "version": "1.17.0",


### PR DESCRIPTION
## What this PR does

Adds the Whop plugin. Whop is a platform for selling online — products, checkout, payments, payouts, memberships, and ads. The plugin connects Grok to a live Whop business through Whop's hosted MCP server, with skills that teach Grok which tool starts which job and when to stop and ask.

- Plugin name: `whop`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/whopio/plugins.git` @ `c804aa9f7597ed6f2de0289c28d80882da05b79c`
- Homepage: https://docs.whop.com/

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`whopio`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated: Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.whop.com/mcp` only — Whop's hosted MCP server, which serves the tools.
- Credentials/permissions it requires (and why): none stored. The user signs in through the browser on first use, and Whop holds the token server-side. The grant covers the reviewed MCP surface for the businesses that user manages.

## Notes for reviewers

The plugin ships four files: an MCP config naming one HTTPS endpoint, and three Markdown skills.

Money is the reason for the third skill. Whop's refunds, payouts, transfers, and deletes are two-step: the first call returns a preview and a confirmation token, and nothing executes until the user approves it. The skill teaches Grok to stop there rather than confirm on its own.

The same plugin ships for Claude Code from the same repo. `dist/grok/whop` is the Grok build.