### PR TITLE
feat: add hydrafetch plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "hydrafetch",
+      "description": "Turn any URL into clean, LLM-ready Markdown and structured data. Scrape a page, map a site, search the web, pull typed JSON by schema, and resolve a company's brand, logo, screenshot or design system from its domain, via the hosted Hydrafetch MCP server. Connects over OAuth with no API key to paste, and new workspaces get free credits with no card.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Hydrafetch/grok-plugin.git",
+        "sha": "7df8101b944fbd282529fb40379d8413da0a2a2f"
+      },
+      "homepage": "https://hydrafetch.com",
+      "keywords": ["hydrafetch", "hydrafetch scrape", "hydrafetch extract"],
+      "domains": ["hydrafetch.com", "app.hydrafetch.com", "docs.hydrafetch.com", "api.hydrafetch.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,48 @@
         ]
       }
     },
+    "hydrafetch": {
+      "sha": "7df8101b944fbd282529fb40379d8413da0a2a2f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "hydrafetch",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "build-a-dataset",
+            "description": "Assemble many pages into a table using queued crawl and batch jobs rather than a loop. Use for corpora, bulk enrichment…"
+          },
+          {
+            "name": "extract-structured-data",
+            "description": "Pull typed, schema-shaped JSON out of web pages. Use when you need fields rather than prose, or the same fields from ma…"
+          },
+          {
+            "name": "hydrafetch",
+            "description": "Use Hydrafetch for live web scraping, site mapping, search, structured extraction, brand and logo lookup, design system…"
+          },
+          {
+            "name": "research-a-company",
+            "description": "Build a company profile from its domain: identity, logos and colours, positioning, and site structure. Use for enrichme…"
+          },
+          {
+            "name": "scrape-for-context",
+            "description": "Turn one URL into clean markdown for a model to read. Use when a user gives you a link, when you need a page as groundi…"
+          },
+          {
+            "name": "show-a-company-logo",
+            "description": "Render a real company logo from a domain: an embeddable image URL for the browser, or JSON for a server. Use for CRM re…"
+          },
+          {
+            "name": "where-to-use-hydrafetch",
+            "description": "Audit a codebase for places Hydrafetch would replace fragile scraping infrastructure or add a capability the project la…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds Hydrafetch, a web data API: send a URL, get back clean Markdown or structured data with the navigation, banners and boilerplate stripped out. The plugin ships the hosted Hydrafetch MCP server plus seven skills that teach an agent which operation answers which question and what each one costs.

- Plugin name: `hydrafetch`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Hydrafetch/grok-plugin.git` @ `7df8101b944fbd282529fb40379d8413da0a2a2f`
- Homepage: https://hydrafetch.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`Hydrafetch`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated: MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin ships no scripts, no hooks and no binaries.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. It reads nothing from the filesystem.
- [x] Hooks and MCP scope are least-privilege. There are no hooks, and the single MCP server is remote HTTP with read-only web tools.
- Network endpoints this plugin calls (and why): exactly one, `https://api.hydrafetch.com/mcp`, the hosted Hydrafetch MCP server that provides the tools. Nothing else is contacted.
- Credentials/permissions it requires (and why): one Hydrafetch API key, needed to attribute and meter usage. It is obtained through the OAuth flow at `https://api.hydrafetch.com`, so a first-time user pastes nothing. A user who prefers a key can set `HYDRAFETCH_API_KEY` and have it sent as a bearer token instead, which is the path for CI. The token is scoped to `web:scrape` and `web:extract`.

## Notes for reviewers

The source repo is `Hydrafetch/grok-plugin`, under the same org as the product, so first-party ownership is verifiable at a glance.

`keywords` and `domains` are deliberately brand-scoped, per CONTRIBUTING. Generic web terms like `scrape`, `crawl` or `markdown` would misfire the plugin CTA against unrelated requests, so the keywords are `hydrafetch` and two product-scoped phrases, and the domains are only hosts we own.

The `.mcp.json` is a single remote HTTP server with no command to execute locally, so there is no local process, no install step and no dependency tree to audit.
