### PR TITLE
Add Brimble plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -227,6 +227,19 @@
       "domains": ["railway.com", "railway.app"]
     },
     {
+      "name": "brimble",
+      "description": "Official Brimble plugin (hosted MCP server + skill). Deploy apps and static sites, inspect build and request logs, provision databases and sandboxes, and manage domains, storage, environments, and teams on Brimble from Grok.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/brimblehq/brimble-grok-plugin.git",
+        "sha": "b438e5dc72fc9a0999629cba9110f231b1d8dce1"
+      },
+      "homepage": "https://brimble.io",
+      "keywords": ["brimble", "brimble deploy", "deploy to brimble"],
+      "domains": ["brimble.io", "app.brimble.io", "mcp.brimble.io"]
+    },
+    {
       "name": "stripe",
       "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
       "category": "development",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -233,7 +233,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/brimblehq/brimble-grok-plugin.git",
-        "sha": "76ec9b5d7e698e443b3704a0122bd6d06dfa3e9f"
+        "sha": "d2a80d663ce04f4236bac0a5f5b5a179e2a5cf6b"
       },
       "homepage": "https://brimble.io",
       "author": { "name": "Brimble" },

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -233,11 +233,12 @@
       "source": {
         "source": "url",
         "url": "https://github.com/brimblehq/brimble-grok-plugin.git",
-        "sha": "5565ac6f54d4972eb12fb086b73fa398f3bff1e1"
+        "sha": "76ec9b5d7e698e443b3704a0122bd6d06dfa3e9f"
       },
       "homepage": "https://brimble.io",
+      "author": { "name": "Brimble" },
       "keywords": ["brimble", "brimble deploy", "deploy to brimble"],
-      "domains": ["brimble.io", "app.brimble.io", "mcp.brimble.io"]
+      "domains": ["brimble.io", "app.brimble.io", "mcp.brimble.io", "paper.brimble.io"]
     },
     {
       "name": "stripe",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -233,7 +233,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/brimblehq/brimble-grok-plugin.git",
-        "sha": "b438e5dc72fc9a0999629cba9110f231b1d8dce1"
+        "sha": "5565ac6f54d4972eb12fb086b73fa398f3bff1e1"
       },
       "homepage": "https://brimble.io",
       "keywords": ["brimble", "brimble deploy", "deploy to brimble"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,24 @@
         ]
       }
     },
+    "brimble": {
+      "sha": "b438e5dc72fc9a0999629cba9110f231b1d8dce1",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "brimble",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "use-brimble",
+            "description": "Operate Brimble: deploy apps and static sites, inspect build and request logs, provision databases and sandboxes, manag…"
+          }
+        ]
+      }
+    },
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -72,8 +72,8 @@
       }
     },
     "brimble": {
-      "sha": "76ec9b5d7e698e443b3704a0122bd6d06dfa3e9f",
-      "version": "1.2.0",
+      "sha": "d2a80d663ce04f4236bac0a5f5b5a179e2a5cf6b",
+      "version": "1.2.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -72,8 +72,8 @@
       }
     },
     "brimble": {
-      "sha": "b438e5dc72fc9a0999629cba9110f231b1d8dce1",
-      "version": "1.0.0",
+      "sha": "5565ac6f54d4972eb12fb086b73fa398f3bff1e1",
+      "version": "1.1.0",
       "components": {
         "mcpServers": [
           {
@@ -84,7 +84,7 @@
         "skills": [
           {
             "name": "use-brimble",
-            "description": "Operate Brimble: deploy apps and static sites, inspect build and request logs, provision databases and sandboxes, manag…"
+            "description": "Operate Brimble from Grok using the hosted MCP: deploy apps and static sites, inspect build and request logs, provision…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -72,8 +72,8 @@
       }
     },
     "brimble": {
-      "sha": "5565ac6f54d4972eb12fb086b73fa398f3bff1e1",
-      "version": "1.1.0",
+      "sha": "76ec9b5d7e698e443b3704a0122bd6d06dfa3e9f",
+      "version": "1.2.0",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

Adds the official Brimble plugin to the Grok Build marketplace.

- Plugin name: `brimble`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/brimblehq/brimble-grok-plugin.git` @ `b438e5dc72fc9a0999629cba9110f231b1d8dce1`
- Homepage: https://brimble.io

The plugin ships a hosted MCP server (`https://mcp.brimble.io`, OAuth) and a `use-brimble` skill for deploy, logs, databases, sandboxes, domains, storage, and environments.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source: [brimblehq/brimble-grok-plugin](https://github.com/brimblehq/brimble-grok-plugin) under the official Brimble org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.brimble.io` — hosted MCP (OAuth + tools)
  - `https://app.brimble.io` — OAuth consent UI
  - `https://api.brimble.io` — Core and Auth APIs, called by the hosted MCP on the user's behalf
  - `https://paper.brimble.io` — product docs via docs search tools
- Credentials/permissions it requires (and why):
  - Brimble dashboard OAuth on first connection (no API key to paste). Env tools return key names only; tool results are sanitized.

## Notes for reviewers

Brimble is a PaaS (comparable to Railway / Vercel). The MCP server implementation lives in a private repo; this marketplace entry points at a public plugin package that only contains `.mcp.json`, the skill, manifest, README, and MIT license — no binaries, hooks, or local code execution.