### PR TITLE
Add bot.store plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "bot-store",
+      "description": "Search bot.store for Grok Bot templates, compare fit and price, and start a human-approved purchase.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Humanleap/bot-store-grok-plugin.git",
+        "sha": "f09eae1e61b8538a7344d8fec4d0f883fb65a5c5"
+      },
+      "homepage": "https://bot.store",
+      "keywords": ["bot.store", "bot store", "bot.store marketplace"],
+      "domains": ["bot.store"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,24 @@
         ]
       }
     },
+    "bot-store": {
+      "sha": "f09eae1e61b8538a7344d8fec4d0f883fb65a5c5",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "bot_store",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "bot-store-marketplace",
+            "description": "Find and open Grok Bot templates through bot.store. Use when the user names bot.store, asks to use the bot.store market…"
+          }
+        ]
+      }
+    },
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `bot-store`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Humanleap/bot-store-grok-plugin.git` at `f09eae1e61b8538a7344d8fec4d0f883fb65a5c5`
- Homepage: https://bot.store

The plugin lets Grok Build search bot.store for Grok Bot templates, inspect listings, open free bots, and hand paid bots to a human-approved bot.store checkout.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org.

## Checklist

- [x] Added exactly one valid, kebab-case marketplace entry.
- [x] Pinned a public, reachable full commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set.
- [x] MIT licence is stated.

## Security

- [x] No remote-code download or execution.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks, local commands, filesystem access, install scripts, or telemetry.
- Network endpoint: `https://bot.store/mcp`, used only for read-only catalogue search, listing details, and a safe checkout handoff.
- Credentials or permissions: none. Paid results return a bot.store checkout URL; the MCP server cannot charge a payment method.

## Notes for reviewers

The source is under the official Humanleap organisation and the hosted MCP endpoint is live. Paid bot access remains behind explicit human approval on bot.store.