### PR TITLE
Add openzoo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "openzoo",
+      "description": "Pay-per-call access to 1,100+ models with no account and no API key, plus holographic memory: bind a corpus once and answer from it by retrieval instead of re-sending it every turn. The demo tier is sponsored, so it works on a fresh install with no wallet.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/staccDOTsol/openzoo-grok-plugin.git",
+        "sha": "851c9e53b6b733e345452d58eec06c3d0afc42dc"
+      },
+      "homepage": "https://openzoo.fun",
+      "keywords": ["openzoo", "openzoo.fun", "lecore"],
+      "domains": ["openzoo.fun", "chat.openzoo.fun", "mcp.openzoo.fun"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,65 @@
         ]
       }
     },
+    "openzoo": {
+      "sha": "851c9e53b6b733e345452d58eec06c3d0afc42dc",
+      "version": "0.1.0",
+      "components": {
+        "agents": [
+          {
+            "name": "corpus-analyst",
+            "description": "Interrogates a large corpus through openzoo — a repo, a book, a chat export, months of logs — by binding it once and as…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "ask",
+            "description": "Ask a question against a bound corpus, or route one question to a different model. Pass the question; add a model id to…"
+          },
+          {
+            "name": "bind",
+            "description": "Bind a file, directory, or pasted text to openzoo once so later questions answer from retrieval instead of re-reading i…"
+          },
+          {
+            "name": "cost",
+            "description": "Show what openzoo calls in this session actually cost, and what the same calls would have cost sent direct. Price a cal…"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Read|Grep|Glob|WebFetch|NotebookRead|Bash"
+          },
+          {
+            "name": "SessionStart",
+            "description": "startup|resume|clear|compact"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "openzoo",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "openzoo-ask",
+            "description": "Call any of 1,100+ text models through one OpenAI-compatible endpoint with no account, no API key and no subscription.…"
+          },
+          {
+            "name": "openzoo-bind",
+            "description": "Send a corpus too large for the context window to openzoo once, then answer from it by retrieval instead of re-uploadin…"
+          },
+          {
+            "name": "openzoo-memory",
+            "description": "Write durable facts about the user to openzoo so they survive between sessions, and read them back later. Free, no acco…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds **openzoo**: holographic memory plus pay-per-call access to 1,100+ models, with no account and no API key.

- Plugin name: `openzoo`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/staccDOTsol/openzoo-grok-plugin.git` @ `851c9e53b6b733e345452d58eec06c3d0afc42dc`
- Homepage: https://openzoo.fun

**Components:** 3 skills (`openzoo-ask`, `openzoo-bind`, `openzoo-memory`), 3 commands (`bind`, `ask`, `cost`), 1 agent (`corpus-analyst`), 1 remote HTTP MCP server, 3 hooks (`SessionStart`, `UserPromptSubmit`, `PostToolUse`), and a vendored local daemon under `lecore/`.

**Works on a fresh install with nothing configured.** Bind, memory and the model catalog are free and unauthenticated, and `zoo_ask` through the MCP server is sponsored — settled on chain from a house wallet we fund, so a clone gets real answers on the first try. Verified on mainnet; a sponsored ask returns the answer plus a settlement signature you can look up.

The sponsored tier is limited by use rather than budget: 6 calls/min, 40/hour, 200/day per client, with a $0.02 per-call ceiling. Exceeding a window returns a plain-English cooldown, never a hard error. There is deliberately no shared daily pot, so no one caller can exhaust the demo for everyone else. A `wallet_id` from `zoo_wallet` lifts every limit and bills the caller's own wallet instead.

**What the hooks do, and where the data goes.** They give the agent ambient memory: what it reads is bound in a detached background process, and the relevant slice is retrieved and injected on the next prompt, so it stops re-reading files it has already seen. All of that talks to `127.0.0.1:8787` by default — the daemon vendored in this plugin. Nothing an agent reads leaves the machine. Egress is one explicit env var (`OPENZOO_ENDPOINT`), the injected context always states which mode it is in, and `OPENZOO_AMBIENT=0` disables the automatic behaviour while keeping the tools.

Measured: a 402,197-character corpus bound free, then a question-only ask read 491 tokens and cost $0.000731 against $0.011648 sending the same call direct.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (explained below).

I'm the author and operator of openzoo.fun, so first-party ownership holds — but the source lives on my personal account (`staccDOTsol`). `github.com/OpenZoo` is already held by an unrelated project. If you'd like this under a dedicated org before merge, say the word and I'll create one and re-pin.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated. MIT, in the plugin repo and its `plugin.json`.

## Security

- [x] No `curl | bash`, no remote code download/exec, no `postinstall`. **Nothing is fetched or installed at runtime.**
- [x] No reading or exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Please read this section rather than trusting the checkboxes — this plugin ships both hooks and vendored code, and I would rather flag both than have you find them.**

**`lecore/` is a vendored daemon: 2,738 lines of Python, source, in the repo, pinned by the SHA above and reviewable in the diff.** It is the local memory store. The plugin starts it, restarts it if it dies, and backs off if it cannot. It is vendored precisely *so that* nothing is downloaded at runtime — I considered `pip install` from a hook and rejected it as exactly the download-and-execute pattern CONTRIBUTING warns about. Its dependencies are Python 3 and numpy and nothing else, verified by running it with `torch`, `leCore` and `sentence_transformers` all absent. If either is missing the plugin fails open with no ambient memory and installs nothing.

**The `PostToolUse` hook reads tool results and writes them to `127.0.0.1:8787`** — the vendored daemon on the user's own machine. That default is the reason auto-binding is defensible at all; a hook that POSTed a user's repo to a remote service would deserve rejection. It spawns a detached worker and returns in ~0.1s. `UserPromptSubmit` retrieves and injects, bounded at 4s, failing open. `SessionStart` prints a fixed string and starts the daemon. No shell, no eval, no obfuscation; every hook is short and readable.

**Network endpoints:**

| Endpoint | Why |
|---|---|
| `http://127.0.0.1:8787` | The vendored local daemon. Default for all memory traffic. |
| `https://mcp.openzoo.fun/mcp` | The MCP server this plugin configures |
| `https://x402-tokens.fly.dev/v1/models` | Model catalog (read-only, unauthenticated) |
| `https://x402-tokens.fly.dev/v1/hrr/bind`, `/v1/hrr/recall` | Hosted memory — only if `OPENZOO_ENDPOINT` is set to it |
| `https://x402-tokens.fly.dev/v1/chat/completions` | Inference |

**Credentials required: none.** openzoo has no API key and no account; payment is x402, settled on chain per request. Inference is the only thing that always leaves the machine, and only when a model is actually asked something — never as a side effect of opening a file.

The `openzoo-memory` skill writes user-supplied facts to a remote service. That is its purpose, it is stated in the skill and the README, and the skill instructs against storing credentials or unshared personal data.

## Notes for reviewers

An earlier revision of this description said "no hooks, no scripts". That was accurate when written and is not accurate now — the plugin gained hooks and the vendored daemon after it was posted, and this body has been rewritten to match the pinned SHA. Flagging it explicitly so the discrepancy is not something you have to discover.

Heads up on one thing I hit while testing: grok CLI 1.0.5 logs `has_hooks=true` for this plugin and then `hooks: discovery complete total_hooks=0`, with `error_count=0`. The same is true of vercel's plugin hooks in the same run, so plugin-provided hooks appear not to be loaded yet on that host. `hooks/INSTALL-GROK.md` documents registering them via `~/.claude/settings.json` in the meantime. Everything else — MCP tools, skills, commands, agent — works from the plugin alone.