### PR TITLE
feat: add Blaze CFO MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "blaze",
+      "description": "Blaze CFO integration for analyzing business cash flow, balances, spending, payroll, bills, receivables, accounting data, and owner-reviewed payment or invoicing workflows through the hosted Blaze MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/blaze-xyz/blaze-grok-plugin.git",
+        "sha": "3d8a5d0cf32c382abd57bf3c657b2d92f86ec468"
+      },
+      "homepage": "https://blaze.money",
+      "keywords": ["blaze", "blaze ai cfo", "blaze cash flow", "blaze payments"],
+      "domains": ["blaze.money", "api.blaze.money", "docs.blaze.money"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,18 @@
         ]
       }
     },
+    "blaze": {
+      "sha": "3d8a5d0cf32c382abd57bf3c657b2d92f86ec468",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "blaze",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: blaze
- Type: remote source
- Source URL + pinned SHA (remote): https://github.com/blaze-xyz/blaze-grok-plugin.git @ 3d8a5d0cf32c382abd57bf3c657b2d92f86ec468
- Homepage: https://blaze.money

Adds the official Blaze CFO remote MCP plugin. It connects Grok to Blaze for business cash-flow, spending, bills, receivables, and owner-reviewed payment or invoicing workflows.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org.

## Checklist

- [x] Added exactly one unique kebab-case entry in .grok-plugin/marketplace.json.
- [x] Remote source pins a full 40-character lowercase SHA; the commit is public and reachable.
- [x] Regenerated .grok-plugin/plugin-index.json.
- [x] python3 scripts/validate-catalog.py passes locally.
- [x] python3 scripts/generate-plugin-index.py --check passes locally.
- [x] Homepage and clear description are set; source includes a README and plugin manifest.
- [x] License is stated.

## Security

- [x] No remote-code execution, downloads, or postinstall scripts.
- [x] No reading or exfiltration of secrets, tokens, environment variables, or .env files.
- [x] MCP scope is least-privilege; no hooks or shell execution are included.
- Network endpoint: https://api.blaze.money/mcp, the hosted Blaze CFO MCP server.
- Credentials/permissions: Blaze OAuth through standard MCP authorization discovery. finance:read enables insights; the controlled finance:propose permission is required only to prepare payment, bill, invoice, or memo drafts. The connector never directly executes a transfer.

## Notes for reviewers

The source is a minimal public wrapper under the official blaze-xyz GitHub organization. It contains only the plugin manifest, hosted HTTP MCP configuration, README, and MIT license—no backend code or credentials.