### PR TITLE
Add openzoo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -268,6 +268,27 @@
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
     {
+      "name": "openzoo",
+      "description": "Holographic memory for your agent — bind a repo, book, or log dump once and answer from it by retrieval instead of re-reading it every turn — plus pay-per-call access to 1,100+ models outside the Grok family, including image and video. Local by default: memory runs on 127.0.0.1 unless you opt in. No account, no API key; calls settle per request over x402.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/staccDOTsol/openzoo-grok-plugin.git",
+        "sha": "b211215b9ed0870824003cc3b17b977a0bdd1959"
+      },
+      "homepage": "https://openzoo.fun",
+      "keywords": [
+        "openzoo",
+        "openzoo.fun",
+        "lecore",
+        "x402"
+      ],
+      "domains": [
+        "openzoo.fun",
+        "mcp.openzoo.fun"
+      ]
+    },
+    {
       "name": "browser-use",
       "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,65 @@
         ]
       }
     },
+    "openzoo": {
+      "sha": "b211215b9ed0870824003cc3b17b977a0bdd1959",
+      "version": "0.1.0",
+      "components": {
+        "agents": [
+          {
+            "name": "corpus-analyst",
+            "description": "Interrogates a large corpus through openzoo — a repo, a book, a chat export, months of logs — by binding it once and as…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "ask",
+            "description": "Ask a question against a bound corpus, or route one question to a different model. Pass the question; add a model id to…"
+          },
+          {
+            "name": "bind",
+            "description": "Bind a file, directory, or pasted text to openzoo once so later questions answer from retrieval instead of re-reading i…"
+          },
+          {
+            "name": "cost",
+            "description": "Show what openzoo calls in this session actually cost, and what the same calls would have cost sent direct. Price a cal…"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Read|Grep|Glob|WebFetch|NotebookRead|Bash"
+          },
+          {
+            "name": "SessionStart",
+            "description": "startup|resume|clear|compact"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "openzoo",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "openzoo-ask",
+            "description": "Reach 1,100+ models outside the Grok family — plus image and video generation — through one endpoint, with no account a…"
+          },
+          {
+            "name": "openzoo-bind",
+            "description": "Send a corpus too large for the context window to openzoo once, then answer from it by retrieval instead of re-uploadin…"
+          },
+          {
+            "name": "openzoo-memory",
+            "description": "Write durable facts about the user to openzoo so they survive between sessions, and read them back later. Free, no acco…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds **openzoo**: holographic memory for a Grok Build agent, plus access to models outside the Grok family.

- Plugin name: `openzoo`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/staccDOTsol/openzoo-grok-plugin.git` @ `b211215b9ed0870824003cc3b17b977a0bdd1959`
- Homepage: https://openzoo.fun

**Memory.** Hand the agent a repo, a book, a chat export, months of logs. It binds the whole thing once and answers by retrieval, instead of carrying the text in context and re-reading it every turn. Measured on the live service: a **402,197-character** corpus bound free, then a question-only ask read **491 tokens** and cost **$0.000731** against **$0.011648** sending the same call to the provider direct.

**Reach.** `zoo_ask` covers 1,100+ text models plus image and video generation through one endpoint — useful when a task wants a specific non-Grok model, or a cheap one for a bulk pass. It sits alongside the Grok models, not in front of them.

**Works on a fresh install with nothing configured.** Binding, memory and the model catalog are free and unauthenticated, and `zoo_ask` through the MCP server is sponsored — settled on chain from a house wallet we fund — so a clone gets real answers on the first try. The sponsored tier is limited by use rather than budget: 6 calls/min, 40/hour, 200/day per client with a $0.02 per-call ceiling. Exceeding a window returns a plain-English cooldown, never a hard error. There is deliberately no shared daily pot, so no one caller can exhaust the demo for everyone else.

**Components:** 3 skills (`openzoo-ask`, `openzoo-bind`, `openzoo-memory`), 3 commands (`bind`, `ask`, `cost`), 1 agent (`corpus-analyst`), 1 remote HTTP MCP server, 3 hooks (`SessionStart`, `UserPromptSubmit`, `PostToolUse`), and a vendored memory daemon under `lecore/`.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage`, `category` and a clear `description` set; `keywords`/`domains` are brand-scoped.
- [x] License stated. MIT, in the plugin repo and its `plugin.json`.
- [x] Diff is additions only — 80 insertions, 0 deletions, no other entry touched.

## Security

**This plugin ships hooks and vendored code. Please read this section rather than trusting the checkboxes — I would rather flag both than have you find them.**

**`lecore/` is a vendored daemon: 2,738 lines of Python, source, in the repo, pinned by the SHA above and reviewable in the diff.** It is the local memory store. The plugin starts it, restarts it if it dies, and backs off if it cannot. It is vendored *precisely so that* nothing is downloaded at runtime — I considered installing it from a hook and rejected that as the download-and-execute pattern CONTRIBUTING warns about. Its dependencies are Python 3 and numpy and nothing else, verified by running it with `torch`, `leCore` and `sentence_transformers` all absent. If either is missing the plugin fails open with no ambient memory and installs nothing.

**The `PostToolUse` hook reads tool results and writes them to `127.0.0.1:8787`** — that vendored daemon, on the user's own machine. That default is the reason automatic binding is defensible at all; a hook that POSTed a user's repo to a remote service would deserve rejection. It spawns a detached worker and returns in ~0.1s. `UserPromptSubmit` retrieves and injects, bounded at 4s, failing open. `SessionStart` prints a fixed string. No shell anywhere in `hooks/`, no eval, no obfuscation; every hook is short and readable.

Egress is one explicit environment variable (`OPENZOO_ENDPOINT`), the injected context always states which mode it is in, and `OPENZOO_AMBIENT=0` disables the automatic behaviour while keeping the tools.

**Network endpoints:**

| Endpoint | Why |
|---|---|
| `http://127.0.0.1:8787` | The vendored local daemon. Default for all memory traffic. |
| `https://mcp.openzoo.fun/mcp` | The MCP server this plugin configures |
| `https://x402-tokens.fly.dev/v1/models` | Model catalog (read-only, unauthenticated) |
| `https://x402-tokens.fly.dev/v1/hrr/bind`, `/v1/hrr/recall` | Hosted memory — only if `OPENZOO_ENDPOINT` is set to it |
| `https://x402-tokens.fly.dev/v1/chat/completions` | Inference |

**Credentials required: none.** There is no API key and no account; payment is x402, settled on chain per request. The plugin reads no environment variables belonging to anything else, no `.env`, no `~/.ssh`. Inference is the only thing that always leaves the machine, and only when a model is actually asked something — never as a side effect of opening a file.

The `openzoo-memory` skill writes user-supplied facts to a remote service. That is its stated purpose, and the skill instructs against storing credentials or unshared personal data.

## Ownership

I'm the author and operator of openzoo.fun, so first-party ownership holds — but the source lives on my personal account (`staccDOTsol`) because `github.com/OpenZoo` is held by an unrelated project. If you'd like this under a dedicated org before merge, say the word and I'll create one and re-pin.

## Notes for reviewers

Heads up on something I hit while testing: grok CLI 1.0.5 logs `has_hooks=true` for this plugin and then `hooks: discovery complete total_hooks=0`, with `error_count=0`. The same is true of vercel's plugin hooks in the same run, so plugin-provided hooks appear not to be loaded on that host yet. `hooks/INSTALL-GROK.md` documents registering them via settings in the meantime. Everything else — MCP tools, skills, commands, agent — works from the plugin alone, and the hooks work as written in hosts that do load them.