### PR TITLE
Add Siftable hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "siftable",
+      "description": "Siftable hosted MCP integration for planning projects, managing tasks, coordinating executable agent work, and retrieving notes, datasets, calendar, contact, and code-memory context. Sign in with Siftable OAuth; no API key is required.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/execufunction-mcp/siftable-plugin.git",
+        "sha": "20a00dfecab7751ba0ef68e9fcf1ab5b31a2e325"
+      },
+      "homepage": "https://siftable.io/docs/mcp.html",
+      "keywords": ["siftable", "siftable mcp", "siftable tasks", "siftable agent work"],
+      "domains": ["siftable.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -787,6 +787,18 @@
         ]
       }
     },
+    "siftable": {
+      "sha": "20a00dfecab7751ba0ef68e9fcf1ab5b31a2e325",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "siftable",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
       "version": "0.6.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `siftable`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/execufunction-mcp/siftable-plugin.git` at `20a00dfecab7751ba0ef68e9fcf1ab5b31a2e325`
- Homepage: https://siftable.io/docs/mcp.html

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official `execufunction-mcp` org.

## Checklist

- [x] Added exactly one valid, kebab-case catalog entry.
- [x] Pinned a public, reachable full 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set; the source repo includes README, manifest, and MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` behavior.
- [x] No local secret, token, `.env`, or environment-variable reads.
- [x] No hooks; the plugin declares only the hosted Siftable MCP server. Tool scopes are elevated through Siftable OAuth only when required.
- Network endpoint: `https://siftable.io/api/v1/mcp`, used for Siftable MCP tool calls and OAuth discovery.
- Credentials/permissions: a Siftable account through OAuth. Users do not paste API keys or personal access tokens.

## Notes for reviewers

The production endpoint, OAuth metadata, public setup documentation, privacy policy, and terms are live. The source contains only plugin metadata, brand assets, reviewer test cases, and the MCP URL.