### PR TITLE
Add flightseatmap plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "flightseatmap",
+      "description": "FlightSeatMap airline seat map integration. Look up the cabin layout for any flight, rank the free seats against preferences like window, aisle, exit row or extra legroom, read traveller reviews of a specific seat, and set alerts for when a better seat frees up. Covers 150+ airlines.",
+      "category": "travel",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/FlightSeatmap/mcp.git",
+        "sha": "33e4e1aceb987c9ce782f63e48436f2dc689b17a"
+      },
+      "homepage": "https://flightseatmap.com/mcp",
+      "keywords": ["flightseatmap", "flight seat map", "airplane seat", "seat alert"],
+      "domains": ["flightseatmap.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "flightseatmap",
-      "description": "FlightSeatMap airline seat map integration. Look up the cabin layout for any flight, rank the free seats against preferences like window, aisle, exit row or extra legroom, read traveller reviews of a specific seat, and set alerts for when a better seat frees up. Covers 150+ airlines.",
+      "description": "FlightSeatMap airline seat map integration. Look up the cabin layout for any flight, rank the free seats against preferences like window, aisle, exit row or extra legroom, read traveller reviews of a specific seat, and set alerts for when a better seat frees up. Covers 117 airlines.",
       "category": "travel",
       "source": {
         "source": "url",
         "url": "https://github.com/FlightSeatmap/mcp.git",
-        "sha": "4e3cd18d4dff1561806afa58c42785e36dbb9126"
+        "sha": "c9d60fc1021a3023264e380dbd2a2f678065dfda"
       },
       "homepage": "https://flightseatmap.com/mcp",
       "keywords": ["flightseatmap", "flight seat map", "airplane seat", "seat alert"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FlightSeatmap/mcp.git",
-        "sha": "33e4e1aceb987c9ce782f63e48436f2dc689b17a"
+        "sha": "4e3cd18d4dff1561806afa58c42785e36dbb9126"
       },
       "homepage": "https://flightseatmap.com/mcp",
       "keywords": ["flightseatmap", "flight seat map", "airplane seat", "seat alert"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,9 +346,19 @@
       }
     },
     "flightseatmap": {
-      "sha": "33e4e1aceb987c9ce782f63e48436f2dc689b17a",
+      "sha": "4e3cd18d4dff1561806afa58c42785e36dbb9126",
       "version": "6.0.0",
       "components": {
+        "commands": [
+          {
+            "name": "best-seats",
+            "description": "Find the best seats on a flight matching your preferences"
+          },
+          {
+            "name": "seatmap",
+            "description": "Look up the seat map for a flight"
+          }
+        ],
         "mcpServers": [
           {
             "name": "flightseatmap",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,8 +346,8 @@
       }
     },
     "flightseatmap": {
-      "sha": "4e3cd18d4dff1561806afa58c42785e36dbb9126",
-      "version": "6.0.0",
+      "sha": "c9d60fc1021a3023264e380dbd2a2f678065dfda",
+      "version": "6.0.1",
       "components": {
         "commands": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,28 @@
         ]
       }
     },
+    "flightseatmap": {
+      "sha": "33e4e1aceb987c9ce782f63e48436f2dc689b17a",
+      "version": "6.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "flightseatmap",
+            "description": "streamable-http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "find-the-best-seat",
+            "description": "Pick the best available seat on any commercial flight using FlightSeatMap's seat maps, seat-level detail, and passenger…"
+          },
+          {
+            "name": "track-seat-availability",
+            "description": "Watch a flight and email the user when a better seat frees up, using FlightSeatMap seat alerts. Use when a user is stuc…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds one new remote-source entry for FlightSeatMap — airline seat maps, seat ratings, traveller reviews and seat alerts for 150+ airlines.

- Plugin name: `flightseatmap`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/FlightSeatmap/mcp.git` @ `33e4e1aceb987c9ce782f63e48436f2dc689b17a`
- Homepage: https://flightseatmap.com/mcp

Ships one streamable-http MCP server and two skills (`find-the-best-seat`, `track-seat-availability`). No hooks, no commands, no agents, no scripts, nothing vendored into this repo.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`FlightSeatmap`), not a personal account.

FlightSeatMap is operated by Merchant Software Solutions Limited, registered in England and Wales (no. 14098922). The source repo, the `flightseatmap.com` domain and the MCP endpoint are all ours.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable (`git ls-remote` confirms it is `HEAD`).
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally — `Catalog OK`.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally — `Plugin index OK`.
- [x] `homepage` + clear `description` set.
- [x] License is stated — MIT, in the source repo's `LICENSE`.

The diff is 35 insertions and 0 deletions; no existing entries were reformatted or touched.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin ships no scripts and no executable code at all — it is a manifest, an MCP server declaration, and two markdown skills.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. There are no hooks. The MCP server is remote streamable-http, so nothing runs on the user's machine.

**Network endpoints this plugin calls (and why):**
- `https://mcp.flightseatmap.com/mcp` — the MCP server itself, the plugin's whole purpose.

**Credentials/permissions it requires (and why):**
- None for six of the ten tools (`get_seatmap`, `find_best_seats`, `get_seat_info`, `interactive_seat_finder`, `get_seat_reviews`, `discover_more_flight_tools`) — these work fully anonymously.
- The remaining four (`search_flight`, `create_seat_alert`, `list_seat_alerts`, `delete_seat_alert`) need a FlightSeatMap account over OAuth 2.1 with PKCE and RFC 7591 dynamic client registration. There is no API key to request and no secret for the user to paste; the client discovers everything from the 401 challenge. Scopes are `read`, `write`, `search`, and each tool asks only for the one it needs.

## Notes for reviewers

- `keywords` and `domains` are deliberately brand-scoped (`flightseatmap`, `flight seat map`, `airplane seat`, `seat alert`, `flightseatmap.com`) so the CTA doesn't misfire on generic travel or flight questions.
- `category` is `travel`, which is new to the catalog. Happy to fold it into an existing category if you'd rather not add one.
- Good flight number for testing: **QF1** (Qantas A380, SYD–LHR) returns a full 341-seat map. Seat maps are keyed on flight number, and not every flight is stocked, so a randomly chosen one may correctly return "not found".