### PR TITLE
Add award-travel-finder plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "award-travel-finder",
+      "description": "Award flight search over MCP. Check award seat availability across 27 airlines, look up award-chart pricing for 23 loyalty programs, compare transfer paths, and find award nights at Marriott, Hilton, IHG and Hyatt.",
+      "category": "travel",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/AwardTravelFinder/mcp.git",
+        "sha": "f6a41a7b0c09220db57e37b075eb1452e506f8fb"
+      },
+      "homepage": "https://awardtravelfinder.com/mcp",
+      "keywords": ["award travel finder", "awardtravelfinder", "award flight availability", "award seat search"],
+      "domains": ["awardtravelfinder.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,34 @@
 {
   "version": 1,
   "plugins": {
+    "award-travel-finder": {
+      "sha": "f6a41a7b0c09220db57e37b075eb1452e506f8fb",
+      "version": "1.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "compare-programs",
+            "description": "Compare loyalty program award charts and rates"
+          },
+          {
+            "name": "search-flights",
+            "description": "Search award flight availability across airlines"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "awardtravelfinder",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "award-travel",
+            "description": "This skill should be used when the user asks about \"award flights\", \"points\", \"miles\", \"avios\", \"asia miles\", \"loyalty…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds one remote-source catalog entry for **Award Travel Finder** — award flight search over MCP.

- Plugin name: `award-travel-finder`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/AwardTravelFinder/mcp.git` @ `f6a41a7b0c09220db57e37b075eb1452e506f8fb`
- Homepage: https://awardtravelfinder.com/mcp

It gives an agent award seat availability across 27 airlines, award-chart pricing for 23 loyalty programs, transfer-path comparison, and award nights at Marriott, Hilton, IHG and Hyatt. The MCP server is hosted at `https://mcp.awardtravelfinder.com/mcp`; the plugin ships two slash commands, one skill, and the `.mcp.json` that points at it.

It is also listed in the official MCP registry as [`com.awardtravelfinder/mcp`](https://registry.modelcontextprotocol.io/v0/servers?search=awardtravelfinder) v3.0.0.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`AwardTravelFinder`), operated by Merchant Software Solutions Limited (UK company no. 14098922).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally → `Catalog OK`.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally → `Plugin index OK`.
- [x] `homepage` + clear `description` set.
- [x] License is stated — MIT, in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege — the plugin ships no hooks at all, and a single MCP server entry.

**Network endpoints this plugin calls (and why):**

- `https://mcp.awardtravelfinder.com/mcp` — the only endpoint. It is our own hosted MCP server, and the sole reason the plugin exists. Reached via `npx mcp-remote` for clients without native remote-MCP support.
- The OAuth flow reaches `https://awardtravelfinder.com` (authorization server) in the user's browser.

**Credentials/permissions it requires (and why):**

- **No API key, and the plugin must not be given one.** Auth is OAuth 2.1 exactly as the MCP spec describes: the server answers unauthenticated requests with an RFC 9728 `WWW-Authenticate` challenge pointing at `/.well-known/oauth-protected-resource`, and supports RFC 7591 dynamic client registration, so nothing needs configuring. The user signs in through their browser on the first tool call. Scope requested is `mcp:read`.
- No filesystem access, no environment variables read, no telemetry.

## Notes for reviewers

- **Category.** I used `travel`, which is new here — the catalog is currently dev-tooling. Happy to change it to something existing if you would rather not add a category.
- **Keywords are deliberately brand-scoped** per CONTRIBUTING's warning about CTA misfires: only `award travel finder`, `awardtravelfinder`, `award flight availability`, `award seat search`, and `awardtravelfinder.com` as the single domain. I left out otherwise-tempting generic terms like `flights`, `travel`, and third-party currency names.
- **Tool discovery without an account.** `initialize` and `tools/list` are deliberately answered unauthenticated, so you can inspect the full tool catalogue before signing in:
  ```bash
  curl -s -X POST https://mcp.awardtravelfinder.com/mcp \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
  ```
  `tools/call` remains OAuth-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)