### PR TITLE
Add feishu plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "feishu",
+      "description": "Connect Feishu/Lark as yourself: docs, calendar, messages, and Bitable via official lark-mcp. First-run QR creates the app; no hardcoded secrets.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/anselorville/feishu-grok-plugin.git",
+        "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce"
+      },
+      "homepage": "https://github.com/anselorville/feishu-grok-plugin",
+      "keywords": ["feishu", "lark", "bitable", "feishu docs"],
+      "domains": ["feishu.cn", "larksuite.com", "open.feishu.cn"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/anselorville/feishu-grok-plugin.git",
-        "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce"
+        "sha": "a1076084520914e46d5cad5f1cf0d138a0660aee"
       },
       "homepage": "https://github.com/anselorville/feishu-grok-plugin",
       "keywords": ["feishu", "lark", "bitable", "feishu docs"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -223,6 +223,30 @@
         ]
       }
     },
+    "feishu": {
+      "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce",
+      "version": "0.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "feishu-connect",
+            "description": "QR connect for Feishu. Run bin/connect.mjs then open the Feishu link."
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "feishu",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "Feishu",
+            "description": "Use when the user wants to read or act on Feishu/Lark docs, calendar, chats, or Bitable. Connect first if tools are mis…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3",
       "version": "2.2.96",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -224,8 +224,8 @@
       }
     },
     "feishu": {
-      "sha": "f991b733dec27bec1ae69a967a153bd59f3313ce",
-      "version": "0.1.0",
+      "sha": "a1076084520914e46d5cad5f1cf0d138a0660aee",
+      "version": "0.1.1",
       "components": {
         "commands": [
           {


### PR DESCRIPTION
## Summary
- Add the scan-to-use `feishu` plugin to the catalog (docs, wiki, calendar, Bitable, IM).
- Source: https://github.com/anselorville/feishu-grok-plugin pinned to `a1076084520914e46d5cad5f1cf0d138a0660aee`.
- First-run QR creates the installer's own Feishu/Lark app; no hardcoded App Secret is shipped.
- Official `@larksuiteoapi/lark-mcp` then runs as the user (`--token-mode user_access_token`) after custom user OAuth (success page: 飞书已连接).
- Regenerated `plugin-index.json`. `python3 scripts/validate-catalog.py` and `python3 scripts/generate-plugin-index.py --check` pass locally.

Connect UI is QR + a markdown pill **在飞书中打开**. Agents must not dump a raw launcher URL in a sentence.

## Test plan
- [ ] Catalog validator passes in CI
- [ ] `grok plugin install feishu --trust` (after merge) or `grok plugin install https://github.com/anselorville/feishu-grok-plugin --trust` now
- [ ] `feishu_connect` shows a QR at `~/.feishu-grok/connect-qr.png` and a 在飞书中打开 control (no raw launcher URL in prose)
- [ ] `feishu_login` opens custom user OAuth (飞书已连接), then reload MCP so official lark-mcp starts as the user
- [ ] Agent waits for process / `~/.feishu-grok/last-event.json` (`connect_ok` / `oauth_ok`) and does not ask the user to type 弄好了