### PR TITLE
Add Skycloak MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "skycloak",
+      "description": "Official MCP server for Skycloak managed Keycloak. Manage clusters, realms, applications, SSO, and users from Grok via https://mcp.skycloak.io.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sky-cloak/skycloak-mcp.git",
+        "sha": "4eabbff334957e0d4108bf7c204539e2f325eabb"
+      },
+      "homepage": "https://skycloak.io",
+      "keywords": ["skycloak", "skycloak mcp", "skycloak keycloak"],
+      "domains": ["skycloak.io", "mcp.skycloak.io", "app.skycloak.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -795,6 +795,18 @@
         ]
       }
     },
+    "skycloak": {
+      "sha": "4eabbff334957e0d4108bf7c204539e2f325eabb",
+      "version": "0.9.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "skycloak",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "9f39fa607a63582d8c5b62aaf6fa4898b9c7caac",
       "version": "0.6.2",


### PR DESCRIPTION
## What this PR does

- Plugin name: skycloak
- Type: remote source
- Source URL + pinned SHA: https://github.com/sky-cloak/skycloak-mcp.git @ 4eabbff334957e0d4108bf7c204539e2f325eabb
- Homepage: https://skycloak.io

Adds Skycloak's hosted MCP server (managed upstream Keycloak) to the Grok plugin marketplace. Source is the official org repo `sky-cloak/skycloak-mcp`. The pinned commit includes `.grok-plugin/plugin.json` and `.mcp.json` pointing at https://mcp.skycloak.io.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Submitted by Guilliano (`gmolaire`), founder of Skycloak. Source is https://github.com/sky-cloak/skycloak-mcp (Apache-2.0).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - https://mcp.skycloak.io (hosted MCP)
  - https://api.skycloak.io (Skycloak API used by the MCP)
  - https://app.skycloak.io (dashboard / API keys)
  - https://login.app.skycloak.io (OAuth login)
- Credentials/permissions it requires (and why): OAuth against Skycloak login, or an optional dashboard API key as `Authorization: Bearer`. No secrets are stored in the plugin files.

## Notes for reviewers

Skycloak is managed upstream Keycloak (Keycloak as a Service). This listing is first-party. The plugin is an HTTP MCP server only (no skills, hooks, or shell). Hosted endpoint is https://mcp.skycloak.io.