### PR TITLE
Add Eryx MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -268,6 +268,19 @@
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
     {
+      "name": "eryx",
+      "description": "Connect Grok Build to an authorized Eryx B2B lead-discovery workspace. Inspect projects, ranked leads, discovery runs, usage, and remaining credits through a hosted MCP server with OAuth.",
+      "category": "sales",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/novolgit/eryx-mcp-plugin.git",
+        "sha": "536ea7bed8de5ab409d462645e539513515d3813"
+      },
+      "homepage": "https://eryx.digital",
+      "keywords": ["eryx", "eryx b2b leads", "eryx lead discovery"],
+      "domains": ["eryx.digital"]
+    },
+    {
       "name": "browser-use",
       "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,18 @@
         ]
       }
     },
+    "eryx": {
+      "sha": "536ea7bed8de5ab409d462645e539513515d3813",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "eryx",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: Eryx
- Type: remote source
- Source URL + pinned SHA: https://github.com/novolgit/eryx-mcp-plugin.git @ 536ea7bed8de5ab409d462645e539513515d3813
- Homepage: https://eryx.digital

Adds the first-party Eryx remote MCP plugin. It connects Grok Build to an authorized Eryx B2B lead-discovery workspace through the hosted Streamable HTTP MCP endpoint.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official GitHub organization.

Eryx and the source repository are operated by novolgit, the GitHub organization that maintains the Eryx product.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a valid kebab-case name.
- [x] The remote source pins a public, reachable, full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the source repo includes a README and `.grok-plugin/plugin.json`.
- [x] The MIT license is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] The plugin contains no hooks or shell execution; MCP scope is limited to the declared remote server.
- Network endpoint: `https://eryx-mcp.groundforr.workers.dev/mcp`, used only for the Eryx Streamable HTTP MCP connection.
- Credentials/permissions: OAuth 2.1 with PKCE authorizes access to one user-selected Eryx workspace. No credentials are embedded in the plugin.

## Notes for reviewers

The plugin package is intentionally minimal: manifests, remote MCP configuration, documentation, logo, and MIT license only. Starting a discovery run consumes Eryx credits, and sending prepared outreach changes external state; both behaviors are disclosed in the README.
