### PR TITLE
Add consult plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/index9-org/grok-consult.git",
-        "sha": "342e9a12590a81d371330327c9435ffd8d11e653"
+        "sha": "3e2d2965cfad04b4a0084b6dad064ad5c624f853"
       },
       "homepage": "https://github.com/index9-org/grok-consult",
       "keywords": ["grok-consult", "claude-consult", "codex-consult", "ask claude", "ask codex"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/index9-org/grok-consult.git",
-        "sha": "3e2d2965cfad04b4a0084b6dad064ad5c624f853"
+        "sha": "60b8dab49e0d6ca8cf43b57eefcf3b3695e0650d"
       },
       "homepage": "https://github.com/index9-org/grok-consult",
       "keywords": ["grok-consult", "claude-consult", "codex-consult", "ask claude", "ask codex"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,15 +283,15 @@
     },
     {
       "name": "consult",
-      "description": "Ask local Claude Code (Pro or Max) and/or Codex CLI (ChatGPT) for a second opinion from Grok Build. Never auto-invoke.",
+      "description": "Ask local Claude Code (Pro or Max), Codex CLI (ChatGPT), and/or Cursor Agent CLI for a second opinion from Grok Build. Never auto-invoke.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/index9-org/grok-consult.git",
-        "sha": "60b8dab49e0d6ca8cf43b57eefcf3b3695e0650d"
+        "sha": "b8933d68a945113cb6186fc9369118b3f442706e"
       },
       "homepage": "https://github.com/index9-org/grok-consult",
-      "keywords": ["grok-consult", "claude-consult", "codex-consult", "ask claude", "ask codex"],
+      "keywords": ["grok-consult", "claude-consult", "codex-consult", "cursor-consult", "ask claude", "ask codex", "ask cursor"],
       "domains": ["index9.dev"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "consult",
+      "description": "Ask local Claude Code (Pro or Max) and/or Codex CLI (ChatGPT) for a second opinion from Grok Build. Never auto-invoke.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/index9-org/grok-consult.git",
+        "sha": "342e9a12590a81d371330327c9435ffd8d11e653"
+      },
+      "homepage": "https://github.com/index9-org/grok-consult",
+      "keywords": ["grok-consult", "claude-consult", "codex-consult", "ask claude", "ask codex"],
+      "domains": ["index9.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,8 +200,8 @@
       }
     },
     "consult": {
-      "sha": "342e9a12590a81d371330327c9435ffd8d11e653",
-      "version": "0.1.2",
+      "sha": "3e2d2965cfad04b4a0084b6dad064ad5c624f853",
+      "version": "0.1.3",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,8 +200,8 @@
       }
     },
     "consult": {
-      "sha": "60b8dab49e0d6ca8cf43b57eefcf3b3695e0650d",
-      "version": "0.1.4",
+      "sha": "b8933d68a945113cb6186fc9369118b3f442706e",
+      "version": "0.1.5",
       "components": {
         "skills": [
           {
@@ -211,6 +211,10 @@
           {
             "name": "codex-consult",
             "description": "Consult Codex CLI (ChatGPT login) from Grok for a second opinion, plan critique, uncommitted/branch/commit review, or o…"
+          },
+          {
+            "name": "cursor-consult",
+            "description": "Consult Cursor Agent CLI from Grok for a second opinion, plan critique, diff review, or occasional implementation, usin…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,8 +200,8 @@
       }
     },
     "consult": {
-      "sha": "3e2d2965cfad04b4a0084b6dad064ad5c624f853",
-      "version": "0.1.3",
+      "sha": "60b8dab49e0d6ca8cf43b57eefcf3b3695e0650d",
+      "version": "0.1.4",
       "components": {
         "skills": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,22 @@
         ]
       }
     },
+    "consult": {
+      "sha": "342e9a12590a81d371330327c9435ffd8d11e653",
+      "version": "0.1.2",
+      "components": {
+        "skills": [
+          {
+            "name": "claude-consult",
+            "description": "Consult Claude Code CLI (Claude Pro or Max, no API key) for a second opinion, plan critique, diff review, or occasional…"
+          },
+          {
+            "name": "codex-consult",
+            "description": "Consult Codex CLI (ChatGPT login) from Grok for a second opinion, plan critique, uncommitted/branch/commit review, or o…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds **consult** as a remote third-party plugin so Grok Build can list it in `/marketplace`.

- Plugin name: `consult`
- Type: remote source
- Source URL + pinned SHA: https://github.com/index9-org/grok-consult.git @ `b8933d68a945113cb6186fc9369118b3f442706e` (tag `v0.1.5`)
- Homepage: https://github.com/index9-org/grok-consult

`consult` lets Grok ask a local Claude Code CLI (Claude Pro or Max), Codex CLI (included with ChatGPT), and/or Cursor Agent CLI (`cursor-agent`, not the editor binary) for a second opinion. Grok stays the daily driver. Never auto-invoke. You need one of those CLIs, not all of them. MIT.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source org: [index9-org](https://github.com/index9-org) ([index9.dev](https://www.index9.dev/)). PR opened from my personal fork of this marketplace repo (`johnwils`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

Index records skills `claude-consult`, `codex-consult`, and `cursor-consult` at version `0.1.5`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none of its own. Wrappers only spawn local `claude` / `codex` / `cursor-agent`. Those CLIs then talk to their own services with the user's existing CLI login.
- Credentials/permissions it requires (and why): Claude Pro or Max (`claude auth login`) and/or a ChatGPT login (`codex login`) and/or a Cursor login (`cursor-agent login`). No API keys. `--trust` is required because the plugin ships helper scripts.

## Notes for reviewers

No MCP servers, hooks, or lifecycle scripts. Skills never auto-invoke. Keywords are scoped to this plugin (`grok-consult`, `claude-consult`, `codex-consult`, `cursor-consult`, `ask claude`, `ask codex`, `ask cursor`) so the CTA should not fire on generic Claude/Codex/Cursor chat.