### PR TITLE
Add rendemo — interactive product demos, sandbox demos, and in-app tours

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "rendemo",
+      "description": "Rendemo interactive product demos. Polish and publish demos recorded with the Rendemo extension, turn any website into a hosted click-through sandbox demo, and build interactive product tours that run inside your own live app — all through Rendemo's MCP server.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/jakegrepo/rendemo-plugin.git",
+        "sha": "2ee03a6f2ca4126f334fac30f7c75b9c8a8056a8"
+      },
+      "homepage": "https://www.rendemo.com",
+      "keywords": ["rendemo", "rendemo demo", "interactive product demo", "product tour"],
+      "domains": ["rendemo.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -741,6 +741,40 @@
         ]
       }
     },
+    "rendemo": {
+      "sha": "2ee03a6f2ca4126f334fac30f7c75b9c8a8056a8",
+      "version": "1.2.0",
+      "components": {
+        "commands": [
+          {
+            "name": "demo",
+            "description": "Install a published Rendemo demo on this site"
+          },
+          {
+            "name": "start",
+            "description": "Start here — choose a recorded demo, sandbox demo, or codebase tour"
+          },
+          {
+            "name": "tour",
+            "description": "Author or edit a codebase tour anchored to markers in this repo"
+          }
+        ],
+        "skills": [
+          {
+            "name": "author-a-tour",
+            "description": "Use when the user asks to create or change a CODEBASE TOUR inside their own live product, or mentions data-rendemo mark…"
+          },
+          {
+            "name": "embed-a-demo",
+            "description": "This skill should be used when the user asks to \"embed a demo\", \"add our demo to the pricing page\", \"install a Rendemo…"
+          },
+          {
+            "name": "sandbox-demos",
+            "description": "This skill should be used when creating or editing a SANDBOX DEMO — a hosted, autoplayable demo built from a site Rende…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
       "version": "1.3.2",


### PR DESCRIPTION
## What this PR does

Adds the Rendemo plugin as a remote-source catalog entry.

- Plugin name: `rendemo`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/jakegrepo/rendemo-plugin.git` @ `2ee03a6f2ca4126f334fac30f7c75b9c8a8056a8` (tag `v1.2.0`)
- Homepage: https://www.rendemo.com

Rendemo turns product recordings into interactive demos: polish and publish demos recorded with the Rendemo browser extension, turn any website into a hosted click-through sandbox demo, and build interactive product tours that run inside your own live app. The plugin wraps Rendemo's MCP server (three slash-command workflows + three skills) so you state an intent instead of picking tools.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Rendemo is a solo-founder company and `jakegrepo` is the founder's account — the same account that publishes the `rendemo-plugin` npm package and operates rendemo.com (the plugin's `.mcp.json` points at rendemo.com's MCP endpoint, and rendemo.com's plugin docs point back at this repo). Happy to verify ownership any way that helps.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT — LICENSE at the repo root; the repo also ships both `.grok-plugin/plugin.json` and `.claude-plugin/plugin.json` manifests.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.

The plugin is documentation-only plus one MCP server declaration: markdown commands/skills and an OAuth-only HTTP MCP entry (`https://www.rendemo.com/api/mcp/mcp`) with no credentials, no helper scripts, no hooks, and no executable code in the plugin at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)