### PR TITLE
Add NexFade marketplace entry

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,26 @@
   },
   "plugins": [
     {
+      "name": "nexfade",
+      "description": "Create one-time, encrypted NexFade links for files and notes, then manage their status from Grok.",
+      "category": "security",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/NexFade/nexfade-grok-plugin.git",
+        "sha": "7f819df0787ba383bc2532b19926b589469bfed9"
+      },
+      "homepage": "https://www.nexfade.com/integrations/grok",
+      "keywords": [
+        "nexfade",
+        "nexfade secure link",
+        "nexfade encrypted sharing"
+      ],
+      "domains": [
+        "nexfade.com",
+        "www.nexfade.com"
+      ]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,24 @@
         ]
       }
     },
+    "nexfade": {
+      "sha": "7f819df0787ba383bc2532b19926b589469bfed9",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "nexfade",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "nexfade",
+            "description": "Create one-time NexFade encrypted links for attached files or sensitive notes, check link status, and revoke links."
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official NexFade plugin for Grok Build. NexFade creates one-time encrypted links for files and notes, checks link status, and revokes links. Encryption happens locally before upload.

- Plugin name: `nexfade`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/NexFade/nexfade-grok-plugin.git` at `7f819df0787ba383bc2532b19926b589469bfed9`
- Homepage: https://www.nexfade.com/integrations/grok

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case `name`.
- [x] Remote source pins a full 40-character lowercase commit SHA, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the source includes a README and `.grok-plugin/plugin.json`.
- [x] The plugin is MIT licensed.

## Security

- [x] No `curl | bash`, remote-code download/exec, dynamic code execution, or `postinstall` hook.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, or unrelated environment variables. The plugin reads only host-provided plugin/workspace paths and its configured NexFade API base URL.
- [x] MCP and filesystem access are least-privilege: only explicitly supplied regular files inside the current Grok workspace are accepted; symlink escapes, environment files, private keys, and common credential directories are rejected.
- Network endpoints: `https://www.nexfade.com` for the NexFade device authorization and link APIs, plus the presigned HTTPS ciphertext-upload destination returned by that API. The plugin has no telemetry.
- Credentials/permissions: the user signs in and approves `account:read`, `drops:read`, and `drops:write` through NexFade's browser device flow. The resulting scoped access token is stored in the host-provided plugin data directory with owner-only permissions; no token is copied into chat.

## Notes for reviewers

The source is published under the official `NexFade` GitHub organization and pinned to the public `v0.1.0` release commit. The package has no runtime dependencies, downloaded binaries, hooks, or install scripts. Its test suite, syntax checks, manifest validation, and a targeted public-source secret scan pass.
