### PR TITLE
Add bruin-plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "bruin",
-      "description": "Grok integration for Bruin — MetTel's Connectivity Management System for telecom expense, network monitoring, mobility, procurement, and IT ticketing across thousands of sites and 2,200+ vendors. Ships an expert Bruin Public API skill today (OAuth 2.0 client-credentials, ticket creation with per-product note schemas for Smart Phones, Cable, Ethernet, Business Line, Starlink, SD-WAN, and PIAB, inventory/site/user endpoints, ticket-lifecycle webhooks, and multi-call workflows), with an MCP server and additional capabilities on the roadmap.",
+      "description": "Grok integration for Bruin — MetTel's Connectivity Management System for telecom expense, network monitoring, mobility, procurement, and IT ticketing across thousands of sites and 2,200+ vendors. Ships an expert Bruin Public API skill: OAuth 2.0 client-credentials, ticket creation with per-product note schemas for Smart Phones, Cable, Ethernet, Business Line, Starlink, SD-WAN, and PIAB, inventory/site/user endpoints, ticket-lifecycle webhooks, and multi-call workflows.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/bruin-eng/agent-skills.git",
-        "sha": "479f8b49ef0f60c67ecf1a9166ff66ddc254e21d"
+        "sha": "8e1435ec45a9d1f1df8a89104b01112db0feaca2"
       },
       "homepage": "https://github.com/bruin-eng/agent-skills",
       "keywords": ["bruin", "bruin api", "mettel bruin", "bruin public api", "bruin ticket"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -282,13 +282,13 @@
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
     {
-      "name": "bruin-plugin",
+      "name": "bruin",
       "description": "Grok integration for Bruin — MetTel's Connectivity Management System for telecom expense, network monitoring, mobility, procurement, and IT ticketing across thousands of sites and 2,200+ vendors. Ships an expert Bruin Public API skill today (OAuth 2.0 client-credentials, ticket creation with per-product note schemas for Smart Phones, Cable, Ethernet, Business Line, Starlink, SD-WAN, and PIAB, inventory/site/user endpoints, ticket-lifecycle webhooks, and multi-call workflows), with an MCP server and additional capabilities on the roadmap.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/bruin-eng/agent-skills.git",
-        "sha": "8a2f19f2c6fb197b7531529137fe7ee7d7ce0dee"
+        "sha": "479f8b49ef0f60c67ecf1a9166ff66ddc254e21d"
       },
       "homepage": "https://github.com/bruin-eng/agent-skills",
       "keywords": ["bruin", "bruin api", "mettel bruin", "bruin public api", "bruin ticket"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "bruin-plugin",
+      "description": "Grok integration for Bruin — MetTel's Connectivity Management System for telecom expense, network monitoring, mobility, procurement, and IT ticketing across thousands of sites and 2,200+ vendors. Ships an expert Bruin Public API skill today (OAuth 2.0 client-credentials, ticket creation with per-product note schemas for Smart Phones, Cable, Ethernet, Business Line, Starlink, SD-WAN, and PIAB, inventory/site/user endpoints, ticket-lifecycle webhooks, and multi-call workflows), with an MCP server and additional capabilities on the roadmap.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/bruin-eng/agent-skills.git",
+        "sha": "8a2f19f2c6fb197b7531529137fe7ee7d7ce0dee"
+      },
+      "homepage": "https://github.com/bruin-eng/agent-skills",
+      "keywords": ["bruin", "bruin api", "mettel bruin", "bruin public api", "bruin ticket"],
+      "domains": ["bruin.com", "api.bruin.com", "apigw.bruin.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,8 +89,8 @@
         ]
       }
     },
-    "bruin-plugin": {
-      "sha": "8a2f19f2c6fb197b7531529137fe7ee7d7ce0dee",
+    "bruin": {
+      "sha": "479f8b49ef0f60c67ecf1a9166ff66ddc254e21d",
       "version": "1.0.0",
       "components": {
         "skills": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,18 @@
         ]
       }
     },
+    "bruin-plugin": {
+      "sha": "8a2f19f2c6fb197b7531529137fe7ee7d7ce0dee",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "bruin-api-integration",
+            "description": "Help a client build, debug, or extend an integration with the Bruin Public API — MetTel's REST API for tickets, invent…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -90,7 +90,7 @@
       }
     },
     "bruin": {
-      "sha": "479f8b49ef0f60c67ecf1a9166ff66ddc254e21d",
+      "sha": "8e1435ec45a9d1f1df8a89104b01112db0feaca2",
       "version": "1.0.0",
       "components": {
         "skills": [


### PR DESCRIPTION
Bruin is MetTel's Connectivity Management System (telecom, network, mobility, procurement, IT ticketing). This entry ships the Bruin Public API integration skill; MCP server and more capabilities are on the roadmap.

Source: https://github.com/bruin-eng/agent-skills

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name: bruin
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): Source: https://github.com/bruin-eng/agent-skills 8e1435ec45a9d1f1df8a89104b01112db0feaca2
- Homepage: https://github.com/bruin-eng/agent-skills

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
- Credentials/permissions it requires (and why):

## Notes for reviewers

<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->
