### PR TITLE
feat(plugins): add PayBox

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,29 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "paybox",
+      "description": "PayBox non-custodial wallet for agents (MCP Server + Skills). Swap and transfer tokens across chains, pay for x402 services, take positions on prediction markets, and issue merchant-scoped virtual cards. PayBox never holds the key; anything that spends is confirmed by the user.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/moonpay/paybox-plugin.git",
+        "sha": "986f57bc98e0181a63368cb418407ba6b7569030"
+      },
+      "homepage": "https://paybox.sh",
+      "keywords": [
+        "paybox",
+        "paybox wallet",
+        "paybox swap",
+        "paybox x402"
+      ],
+      "domains": [
+        "paybox.sh",
+        "api.paybox.sh",
+        "app.paybox.sh",
+        "docs.paybox.sh"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,32 @@
         ]
       }
     },
+    "paybox": {
+      "sha": "986f57bc98e0181a63368cb418407ba6b7569030",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "paybox",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "paybox-get-started",
+            "description": "Understand what PayBox access the user has granted and how to widen it. Use when the user asks what their wallet can do…"
+          },
+          {
+            "name": "paybox-pay-and-swap",
+            "description": "Details for moving money with PayBox that the standing instructions do not carry — units, the checks to run before spen…"
+          },
+          {
+            "name": "paybox-x402-services",
+            "description": "Judgement for paying x402 services — which tool to reach for, why a listing fails, and telling the user the cost before…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
Adds **PayBox** — a non-custodial wallet for AI agents — as a url-sourced plugin.

Swap and transfer tokens across chains, pay for x402 services, take positions on prediction markets, and issue merchant-scoped virtual cards. PayBox never holds the private key: every operation that spends is confirmed by the user in a signing window that holds the key and signs there and nowhere else. The agent orchestrates, it does not authorize.

- **Source:** https://github.com/moonpay/paybox-plugin — public, MIT, owned by the MoonPay org
- **Pinned SHA:** `986f57bc98e0181a63368cb418407ba6b7569030` (full 40-char lowercase, reachable)
- **Ships:** one HTTP MCP server (`https://api.paybox.sh/mcp`) + 3 skills

| Skill | Covers |
|---|---|
| `paybox-get-started` | the grant model, approval modes, what to do when access blocks you |
| `paybox-pay-and-swap` | units, pre-spend checks, what a card authorization does not do |
| `paybox-x402-services` | which x402 tool to reach for, cost before spending, failing listings |

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` kebab-case and unique
- [x] Full 40-char lowercase commit `sha`; the commit is public and reachable
- [x] `.grok-plugin/plugin-index.json` regenerated with `scripts/generate-plugin-index.py`, not hand-edited
- [x] `homepage` and a clear `description`; brand-scoped `keywords`/`domains`; `category` set
- [x] Licensed — MIT, stated in the repo and its `plugin.json`
- [x] Read the security expectations and the plugin complies

## Validation

```
$ python3 scripts/validate-catalog.py
Catalog OK (.grok-plugin/marketplace.json)

$ python3 scripts/generate-plugin-index.py --check
Plugin index OK (.grok-plugin/plugin-index.json)
```

## Security

No executable code, no install or `postinstall` hooks, no downloaded binaries, no `eval` of remote content. The plugin is a manifest, an `.mcp.json` pointing at one HTTPS endpoint, and three markdown skills. No secrets are shipped, and nothing reads local files, environment variables, or credentials. Network access is limited to the declared MCP endpoint on `api.paybox.sh`; the `domains` listed are all owned by MoonPay.

Spend limits and per-credential approval modes are enforced server-side rather than by the agent, and no flow asks the agent for a private key or seed phrase.

## One question

I set `"category": "development"` to match `stripe`, the only other payments product in the catalog, since there is no payments/finance category today. Happy to change it if you would prefer a new category or a different existing one.