### PR TITLE
feat(plugins): add Frasma remote MCP Kanban plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "frasma",
+      "description": "Frasma Kanban as the source of truth. Remote MCP with OAuth so Grok Build shares the same backlog as the Frasma web app. Sign in with your Frasma account on first connect.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/francemazzi/frasma-plugin.git",
+        "sha": "5714814670b86668bc778d5e1a66f800681dc2dd"
+      },
+      "homepage": "https://frasma.org",
+      "keywords": ["frasma", "frasma kanban", "frasma mcp"],
+      "domains": ["frasma.org", "app.frasma.org", "api.frasma.org"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,24 @@
         ]
       }
     },
+    "frasma": {
+      "sha": "5714814670b86668bc778d5e1a66f800681dc2dd",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "frasma",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "frasma-kanban",
+            "description": "Use the Frasma Kanban as the source of truth for project work. Apply when analyzing a project, creating or updating tas…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `frasma`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/francemazzi/frasma-plugin.git` @ `5714814670b86668bc778d5e1a66f800681dc2dd`
- Homepage: https://frasma.org

Adds a Grok Build catalog entry for Frasma. The plugin is MIT markdown + `mcp.json` pointing at the hosted Streamable HTTP MCP `https://api.frasma.org/mcp`. Users sign in with their Frasma account (OAuth 2.1 + DCR). No stdio, no binaries, no secrets in the plugin repo.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

There is no `frasma` GitHub organization yet. The product and plugin are published from my personal account (`francemazzi`), which is the Frasma owner account.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://api.frasma.org/mcp` (Kanban MCP) and Frasma OAuth well-known / authorize / token / register / revoke on `https://api.frasma.org`.
- Credentials/permissions it requires (and why): OAuth login as the Frasma user so tools inherit existing RBAC. No API keys in the plugin package.

## Notes for reviewers

Plugin package: https://github.com/francemazzi/frasma-plugin (MIT). The Frasma API itself is a separate product and is not vendored here.

Made with [Cursor](https://cursor.com)