### PR TITLE
Add ClickFlow plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "clickflow",
+      "description": "SEO and content-marketing automation via ClickFlow's hosted MCP server. Research keywords, plan and draft brand-aligned content, publish to WordPress/Webflow/Shopify/HubSpot/Sanity/Strapi, find and fix decaying pages, and measure results from Search Console and AI-assistant visibility.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/singlegrain/clickflow-grok-plugin.git",
+        "sha": "fab4d0b34b36e618285a8b795f95a4d71becc538"
+      },
+      "homepage": "https://www.clickflow.com",
+      "keywords": ["clickflow", "clickflow seo", "clickflow mcp", "clickflow content"],
+      "domains": ["clickflow.com", "www.clickflow.com", "app.clickflow.com", "docs.clickflow.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -143,6 +143,36 @@
         ]
       }
     },
+    "clickflow": {
+      "sha": "fab4d0b34b36e618285a8b795f95a4d71becc538",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "clickflow",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "clickflow-ai-visibility",
+            "description": "Measure and improve how a brand shows up inside AI assistants — position versus competitors in ChatGPT and Perplexity,…"
+          },
+          {
+            "name": "clickflow-content-pipeline",
+            "description": "Take a keyword or a content idea through ClickFlow end to end — validate search intent and competition, create a roadma…"
+          },
+          {
+            "name": "clickflow-decay-loop",
+            "description": "Run ClickFlow's content-decay refresh loop from your own AI agent. Weekly, it reads back due refreshes (7/14/30-day GSC…"
+          },
+          {
+            "name": "clickflow-seo",
+            "description": "Orientation for working with a ClickFlow SEO workspace over MCP — connect, select the right organization, and find the…"
+          }
+        ]
+      }
+    },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds ClickFlow to the catalog. ClickFlow is an SEO and content-marketing platform; the plugin
connects Grok Build to our hosted MCP server so an agent can research keywords, plan and draft
content, publish to a CMS, and measure results from Search Console and AI-assistant visibility.

- Plugin name: `clickflow`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/singlegrain/clickflow-grok-plugin.git` @ `fab4d0b34b36e618285a8b795f95a4d71becc538`
- Homepage: https://www.clickflow.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

ClickFlow is a product of **Single Grain**, and the plugin is published under our official
`singlegrain` GitHub org — the same org that holds the ClickFlow application itself. The org name
differs from the product name because Single Grain is the parent company; `github.com/clickflow` is
an unrelated third party's personal account, not ours. See "Notes for reviewers" for how to verify.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The plugin repo ships `.grok-plugin/plugin.json`, `.mcp.json`, `README.md`, `LICENSE` (MIT), and
four skills. It is remote-sourced, so nothing is vendored here.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin contains **no hooks, no commands, no agents, no scripts, and no install steps**. It is a
single remote MCP server declaration plus four Markdown skills. Nothing executes locally.

**Network endpoints this plugin calls (and why):**

| Host | Why |
|---|---|
| `api.clickflow.com` | The MCP server itself, and its OAuth protected-resource metadata |
| `clerk.clickflow.com` | OAuth 2.1 authorization server: dynamic client registration, authorize, token, JWKS |

Both are operated by us. No third-party endpoints, no telemetry.

**Credentials/permissions it requires (and why):**

OAuth 2.1, issued by our Clerk tenant, discovered per spec — no client credentials are embedded in
the repo:

1. Unauthenticated `POST https://api.clickflow.com/v1/mcp` → `401` with
   `WWW-Authenticate: Bearer resource_metadata="https://api.clickflow.com/.well-known/oauth-protected-resource/v1/mcp"`
2. That metadata names the authorization server: `https://clerk.clickflow.com`
3. The client registers dynamically (RFC 7591) at `https://clerk.clickflow.com/oauth/register` and
   completes an authorization-code flow with PKCE `S256`

Scopes: `openid`, `profile`, `email`, `offline_access`. A token authorizes only that user's own
ClickFlow organizations; every tool call is scoped server-side to the organization the user has
selected. For headless/scheduled use the server also accepts a user-generated `cf_ak_` API key as a
bearer token, since interactive OAuth can't complete without a browser.

The server exposes 51 tools. Read-only tools carry `readOnlyHint`; the two destructive ones
(`platform_unpublish_page`, `platform_revert_internal_links`) carry `destructiveHint` so a client can
gate them. Because content generation spends real quota and publishing changes a live website, the
skills enforce human gates rather than leaving them to the model: drafts by default, publishing only
on explicit approval, and deletions/redirects/`noindex`/consolidations recommended but never executed.

## Notes for reviewers

**On the org/brand difference.** ClickFlow is built and operated by Single Grain, so the plugin is
sourced from `singlegrain/clickflow-grok-plugin` rather than a `clickflow` org. Verifiable at a
glance: the plugin repo is public under our org, `.grok-plugin/plugin.json` names Single Grain as
author, the MCP endpoint and OAuth issuer are both on `clickflow.com` subdomains we control, and
`docs.clickflow.com` links to the plugin repo.

**Components** (matches `plugin-index.json`): 1 MCP server (`clickflow`, http) and 4 skills —
`clickflow-seo` (orientation: connect, select an org, the read/write split and approval gates),
`clickflow-content-pipeline` (keyword → draft → review → CMS publish),
`clickflow-decay-loop` (a standing weekly find-fix-measure loop over Search Console data),
`clickflow-ai-visibility` (brand position inside ChatGPT/Perplexity, plus GA4 AI-referred traffic).

**Keywords/domains** are deliberately brand-scoped — `clickflow`, `clickflow seo`, `clickflow mcp`,
`clickflow content`, and only domains we own — so the install CTA doesn't fire on generic SEO or
content-marketing requests.

Happy to answer anything or adjust scope.
