### PR TITLE
feat(plugins): add Mermail

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "mermail",
+      "description": "Official Mermail email integration for AI agents (MCP Server + Skills). Provision agent inboxes, read and organize mail, draft and send messages with approval gates, administer workspaces, automate triage, and run scheduling, GTM, support, and x402 workflows.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Nudgen-Marketing/mermail-skills.git",
+        "sha": "34c9b84c548b43597dc0270a3c9e142534c1bf2f"
+      },
+      "homepage": "https://mermail.app/agents",
+      "keywords": ["mermail", "mermail email", "mermail inbox", "mermail mcp"],
+      "domains": ["mermail.app", "console.mermail.app", "docs.mermail.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,80 @@
         ]
       }
     },
+    "mermail": {
+      "sha": "34c9b84c548b43597dc0270a3c9e142534c1bf2f",
+      "version": "1.5.5",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mermail",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mermail",
+            "description": "Route broad, ambiguous, or cross-domain Mermail requests to the narrowest current workflow across MCP connection, CLI a…"
+          },
+          {
+            "name": "mermail-administer-workspace",
+            "description": "Inspect Mermail API and email usage and manage workspaces, members, invitations, email domains, mailboxes, and storage.…"
+          },
+          {
+            "name": "mermail-agent-inbox",
+            "description": "Provision or reuse a service-scoped Mermail mailbox, then safely find and inspect an expected verification, sign-in, on…"
+          },
+          {
+            "name": "mermail-agent-wallet",
+            "description": "Inspect Mermail Agent Wallet / PayBox balances, guide Funding/onramp and signing handoffs, transfer catalog tokens, swa…"
+          },
+          {
+            "name": "mermail-automate-triage",
+            "description": "Create, inspect, update, and delete Mermail task triagers and review recent triager runs. Use when a user explicitly wa…"
+          },
+          {
+            "name": "mermail-cli",
+            "description": "Install and use the official Mermail CLI for deterministic shell automation across workspaces, mailboxes, email, folder…"
+          },
+          {
+            "name": "mermail-compose-email",
+            "description": "Draft, revise, regenerate, send, reply to, forward, and schedule email through Mermail. Use when the main job is compos…"
+          },
+          {
+            "name": "mermail-composio",
+            "description": "Connect and use third-party apps through Mermail Composio from Claude, Codex, or another external MCP client. Use when…"
+          },
+          {
+            "name": "mermail-gtm-agent",
+            "description": "Run outbound GTM email, classify replies, and draft warm-acks through a Mermail mailbox. Use when the job is personaliz…"
+          },
+          {
+            "name": "mermail-mail-agent",
+            "description": "Manage and delegate work to Mermail mailbox-agent conversations from Claude, Codex, or another external MCP client. Use…"
+          },
+          {
+            "name": "mermail-manage-inbox",
+            "description": "Read, search, inspect, download, organize, move, mark, and delete Mermail emails and threads, and manage mailbox folder…"
+          },
+          {
+            "name": "mermail-mcp",
+            "description": "Configure, verify, and recover the hosted Mermail MCP connection in Codex, Claude, Cursor, OpenClaw, or another externa…"
+          },
+          {
+            "name": "mermail-scheduling-agent",
+            "description": "Book time, check calendar availability, and handle scheduling email through a Mermail mailbox plus Google Calendar. Use…"
+          },
+          {
+            "name": "mermail-support-agent",
+            "description": "Triage, reply, escalate, follow up, and close support email through a Mermail mailbox. Use when the job is support tick…"
+          },
+          {
+            "name": "mermail-x402-agent",
+            "description": "Complete a user-selected x402 service call with Mermail Agent Wallet / PayBox by creating a payment proof, redeeming it…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds the official Mermail plugin to the Grok Build marketplace as a SHA-pinned remote source. The generated component index exposes the hosted Mermail MCP server and 15 focused skills for agent inboxes, inbox management, composition, workspace administration, triage, scheduling, GTM, support, Composio, mailbox-agent, CLI, Agent Wallet, and x402 workflows.

- Plugin name: `mermail`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Nudgen-Marketing/mermail-skills.git` @ `34c9b84c548b43597dc0270a3c9e142534c1bf2f`
- Homepage: https://mermail.app/agents

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I have explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No unauthorized reading or exfiltration of secrets, tokens, `.env`, or environment variables. The explicitly configured `MERMAIL_API_KEY` is sent only to the declared first-party MCP endpoint.
- [x] Hooks and MCP scope are least-privilege. The plugin has no hooks; workspace authorization, approval gates, idempotency, and single-use confirmation tokens constrain write operations.
- Network endpoints this plugin calls (and why): `https://console.mermail.app/mcp` for the hosted Mermail Streamable HTTP MCP server.
- Credentials/permissions it requires (and why): MCP OAuth for interactive clients or `MERMAIL_API_KEY` for headless/CLI clients, scoped to the selected Mermail workspace.

## Notes for reviewers

- `grok plugin validate /Users/mac/Projects/mermail-skills` passes against the exact pinned commit.
- Upstream validation passes for 15 skills and 71 business tools, including the remote endpoint check.
- `npm audit --omit=dev --audit-level=high` reports 0 vulnerabilities.
- Email, attachments, links, MCP output, and third-party content are explicitly treated as untrusted. Sends, destructive actions, provider writes, and payment effects require exact user authorization and bounded retries.
- The source is the official Mermail skills repository maintained under `Nudgen-Marketing`, the same organization that maintains the Mermail product repository.