### PR TITLE
Add FlightQueue plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "flightqueue",
+      "description": "FlightQueue airport intelligence. Security wait times and forecasts, FAA delays, EU Entry/Exit System border queues, lounges, terminals, aviation weather, and airline baggage performance for 8,000+ airports. Hosted remote MCP server, OAuth sign-in.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Flight-Queue/mcp.git",
+        "sha": "103cca86ebea811f404c7e9bc3fd48694d97189b"
+      },
+      "homepage": "https://mcp.flightqueue.com",
+      "keywords": ["flightqueue", "flight queue", "flightqueue airport"],
+      "domains": ["flightqueue.com", "mcp.flightqueue.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,18 @@
         ]
       }
     },
+    "flightqueue": {
+      "sha": "103cca86ebea811f404c7e9bc3fd48694d97189b",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "flightqueue",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds one remote-source entry for FlightQueue, a hosted MCP server for airport intelligence.

- Plugin name: `flightqueue`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Flight-Queue/mcp.git` @ `103cca86ebea811f404c7e9bc3fd48694d97189b`
- Homepage: https://mcp.flightqueue.com

Security wait times and forecasts, FAA delays and ground stops, EU Entry/Exit System border queues, Schengen day counting, lounges, terminals, aviation weather, and airline baggage performance across 8,000+ airports. 22 tools, all annotated.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`Flight-Queue` is our official GitHub org. The product is FlightQueue; the legal entity is Merchant Software Solutions Limited, company number 14098922, registered in England and Wales.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT, in `LICENSE` at the source repo root.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The source repo is manifests only. No skills, commands, agents, hooks, scripts or installable code — the entire plugin is one `.mcp.json` pointing at a hosted HTTPS endpoint, so there is nothing to execute locally.

- **Network endpoints this plugin calls (and why):** `https://mcp.flightqueue.com/mcp` only. That is the MCP server itself.
- **Credentials/permissions it requires (and why):** OAuth 2.1 with PKCE (S256 required, plain disabled), handled by the client. Users sign in with a FlightQueue account so per-account tier and rate limits apply. No API key, no header auth, no anonymous access, and the plugin stores no credentials. 19 of the 22 tools work on a free account.

Of the 22 tools, 20 are read-only. The two writes are `submit_wait_time_report` (contributes a wait-time observation) and `create_wait_time_alert` (sets a threshold alert). Both are annotated `readOnlyHint: false, destructiveHint: false` — they add a row and delete nothing.

## Notes for reviewers

Two things worth flagging rather than letting you find them:

**Category is omitted deliberately.** The catalog uses `development`, `deployment`, `database`, `monitoring` and `observability`. None fits, and inventing a `travel` category in a plugin PR seemed worse than leaving an optional field out. Happy to add whatever you prefer.

**This is not a developer-infrastructure plugin,** unlike most of the catalog. The honest pitch is that travel is a common real-world side quest for people already in Grok, and the data (live security queues, FAA ground stops, EES border waits) is not something a model can answer from training data — it is genuinely live. If you would rather keep the marketplace tightly scoped to dev tooling, no hard feelings, just close it.

`keywords` and `domains` are deliberately brand-scoped per CONTRIBUTING, so the CTA only fires on FlightQueue-specific prompts rather than any mention of airports or flights.