### PR TITLE
Add hwpxkit plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "hwpxkit",
+      "description": "Open an HWPX (Hancom Office) document in a private, expiring session, inspect its structure, fill form fields, apply text and row edits, and download the edited copy with one-step rollback. The source file is never modified.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/HWPXkit/hwpxkit-plugin.git",
+        "sha": "05a495602e64a256115d9c6c1ca4ebd7fb3207fe"
+      },
+      "homepage": "https://hwpxkit.jhlim.dev",
+      "keywords": ["hwpxkit", "hwpxkit hwpx", "edit hwpx with hwpxkit", "hwpxkit 한글 문서"],
+      "domains": ["hwpxkit.jhlim.dev", "mcp.hwpxkit.jhlim.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,24 @@
         ]
       }
     },
+    "hwpxkit": {
+      "sha": "05a495602e64a256115d9c6c1ca4ebd7fb3207fe",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "hwpxkit",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "hwpxkit-document-editing",
+            "description": "Use HWPXkit's authenticated MCP tools to inspect and edit an HWPX document in a private, expiring session."
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds one new plugin entry for HWPXkit, a remote MCP server for editing HWPX
(Hancom Office) documents, and regenerates the component index.

- Plugin name: `hwpxkit`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/HWPXkit/hwpxkit-plugin.git` @ `05a495602e64a256115d9c6c1ca4ebd7fb3207fe`
- Homepage: https://hwpxkit.jhlim.dev

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`HWPXkit`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in the source repo's `LICENSE` and manifest).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): a single Streamable HTTP MCP
  endpoint, `https://mcp.hwpxkit.jhlim.dev/mcp`. It is the only endpoint the
  plugin configuration declares, and it is the service that performs the
  document operations. The other URLs in the README are informational links
  (homepage, support, privacy, terms) that a user opens, not endpoints the
  plugin calls.
- Credentials/permissions it requires (and why): an OAuth 2.0 access token
  obtained per user via authorization code flow with PKCE (S256) and dynamic
  client registration. No API key or pre-shared client secret is distributed,
  and no credential value is stored in the source repository. Document access
  is scoped to a private, expiring session; the source file is never modified.

## Notes for reviewers

The source repository is declaration-only: manifest, MCP configuration,
README, one skill, and the license. It contains no engine source, no credential
value, and no sample documents. Its six MCP tools open a document, list
editable targets, inspect it, apply edits, roll back one edit state, and close
the session.

`source.source: "url"` is intentional. `scripts/validate-catalog.py` recognizes
the `source` key when deciding whether to enforce the 40-char SHA rule, while
`scripts/generate-plugin-index.py` accepts either `source` or `type`. Using
`source` keeps both programs on the same path; with `type` the validator skips
its SHA check.

`category` is `productivity`, matching the lower-case convention used by the
existing entries. Every keyword is brand-prefixed so the plugin CTA cannot fire
on unrelated document requests.
