### PR TITLE
Add airport-lounge-list plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "airport-lounge-list",
+      "description": "Airport lounge access. Search 8,500+ lounges worldwide and check which ones a credit card, membership, airline status or ticket class gets you into, with amenities, hours and terminal. Log visits and reviews once signed in.",
+      "category": "travel",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Airport-Lounge-List/mcp-server.git",
+        "sha": "5beb3e8c796e9500087bfacfbaaa9b46bc13d273"
+      },
+      "homepage": "https://airportloungelist.com/mcp",
+      "keywords": ["airport lounge list", "airportloungelist", "airport lounge", "lounge access", "priority pass lounge"],
+      "domains": ["airportloungelist.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "airport-lounge-list": {
+      "sha": "5beb3e8c796e9500087bfacfbaaa9b46bc13d273",
+      "version": "0.7.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airport-lounge-list",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds one new plugin entry. Airport Lounge List is a hosted remote MCP server that answers airport lounge access questions — which lounges are at an airport, and which ones a given credit card, membership, airline status or ticket class actually gets you into.

- Plugin name: `airport-lounge-list`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Airport-Lounge-List/mcp-server.git` @ `5beb3e8c796e9500087bfacfbaaa9b46bc13d273`
- Homepage: https://airportloungelist.com/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The source repo is `Airport-Lounge-List/mcp-server`, the official org for airportloungelist.com. Both the site and the org are operated by Merchant Software Solutions Limited, registered in England and Wales, [company number 14098922](https://find-and-update.company-information.service.gov.uk/company/14098922). Domain ownership is independently checkable: `https://mcp.airportloungelist.com/.well-known/mcp.json` serves the server card, and the same domain publishes RFC 9728 and RFC 8414 metadata.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. MIT, in the source repo — it covers the metadata and docs; the lounge data itself is proprietary and covered by the service's terms.

The diff is additions only; no existing entry is reformatted or touched.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):** exactly one — `https://mcp.airportloungelist.com/mcp`, the MCP server itself, declared in [`.mcp.json`](https://github.com/Airport-Lounge-List/mcp-server/blob/main/.mcp.json). Nothing else.

**Credentials/permissions it requires (and why):** none to start. Eight of the 21 tools are public read-only lounge data and need no token; they are rate limited per IP. The other thirteen read or change the user's own reviews, visits and wishlist, and use OAuth 2.1 with PKCE and RFC 7591 dynamic client registration — the client registers itself and the user consents in a browser, so no password or API key is ever handled by the plugin. `write` scope is required for the eight mutating tools; `read` covers the rest.

## Notes for reviewers

The plugin ships **no executable code** — no hooks, no scripts, no skills, no commands. The whole source repo is a `.mcp.json` naming one HTTPS endpoint, a `.grok-plugin/plugin.json` manifest, a README, a tool table and a `server.json`. There is nothing to run locally, so there is no filesystem, environment or shell access to audit.

Every tool declares MCP `annotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) and a `title`, so Grok can distinguish reads from writes before calling anything. You can verify the full tool list anonymously:

```bash
curl -s -X POST https://mcp.airportloungelist.com/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

`keywords` and `domains` are deliberately brand-scoped — no generic terms like `travel`, `flight` or `airport` on their own that would mis-fire the CTA.