### PR TITLE
Add context-cliff-plug

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "context-cliff-plug",
+      "description": "Context-window fill bar for Grok Bot and Grok Build. Warns at 40% (the 200k long-context rate cliff), then every 10%, and estimates $ saved if you hand off to a new session.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mmelnychuk/jobby-bot.git",
+        "sha": "2044a3fbbedf84233401329033ec12664a2c650b"
+      },
+      "homepage": "https://github.com/mmelnychuk/jobby-bot",
+      "keywords": ["context-cliff-plug", "context-cliff", "jobby-bot"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,39 @@
         ]
       }
     },
+    "context-cliff-plug": {
+      "sha": "2044a3fbbedf84233401329033ec12664a2c650b",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "context-meter",
+            "description": "Show the current context fill bar and estimated $ save from handing off."
+          },
+          {
+            "name": "handoff",
+            "description": "Draft a short handoff summary so the user can start a new session under the 200k cliff."
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PreCompact"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "context-meter",
+            "description": "Use when context fill, token cost, the 200k rate cliff, or a session handoff comes up. Show the bar and estimated savin…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `context-cliff-plug`
- Type: remote source
- Source URL + pinned SHA: https://github.com/mmelnychuk/jobby-bot.git @ `2044a3fbbedf84233401329033ec12664a2c650b`
- Homepage: https://github.com/mmelnychuk/jobby-bot

Context-window fill bar for Grok Bot and Grok Build. Warns at 40% (the 200k long-context rate cliff), then every 10%, and estimates $ saved if you hand off to a new session. optional hand-off and respawn. dramatic token burn decrease.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

Source is my personal GitHub account (`mmelnychuk/jobby-bot`). I am the author (Michael Melnychuk). There is no separate org yet.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT. Manifest at `.grok-plugin/plugin.json`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none. Local Python scripts only.
- Credentials/permissions it requires (and why): none.

## Notes for reviewers

Author-maintained plugin. No MCP servers. Hooks run `scripts/meter.py` on Stop / UserPromptSubmit / PreCompact. Optional Tk HUD is Grok Bot-only and is not required for Grok Build install.