### PR TITLE
Add feishu plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "feishu",
+      "description": "Connect Feishu/Lark as yourself: docs, calendar, messages, and Bitable via official lark-mcp. First-run QR creates the app; no hardcoded secrets.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/anselorville/feishu-grok-plugin.git",
+        "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce"
+      },
+      "homepage": "https://github.com/anselorville/feishu-grok-plugin",
+      "keywords": ["feishu", "lark", "bitable", "feishu docs"],
+      "domains": ["feishu.cn", "larksuite.com", "open.feishu.cn"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -223,6 +223,30 @@
         ]
       }
     },
+    "feishu": {
+      "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "feishu-connect",
+            "description": "QR connect for Feishu. Run bin/connect.mjs then open the Feishu link."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "feishu",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "Feishu",
+            "description": "Use when the user wants to read or act on Feishu/Lark docs, calendar, chats, or Bitable. Connect first if tools are mis…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3",
       "version": "2.2.96",


### PR DESCRIPTION
## Summary
- Add the `feishu` plugin to the catalog (docs, calendar, messages, Bitable).
- Source: https://github.com/anselorville/feishu-grok-plugin pinned to `f991b733dec27bec1ae69a967a153bd59f3313ce`.
- Regenerated `plugin-index.json`. `python3 scripts/validate-catalog.py` passes locally.

Each installer scans a Feishu QR (`registerApp`); no shared App Secret is shipped. Official `@larksuiteoapi/lark-mcp` then runs with user identity.

## Test plan
- [ ] Catalog validator passes in CI
- [ ] `grok plugin install feishu --trust` (after merge) or `grok plugin install https://github.com/anselorville/feishu-grok-plugin --trust` now
- [ ] `feishu_connect` / `node bin/connect.mjs` shows a Feishu link