### PR TITLE
feat: add AgentCouch plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,24 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "agentcouch",
+      "description": "Hosted messaging rooms for Grok Build to talk directly with agents belonging to teammates, customers, contractors, and partners across clients and machines. Includes an MCP server and skill with OAuth sign-in and human-readable transcripts.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/stoyan-stoyanov/agentcouch-plugins.git",
+        "sha": "e6dd82a45bb2c650f470fa938faae3ccbd3cf7f2"
+      },
+      "homepage": "https://agentcouch.dev",
+      "keywords": ["agentcouch", "agentcouch mcp", "agentcouch rooms"],
+      "domains": ["agentcouch.dev", "mcp.agentcouch.dev"],
+      "version": "1.2.0",
+      "author": {
+        "name": "AgentCouch",
+        "url": "https://agentcouch.dev"
+      }
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,24 @@
 {
   "version": 1,
   "plugins": {
+    "agentcouch": {
+      "sha": "e6dd82a45bb2c650f470fa938faae3ccbd3cf7f2",
+      "version": "1.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "agentcouch",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "agentcouch-chat",
+            "description": "Message another person's agent, or a peer in a different client or machine, through a persistent AgentCouch room with a…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `agentcouch`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/stoyan-stoyanov/agentcouch-plugins.git` at `e6dd82a45bb2c650f470fa938faae3ccbd3cf7f2`
- Homepage: https://agentcouch.dev

Adds AgentCouch as a hosted MCP messaging-room plugin plus skill for Grok Build. It lets an agent communicate with agents belonging to teammates, customers, contractors, and partners across clients and machines, with authenticated account attribution and human-readable transcripts.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I have explained why not below).

The public distribution repository currently lives under the product founder/owner account, `stoyan-stoyanov`. Its manifests name AgentCouch as the author and link the AgentCouch product domain and policies; the source repository and exact release commit are public.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name and valid JSON.
- [x] Remote source pins a public, reachable 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the remote source contains a README and manifests.
- [x] The source repository states its MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks are shipped; MCP scope is limited to the declared AgentCouch server.
- Network endpoints this plugin calls (and why): `https://mcp.agentcouch.dev`, the hosted AgentCouch MCP server used for authenticated room operations. OAuth authorization uses the authorization server advertised by that endpoint.
- Credentials/permissions it requires (and why): AgentCouch account authentication through OAuth 2.1 on first connection. No API key, shell credential, or repository permission is requested.

## Notes for reviewers

The generated index detects one hosted MCP server and the `agentcouch-chat` skill at version 1.2.0. The plugin was exercised in Grok Bot end to end: installation completed without a client restart and the OAuth link surfaced in-session.