### PR TITLE
Add mcp-oauth-connect

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,11 +288,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/GFB2026/mcp-oauth-connect.git",
-        "sha": "5c0ae7b5d60d49338e7d4bff5e159c4bccc640ec"
+        "sha": "5b0842b9929cbb6320d977c23dc123eec0b03126"
       },
-      "homepage": "https://gregfredabytes.com/mcp-oauth-connect",
+      "homepage": "https://gfbytes.com/mcp-oauth-connect/",
       "keywords": ["mcp-oauth-connect", "gregfredabytes", "gfb mcp oauth"],
-      "domains": ["gregfredabytes.com"]
+      "domains": ["gfbytes.com", "www.gfbytes.com", "mcp.gfbytes.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "mcp-oauth-connect",
+      "description": "Diagnose MCP OAuth 2.0 so claude.ai, Claude Desktop, Cursor, and Grok Connectors actually attach. Checks protected-resource metadata, S256 PKCE, POST /mcp, and absolute resource_metadata.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/GFB2026/mcp-oauth-connect.git",
+        "sha": "5c0ae7b5d60d49338e7d4bff5e159c4bccc640ec"
+      },
+      "homepage": "https://gregfredabytes.com/mcp-oauth-connect",
+      "keywords": ["mcp-oauth-connect", "gregfredabytes", "gfb mcp oauth"],
+      "domains": ["gregfredabytes.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,10 +288,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/GFB2026/mcp-oauth-connect.git",
-        "sha": "5b0842b9929cbb6320d977c23dc123eec0b03126"
+        "sha": "28a9e8a00f7fe64111a8df2fb0aea01ad5595642"
       },
-      "homepage": "https://gfbytes.com/mcp-oauth-connect/",
-      "keywords": ["mcp-oauth-connect", "gregfredabytes", "gfb mcp oauth"],
+      "homepage": "https://gfbytes.com/products/mcp-oauth-connect/",
+      "keywords": ["mcp-oauth-connect", "gfbytes", "gfb mcp oauth"],
       "domains": ["gfbytes.com", "www.gfbytes.com", "mcp.gfbytes.com"]
     }
   ]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,18 @@
         ]
       }
     },
+    "mcp-oauth-connect": {
+      "sha": "5c0ae7b5d60d49338e7d4bff5e159c4bccc640ec",
+      "version": "0.2.0",
+      "components": {
+        "skills": [
+          {
+            "name": "mcp-oauth-connect",
+            "description": "Diagnose MCP OAuth 2.0 so claude.ai Connectors, Claude Desktop, Cursor, and Grok can actually attach. Use when a connec…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,7 +346,7 @@
       }
     },
     "mcp-oauth-connect": {
-      "sha": "5b0842b9929cbb6320d977c23dc123eec0b03126",
+      "sha": "28a9e8a00f7fe64111a8df2fb0aea01ad5595642",
       "version": "0.2.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,7 +346,7 @@
       }
     },
     "mcp-oauth-connect": {
-      "sha": "5c0ae7b5d60d49338e7d4bff5e159c4bccc640ec",
+      "sha": "5b0842b9929cbb6320d977c23dc123eec0b03126",
       "version": "0.2.0",
       "components": {
         "skills": [


### PR DESCRIPTION
## What this PR does  - Plugin name: mcp-oauth-connect - Type: remote source - Source URL + pinned SHA: https://github.com/GFB2026/mcp-oauth-connect.git @ 28a9e8a00f7fe64111a8df2fb0aea01ad5595642 - Homepage: https://gfbytes.com/products/mcp-oauth-connect/  Diagnose skill for MCP OAuth 2.0 / DCR so claude.ai Connectors, Claude Desktop, Cursor, and Grok actually attach. Stdlib probe (PRM, S256, POST /mcp, absolute resource_metadata, no cross-host 3xx). Ping-only template in the source repo; no host-shell MCP.  ## Ownership  - [x] I own this plugin or have the right to distribute it. - [x] The source repo is published under GFB2026 (GregFredaBytes product GitHub user ΓÇö there is not a separate GitHub Organization yet).  ## Checklist  - [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`). - [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable. - [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`). - [x] `python3 scripts/validate-catalog.py` passes locally. - [x] `python3 scripts/generate-plugin-index.py --check` passes locally. - [x] `homepage` + clear `description` set. - [x] License is stated (MIT for the plugin/skill; template/ is separately licensed and is not the Marketplace install).  ## Security  - [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. - [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. - [x] Hooks and MCP scope are least-privilege (skill + diagnose script only; no plugin MCP server). - Network endpoints this plugin calls (and why): HTTPS to the MCP URL the operator passes to `diagnose.py` (authorization-server metadata, protected-resource metadata, GET/POST `/mcp`). No other hosts. - Credentials/permissions it requires (and why): none for diagnose. Optional buyer license key is env on their host, not collected by the plugin.  ## Notes for reviewers  Keywords are brand-scoped (`mcp-oauth-connect`, `gregfredabytes`, `gfb mcp oauth`) plus domain `gregfredabytes.com`. Template is ping-only. Cursor official Marketplace is not this PR.  Made with [Cursor](https://cursor.com)