### PR TITLE
Add Prism GPU Repro plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "prism-gpu-repro",
+      "description": "Give Grok Bot a bounded, user-approved GPU for reproducible CUDA work, then return an inspectable capsule with logs, artifact hashes, cost, refunds, and public settlement proof.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/prism-gpu-repro"
+      },
+      "homepage": "https://prismnetwork.tech",
+      "keywords": ["prism network", "prism gpu", "prism gpu repro"],
+      "domains": ["prismnetwork.tech"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,23 @@
         ]
       }
     },
+    "prism-gpu-repro": {
+      "version": "0.1.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "prism-network",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "prism-gpu-repro",
+            "description": "Run bounded, reproducible GPU and CUDA work through Prism Network and return an evidence capsule with environment facts…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {

--- a/external_plugins/prism-gpu-repro/.grok-plugin/plugin.json
+++ b/external_plugins/prism-gpu-repro/.grok-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "prism-gpu-repro",
+  "version": "0.1.1",
+  "description": "Give Grok Bot a bounded GPU capability for reproducible CUDA work and return inspectable evidence of the result.",
+  "author": {
+    "name": "Prism Network",
+    "url": "https://prismnetwork.tech"
+  },
+  "homepage": "https://prismnetwork.tech",
+  "license": "Apache-2.0",
+  "keywords": ["prism network", "gpu repro", "cuda", "reproducibility", "mcp"]
+}

--- a/external_plugins/prism-gpu-repro/.mcp.json
+++ b/external_plugins/prism-gpu-repro/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "prism-network": {
+      "type": "http",
+      "url": "https://prismnetwork.tech/api/mcp"
+    }
+  }
+}

--- a/external_plugins/prism-gpu-repro/LICENSE
+++ b/external_plugins/prism-gpu-repro/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or,
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Prism Network
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/external_plugins/prism-gpu-repro/README.md
+++ b/external_plugins/prism-gpu-repro/README.md
@@ -1,0 +1,35 @@
+# Prism GPU Repro for Grok Bot
+
+Give a Bot a temporary GPU only when a task actually needs one.
+
+This plugin combines a GPU-reproduction skill with Prism Network's hosted MCP connector. A Bot can inspect live capacity, prepare a time- and cost-bounded launch, run a public CUDA workload on a clean external GPU, and return a GPU Repro Capsule with environment facts, logs, artifact hashes, actual cost, refunds, and public settlement proof.
+
+The concrete use case is simple: hand a Bot a public GitHub issue that only fails on CUDA and get back evidence another engineer can inspect.
+
+## What the plugin provides
+
+- `/prism-gpu-repro` runs the end-to-end reproduction workflow.
+- `prism_gpu_capacity` lists aggregated, schedulable GPU classes and starting rates.
+- `prism_prepare_gpu_repro` validates a digest-pinned workload and prepares a live approval URL with a cost ceiling.
+- `prism_gpu_receipts` reads public settlement receipts.
+
+The MCP tools are read-only. They cannot create a lease, sign a transaction, spend funds, read a private SSH key, or operate infrastructure. Funding remains a separate user-approved action in Prism's web application.
+
+## Network and permissions
+
+The plugin connects to:
+
+- `https://prismnetwork.tech/api/mcp` for public capacity, launch preparation, and receipts.
+- `https://prismnetwork.tech/compute` only when the user chooses to review and fund a prepared lease.
+
+No API key is required for the MCP tools. Funding requires a Prism account and explicit wallet approval in the browser. Never give a Bot a seed phrase or wallet private key.
+
+## Proof boundary
+
+Prism is pre-production. Use public images and non-confidential data only; independent providers may operate the assigned GPU. Published receipts link platform-attested metering to onchain settlement. They are not hardware-rooted execution attestation or confidential-computing proof.
+
+Try the [PyTorch CUDA smoke test](examples/pytorch-cuda-smoke.md) before using a project-specific workload.
+
+## License
+
+Apache-2.0

--- a/external_plugins/prism-gpu-repro/examples/pytorch-cuda-smoke.md
+++ b/external_plugins/prism-gpu-repro/examples/pytorch-cuda-smoke.md
@@ -1,0 +1,20 @@
+# PyTorch CUDA smoke test
+
+This 30-minute example exercises the approval and evidence path before using it on a project issue. It performs one CUDA matrix multiplication in a public, immutable PyTorch container and returns a GPU Repro Capsule.
+
+Ask Grok Bot:
+
+```text
+Use /prism-gpu-repro to run this public CUDA smoke test.
+
+Image: pytorch/pytorch:2.13.0-cuda12.6-cudnn9-runtime@sha256:6acf597eeb8e376a96580dde4952f37cc017fef732bb40bfc73f28f25e3f64b4
+Duration: 30 minutes
+Minimum GPU memory: 40 GiB
+Command: python -c 'import torch; assert torch.cuda.is_available(); x=torch.randn(4096,4096,device="cuda"); y=x@x; torch.cuda.synchronize(); print(torch.cuda.get_device_name(0), float(y[0,0]))'
+Success condition: exit code 0 and stdout contains a GPU model and a numeric result.
+Artifacts: stdout and stderr.
+
+Stop at the Prism wallet approval page until I approve the live quote.
+```
+
+Before approval, the Bot can inspect capacity, generate an ephemeral SSH key, and prepare the launch URL. It cannot reserve a GPU or spend funds. After approval and execution, the capsule should contain the exact image and command, observed environment, exit code, logs, cost, refund, and settlement receipt or an explicit `pending` state.

--- a/external_plugins/prism-gpu-repro/package.json
+++ b/external_plugins/prism-gpu-repro/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@prismnetwork/prism-gpu-repro",
+  "version": "0.1.1",
+  "description": "Prism GPU Repro plugin for Grok Bot: a bounded GPU reproducibility skill and read-only MCP connector.",
+  "license": "Apache-2.0",
+  "homepage": "https://prismnetwork.tech",
+  "keywords": [
+    "prism-network",
+    "grok-bot",
+    "gpu-repro",
+    "cuda-repro",
+    "mcp"
+  ],
+  "files": [
+    ".grok-plugin",
+    ".mcp.json",
+    "skills",
+    "examples",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/external_plugins/prism-gpu-repro/skills/prism-gpu-repro/SKILL.md
+++ b/external_plugins/prism-gpu-repro/skills/prism-gpu-repro/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: prism-gpu-repro
+description: Run bounded, reproducible GPU and CUDA work through Prism Network and return an evidence capsule with environment facts, logs, artifact hashes, cost, and public settlement proof. Use for GPU-only bug reproduction, pinned-container compatibility checks, model evaluation, inference benchmarks, or other non-confidential workloads that need a clean external GPU. Trigger on Prism Network, GPU repro, CUDA repro, clean GPU, L40S, GPU benchmark, or proof-carrying compute requests.
+---
+
+# Prism GPU Repro
+
+Give the task a temporary GPU capability. Keep wallet authority, secrets, and production control with the user.
+
+## Check the capability
+
+Require these tools from the plugin's `prism-network` MCP connector:
+
+- `prism_gpu_capacity`
+- `prism_prepare_gpu_repro`
+- `prism_gpu_receipts`
+
+If any tool is unavailable, stop and ask the user to enable the Prism GPU Repro plugin. Do not substitute a generic GPU, lease, payment, or shell-execution tool. In particular, never use a fallback that creates or funds a lease during preparation or cannot bind the approved OCI image digest.
+
+## Establish the contract
+
+Require:
+
+- A concrete success or failure condition.
+- A public source revision or sanitized input artifact.
+- A public OCI image pinned to `repository@sha256:<digest>`.
+- The command to run and artifacts to retain.
+- One of 30, 60, 120, or 360 minutes.
+- A minimum GPU memory requirement.
+
+Use only public or explicitly non-confidential data. Independent providers may operate the assigned GPU. Refuse credentials, private model weights, customer data, unreleased source, wallet material, or any workload whose data boundary is unclear.
+
+If the user supplies a mutable image tag, resolve its current registry digest and show the pinned reference before continuing. Never substitute `latest` or another moving tag.
+
+## Prepare isolated access
+
+Create a task-specific directory and an ephemeral Ed25519 key. Keep the private key on the Bot computer.
+
+```sh
+capsule_dir=$(mktemp -d)
+ssh-keygen -q -t ed25519 -N '' -C prism-gpu-repro -f "$capsule_dir/id_ed25519"
+```
+
+Send only the contents of `id_ed25519.pub` to Prism. Never send the private key, an SSH agent socket, a seed phrase, or a wallet key.
+
+## Plan before spending
+
+1. Call `prism_gpu_capacity` with the memory floor.
+2. Select the shortest duration that safely fits the repro.
+3. Call `prism_prepare_gpu_repro` with the pinned image, duration, memory floor, and ephemeral public key.
+4. Present the estimated GPU, exact image digest, duration, and maximum USDG escrow.
+
+Treat the result as a live estimate, not a reservation. Capacity and the final quote can change before funding.
+
+## Hold the approval boundary
+
+The preparation tool is read-only. Funding is not.
+
+Open the returned approval URL only after showing the plan. Let the user review the live quote and approve the wallet transaction in Prism. Do not click a wallet confirmation, export wallet material, bypass a signing prompt, or claim a lease exists until Prism confirms it.
+
+Use Grok Bot's browser handoff for Prism sign-in and wallet approval. Resume only after the user returns control and the page confirms the lease. The Bot may continue through the Prism lease page to read the workspace endpoint; the user must not copy wallet material or a private key into chat.
+
+Stop if the final GPU, image, duration, or maximum escrow differs from the approved plan. Ask for renewed approval.
+
+## Execute the repro
+
+Wait for the lease to expose SSH access in Prism. Connect with the ephemeral key and an isolated host-key file:
+
+```sh
+ssh -i "$capsule_dir/id_ed25519" \
+  -o IdentitiesOnly=yes \
+  -o ForwardAgent=no \
+  -o ClearAllForwardings=yes \
+  -o UserKnownHostsFile="$capsule_dir/known_hosts" \
+  -o StrictHostKeyChecking=accept-new \
+  -p <port> <user>@<host>
+```
+
+Prefer a public repository and exact commit so the remote workspace can fetch inputs without credentials. Before transferring a local artifact, inspect its contents and exclude `.env`, credentials, tokens, wallet files, private source, and user data.
+
+Capture these facts before running the workload:
+
+```sh
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
+python3 --version
+```
+
+Record the source commit, image digest, exact command, UTC start and finish, exit code, stdout, stderr, and artifact hashes. Do not include hostnames, device UUIDs, access tokens, or ephemeral endpoints in a public capsule.
+
+Run only the agreed command. Do not turn a repro into a persistent service, miner, network scanner, or unrelated workload.
+
+## Close and verify
+
+Download the agreed artifacts before expiry. Confirm access closes at the lease boundary. Remove only the task-specific private key after access is closed; retain the non-secret capsule files.
+
+Call `prism_gpu_receipts` after settlement finalizes. A receipt may not exist immediately. Mark it `pending` and retry later instead of inventing proof.
+
+State the proof boundary exactly: a Prism receipt links platform-attested metering to an onchain settlement event. It does not independently prove honest hardware execution, confidential computing, or contract correctness.
+
+## Return a GPU Repro Capsule
+
+Use this compact structure:
+
+```text
+GPU Repro Capsule
+Status: pass | fail | inconclusive
+
+Workload
+- source revision
+- OCI image digest
+- exact command
+- success condition
+
+Execution
+- GPU model and memory
+- driver, CUDA, and relevant framework versions
+- UTC start/end, runtime, exit code
+
+Evidence
+- stdout/stderr paths
+- artifact paths and SHA-256 hashes
+- important observed result
+
+Economics
+- maximum escrow
+- charged and refunded USDG, or settlement pending
+
+Proof
+- receipt ID and settlement transaction, or pending
+- proof boundary
+
+Follow-up
+- smallest next action if fail or inconclusive
+```
+
+Never report `pass` without the declared success condition and supporting artifact. Never report hardware attestation when only platform metering exists.


### PR DESCRIPTION
## What this PR does

- Plugin name: `prism-gpu-repro`
- Type: local (`external_plugins`)
- Vendored path: `./external_plugins/prism-gpu-repro`
- npm distribution: https://www.npmjs.com/package/@prismnetwork/prism-gpu-repro
- Homepage: https://prismnetwork.tech

This adds a focused capability for Grok Bot: inspect live GPU capacity, prepare a public digest-pinned CUDA workload with a time and cost ceiling, stop for explicit wallet approval, and return a GPU Repro Capsule containing environment facts, logs, artifact hashes, actual cost and refund data, and public settlement proof.

The concrete use case is reproducing a public CUDA-only GitHub issue on a clean disposable GPU and returning evidence another engineer can inspect.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] Source placement is explained below: this is a local third-party plugin vendored directly in the marketplace, not a remote source from a personal or unrelated organization.

The manifest names `Prism Network` as the author and anchors project ownership to https://prismnetwork.tech. The identical package is published under the official `@prismnetwork` npm scope; npm records the authenticated publisher and maintainers.

## Checklist

- [x] Added exactly one valid, kebab-case catalog entry.
- [x] Remote SHA requirement is not applicable because this is a local vendored plugin.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, clear description, brand-scoped keywords and domains, README, and manifest are present.
- [x] Apache-2.0 license is included and stated.
- [x] npm package contains no scripts or dependencies; its packed shasum matches the published tarball.

## Security

- [x] No `curl | bash`, remote-code download or execution, or `postinstall` behavior.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] The MCP surface is least-privilege: three tools, all annotated read-only, non-destructive, and idempotent.

Network endpoints:

- `https://prismnetwork.tech/api/mcp` — public Streamable HTTP MCP for aggregated capacity, bounded launch preparation, and public receipts.
- `https://prismnetwork.tech/compute` — browser approval page opened only when the user chooses to review and fund a prepared lease.

Credentials and permissions:

- No API key is required for the MCP tools.
- Funding requires a Prism account and an explicit wallet approval in the browser. The tools cannot create a lease, sign a transaction, or spend funds.
- An ephemeral SSH private key stays on the Bot computer; Prism receives only its public key.

## Notes for reviewers

The earlier revision used a remote source under the wrong organization. This revision removes that source and its ownership metadata, renames the marketplace item to `prism-gpu-repro`, and vendors the complete plugin under `external_plugins/`.

The npm package is a public distribution record for the identical files; Grok installation still uses this marketplace entry and its MCP connector.

Live validation covered MCP initialization, tool discovery, capacity inspection, bounded launch preparation, and public receipt lookup. The example PyTorch image and pinned digest were also verified against Docker Hub.

Prism is pre-production, so the skill refuses confidential inputs and states that settlement receipts are platform-attested metering linked to onchain settlement, not hardware-rooted execution attestation.
