### PR TITLE
Add thin-grok-bot-deep-work-on-cli — keep Grok Bot thin, hand deep work to CLI

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "thin-grok-bot-deep-work-on-cli",
+      "description": "Keep Grok Bot as a teammate mesh. Hand deep builds and investigations to Cursor CLI, Cursor cloud agents, or grok CLI so the work spends plan-pool credits and uses subtree agents.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Luca-Blight/thin-grok-bot-deep-work-on-cli.git",
+        "sha": "bff05f6a28199a19eae2590f092cf2d939934ad5"
+      },
+      "homepage": "https://github.com/Luca-Blight/thin-grok-bot-deep-work-on-cli",
+      "keywords": ["thin-grok-bot", "thin grok bot", "grok-bot", "thin-grok-bot-deep-work-on-cli"],
+      "author": "Zachary Royals"
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -965,6 +965,17 @@
         ]
       }
     },
+    "thin-grok-bot-deep-work-on-cli": {
+      "sha": "bff05f6a28199a19eae2590f092cf2d939934ad5",
+      "components": {
+        "skills": [
+          {
+            "name": "thin-grok-bot-deep-work-on-cli",
+            "description": "Use this when handing off any non-trivial build, investigation, or deep reasoning from Grok Bot. Keep the Bot mesh thin…"
+          }
+        ]
+      }
+    },
     "tinyfish": {
       "sha": "89457fba3fa44c7b2227807948628011983ab668",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary

- Add one remote catalog entry for `thin-grok-bot-deep-work-on-cli`, a personal Grok Bot skill plugin.
- Source is the public repo https://github.com/Luca-Blight/thin-grok-bot-deep-work-on-cli, pinned to full commit `bff05f6a28199a19eae2590f092cf2d939934ad5` (logo + single-line skill description; that SHA is on public branch `fix-skill-description-yaml` after PR #1 — main has the description merge but not the logo yet).
- Regenerated `.grok-plugin/plugin-index.json` via `python3 scripts/generate-plugin-index.py`. Index lists one skill: `thin-grok-bot-deep-work-on-cli`.

Nothing is vendored under `external_plugins/`. Plugin files live in the upstream repo.

## Why

Grok Bot is a teammate mesh. This skill tells the Bot to stay thin and hand deep builds or investigations to Cursor CLI, Cursor cloud agents, or grok CLI so the work spends plan-pool credits and uses subtree agents.

## Files changed

| File | Change |
|------|--------|
| `.grok-plugin/marketplace.json` | Adds `thin-grok-bot-deep-work-on-cli` with remote source and pinned SHA |
| `.grok-plugin/plugin-index.json` | Regenerated — lists the one skill discovered from the pinned commit |

## Security and compliance

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the plugin itself. Skills-only: no hooks, no MCP, no LSP, no scripts. The SKILL.md documents the official grok CLI install (`curl -fsSL https://x.ai/cli/install.sh`) as a one-time user setup on the Bot computer; the plugin does not run it.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (none).
- Network endpoints this plugin calls (and why): none. Skill text refers users to the official grok CLI installer on x.ai and to Cursor cloud agents.
- Credentials/permissions it requires (and why): none from the plugin. Users who follow the skill's setup run `grok login --device-auth` themselves.

- **SHA pinning:** full 40-character lowercase commit `bff05f6a28199a19eae2590f092cf2d939934ad5`, public and reachable.
- **MIT license** in the upstream repo.
- **Author:** Zachary Royals (`Luca-Blight`). Personal Grok Bot skill, not an org product.

## Local validation (pre-PR)

```
python3 scripts/generate-plugin-index.py
python3 scripts/validate-catalog.py
python3 scripts/generate-plugin-index.py --check
```

Results:

- [x] `validate-catalog.py` passed (`Catalog OK`)
- [x] `generate-plugin-index.py --check` passed (`Plugin index OK`)

## Checklist

- [x] Plugin ID is kebab-case (`thin-grok-bot-deep-work-on-cli`) and unique
- [x] Remote source with full 40-char lowercase SHA
- [x] `plugin-index.json` regenerated (not hand-edited)
- [x] Homepage + description; brand-scoped keywords (no generic CTA terms)
- [x] Upstream repo is public and reachable at the pinned commit

## Notes for reviewers

The upstream plugin ships Cursor-style `plugin.json` at the repo root and `.cursor-plugin/plugin.json`. It does not have `.grok-plugin/plugin.json` or `.claude-plugin/plugin.json`. Per `scripts/plugin_catalog.py`, those grok/claude manifests are optional for remote sources: `load_manifest` returns `{}` and skills are still discovered from `skills/*/SKILL.md`. Version is omitted from the generated index for that reason. CONTRIBUTING requires a grok/claude manifest for **local** (vendored) plugins only.