### PR TITLE
Add BubblaV plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -227,6 +227,19 @@
       "domains": ["railway.com", "railway.app"]
     },
     {
+      "name": "bubblav",
+      "description": "BubblaV AI chatbot platform — search your knowledge base, manage your chatbot persona and widget, analyze conversations, and close content gaps, directly from Grok Build, via the BubblaV remote MCP server.",
+      "category": "support",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/bubblav-org/grok-plugin.git",
+        "sha": "b7d13bf267b4fb8bfd3f6fcc0449eaf75161d648"
+      },
+      "homepage": "https://bubblav.com",
+      "keywords": ["bubblav", "bubblav mcp", "chatbot knowledge base", "ai support"],
+      "domains": ["bubblav.com", "www.bubblav.com", "docs.bubblav.com"]
+    },
+    {
       "name": "stripe",
       "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,40 @@
         ]
       }
     },
+    "bubblav": {
+      "sha": "b7d13bf267b4fb8bfd3f6fcc0449eaf75161d648",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "bubblav",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "bubblav-analyze-reports",
+            "description": "Read and summarize the BubblaV chatbot analytics report — total conversations, containment rate, average response time,…"
+          },
+          {
+            "name": "bubblav-content-gaps",
+            "description": "Discover what questions visitors are asking that the BubblaV chatbot cannot answer, and recommend specific sources to a…"
+          },
+          {
+            "name": "bubblav-manage-chatbot",
+            "description": "Read and update the BubblaV chatbot's persona, custom instructions, greeting, suggestions, bot name, and widget design…"
+          },
+          {
+            "name": "bubblav-mcp",
+            "description": "Connect to the BubblaV remote MCP server, list available tools, generate scoped API keys, and decide which companion sk…"
+          },
+          {
+            "name": "bubblav-search-knowledge",
+            "description": "Semantic search over the user's BubblaV-indexed website content with citations. Use this skill whenever the user asks t…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

Adds the official [BubblaV](https://www.bubblav.com/) plugin to the Grok Build marketplace catalog as a remote source.

- Plugin name: bubblav
- Type: remote source
- Source URL + pinned SHA: https://github.com/bubblav-org/grok-plugin.git + b7d13bf267b4fb8bfd3f6fcc0449eaf75161d648
- Homepage: https://github.com/bubblav-org/grok-plugin

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - https://www.bubblav.com/mcp the official BubblaV remote MCP server. It serves the MCP protocol.
  - https://www.bubblav.com/api/mcp API-style alias of the same MCP server for headless / API-key clients. Documented in the README and in the .mcp.json note field.
- Credentials/permissions it requires (and why):
  - BubblaV OAuth for hosted MCP workflows.
  - For users who choose the headless / API-key path, the plugin requires a scoped MCP API key. The key is created by the user in their BubblaV dashboard.

## Notes for reviewers

None
