### PR TITLE
Add godmode to the catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "base44",
@@ -78,8 +100,17 @@
         "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
-      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
-      "domains": ["base44.com", "docs.base44.com"]
+      "keywords": [
+        "base44",
+        "base44 cli",
+        "base44 sdk",
+        "base44 app",
+        "base44 deploy"
+      ],
+      "domains": [
+        "base44.com",
+        "docs.base44.com"
+      ]
     },
     {
       "name": "mongodb",
@@ -92,8 +123,16 @@
         "path": "plugins/mongodb"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
-      "domains": ["mongodb.com"]
+      "keywords": [
+        "mongodb community",
+        "mongo",
+        "mongosh",
+        "mongodb local mcp",
+        "enterprise advanced"
+      ],
+      "domains": [
+        "mongodb.com"
+      ]
     },
     {
       "name": "mongodb-atlas",
@@ -106,8 +145,17 @@
         "path": "plugins/mongodb-atlas"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb atlas",
+        "atlas",
+        "mongodb",
+        "atlas cluster",
+        "atlas mcp"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -119,8 +167,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -131,8 +184,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "wix",
@@ -144,8 +206,18 @@
         "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
       },
       "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
-      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
+      "keywords": [
+        "wix",
+        "wix cli",
+        "wix mcp",
+        "wix apps",
+        "wix headless"
+      ],
+      "domains": [
+        "wix.com",
+        "dev.wix.com",
+        "manage.wix.com"
+      ]
     },
     {
       "name": "netlify",
@@ -157,12 +229,19 @@
         "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
       },
       "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
-      "domains": ["netlify.com", "app.netlify.com"]
+      "keywords": [
+        "netlify",
+        "netlify deploy",
+        "deploy to netlify"
+      ],
+      "domains": [
+        "netlify.com",
+        "app.netlify.com"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -170,8 +249,14 @@
         "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -183,8 +268,14 @@
         "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -196,8 +287,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -209,8 +308,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -223,8 +331,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -237,12 +352,22 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -251,8 +376,17 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
     },
     {
       "name": "pstack",
@@ -265,11 +399,15 @@
         "path": "pstack"
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": ["pstack", "poteto-mode", "poteto"]
+      "keywords": [
+        "pstack",
+        "poteto-mode",
+        "poteto"
+      ]
     },
     {
       "name": "browser-use",
-      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",
       "source": {
         "source": "url",
@@ -278,8 +416,31 @@
         "path": "grok"
       },
       "homepage": "https://browser-use.com",
-      "keywords": ["browser use", "browser-use", "browser use cloud"],
-      "domains": ["browser-use.com", "cloud.browser-use.com"]
+      "keywords": [
+        "browser use",
+        "browser-use",
+        "browser use cloud"
+      ],
+      "domains": [
+        "browser-use.com",
+        "cloud.browser-use.com"
+      ]
+    },
+    {
+      "name": "godmode",
+      "description": "A local, tamper-evident record of what a coding agent did, what it claimed, and what was verified. Hash-chained archive, honest claim grading, and a pre-tool gate that classifies every command before it runs.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/AIimagined/Godmode.git",
+        "sha": "1909cfa3cad1785b0d1d671b2d40952e02fad921"
+      },
+      "homepage": "https://github.com/AIimagined/Godmode",
+      "keywords": [
+        "godmode",
+        "godmode continuity",
+        "godmode governance"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -339,7 +339,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/AIimagined/Godmode.git",
-        "sha": "250508b7af01b229323cc5fe1f4550e470bafc85"
+        "sha": "47bb79a30ee4c00ccba83c1e8fc6af4fc615491e"
       },
       "homepage": "https://github.com/AIimagined/Godmode",
       "keywords": ["godmode", "godmode continuity", "godmode governance"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/AIimagined/Godmode.git",
-        "sha": "cbca7bdce4c480fa8b8766e36b8ab171504bd3d6"
+        "sha": "f22ae722e9beed2b34761fa3c41b2d243a4fd2c5"
       },
       "homepage": "https://github.com/AIimagined/Godmode",
       "keywords": ["godmode", "godmode continuity", "godmode governance"]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/AIimagined/Godmode.git",
-        "sha": "103ff20b06dc412303886c83dc6644d85f1f9c2f"
+        "sha": "cbca7bdce4c480fa8b8766e36b8ab171504bd3d6"
       },
       "homepage": "https://github.com/AIimagined/Godmode",
       "keywords": ["godmode", "godmode continuity", "godmode governance"]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,67 @@
         ]
       }
     },
+    "godmode": {
+      "sha": "1909cfa3cad1785b0d1d671b2d40952e02fad921",
+      "version": "0.3.3",
+      "components": {
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Write|Edit|MultiEdit|NotebookEdit|write|search_replace"
+          },
+          {
+            "name": "PreCompact"
+          },
+          {
+            "name": "PreToolUse",
+            "description": "Bash|PowerShell|Write|Edit|NotebookEdit|apply_patch|functions\\.exec|shell_command|run_terminal_command|search_replace|w…"
+          },
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "godmode",
+            "description": "Coordinate local context continuity, evidence, and guarded coding workflows. Use when starting or resuming substantive…"
+          },
+          {
+            "name": "godmode-code-of-law",
+            "description": "Use at the start of every session and before every new task - the project's generated Code of Law; read GODMODE-CODE-OF…"
+          },
+          {
+            "name": "godmode-continuity",
+            "description": "Reconstruct and preserve private project continuity from local evidence. Use when resuming work, changing branches or w…"
+          },
+          {
+            "name": "godmode-governance",
+            "description": "Preview and govern protected engineering actions without executing them implicitly. Use before destructive, externally…"
+          },
+          {
+            "name": "godmode-investigation",
+            "description": "Diagnose technical failures with reproducible evidence and bounded hypotheses. Use when a bug, regression, test failure…"
+          },
+          {
+            "name": "godmode-repair",
+            "description": "Re-pitch an answer that did not land, and record why it did not. Use when the operator says they do not follow, asks fo…"
+          },
+          {
+            "name": "godmode-skill-forge",
+            "description": "Create an original, compact project skill after a repeated capability gap is proven. Use when at least two real tasks n…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,8 +358,8 @@
       }
     },
     "godmode": {
-      "sha": "103ff20b06dc412303886c83dc6644d85f1f9c2f",
-      "version": "0.3.19",
+      "sha": "cbca7bdce4c480fa8b8766e36b8ab171504bd3d6",
+      "version": "0.3.20",
       "components": {
         "hooks": [
           {
@@ -381,6 +381,9 @@
           },
           {
             "name": "Stop"
+          },
+          {
+            "name": "SubagentStop"
           },
           {
             "name": "UserPromptSubmit"

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,8 +358,8 @@
       }
     },
     "godmode": {
-      "sha": "cbca7bdce4c480fa8b8766e36b8ab171504bd3d6",
-      "version": "0.3.20",
+      "sha": "f22ae722e9beed2b34761fa3c41b2d243a4fd2c5",
+      "version": "0.3.21",
       "components": {
         "hooks": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -384,8 +384,8 @@
       }
     },
     "godmode": {
-      "sha": "250508b7af01b229323cc5fe1f4550e470bafc85",
-      "version": "0.3.22",
+      "sha": "47bb79a30ee4c00ccba83c1e8fc6af4fc615491e",
+      "version": "0.3.24",
       "components": {
         "hooks": [
           {
@@ -422,7 +422,7 @@
           },
           {
             "name": "godmode-code-of-law",
-            "description": "Use at the start of every session and before every new task - read GODMODE-CODE-OF-LAW.md at the project root, the proj…"
+            "description": "Use at the start of every session and before every new task - read GODMODE-CODE-OF-LAW.md at the project root when it e…"
           },
           {
             "name": "godmode-continuity",


### PR DESCRIPTION
Adds Godmode as a SHA-pinned remote third-party entry: a local, tamper-evident record of what a coding agent did, what it claimed, and what was verified, with a pre-tool gate that classifies commands before they run. Pinned to the v0.3.3 release commit (1909cfa3cad1785b0d1d671b2d40952e02fad921). Index regenerated with scripts/generate-plugin-index.py; validate-catalog.py and the --check both pass locally.

**What Godmode is**: a local, tamper-evident record of what a coding agent did, what it claimed, and what was verified — with a pre-tool gate that classifies commands before they run. Continuity across sessions (godmode resume, bounded session briefs, checkpoints), an evidence discipline for claims (uncited claims downgrade on the record), a generated per-project Code of Law from the project's own recorded corrections, and a password-gated capability system for irreversible operations. Seven skills, stdlib-only Python, zero runtime dependencies, zero network use, Apache-2.0. Runs on Grok, Claude Code, Codex, and OpenCode at this commit. Full docs: README (https://github.com/AIimagined/Godmode/tree/1909cfa).

 Try it with nothing blocked: grok plugin install godmode --trust, then godmode init and echo '{"gate_mode": "observe"}' > .godmode-authorization-policy.json — work a normal week, then godmode roi --digest lists every deny/ask it would have issued, by category. Delete the file to enforce.
 
 It proves itself: godmode selftest --brief (controls enforced), godmode scenarios --brief (staged failures caught) — both run against the pinned tree.
 
Notes for review:

- Hooks execute Python by design - that is the product. PreToolUse carries a tool matcher (Bash|...|run_terminal_command|search_replace|write); SessionStart, UserPromptSubmit, Stop, PreCompact, SessionEnd and PostToolUse are lifecycle events that are not tool-scoped, the same shape other agent-discipline plugins in this ecosystem use. Every hook is a stdlib-only Python script inside the pinned tree; zero runtime dependencies, zero network use, no daemon, no telemetry - the repository's own privacy contract forbids network egress and prompt storage.
- Grok has no ask decision, so recoverable R2/R3 refusals fold to deny with a staged-capability remedy (godmode authorize stage). Fail-closed by design; the README states it.
- No automatic-resume claim is made for Grok: the gate and CLI/skills are live-proven on Grok 1.0.5 (deny honored, interception grade HARD after a live probe on this exact commit); session-brief injection is best-effort and documented as such.