### PR TITLE
Add reecopedia (EU product and sustainability law MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,285 +1,448 @@
 {
-  "name": "xai-official",
-  "description": "Official xAI plugin marketplace",
-  "owner": {
-    "name": "xAI"
+ "name": "xai-official",
+ "description": "Official xAI plugin marketplace",
+ "owner": {
+  "name": "xAI"
+ },
+ "plugins": [
+  {
+   "name": "vercel",
+   "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
+   "category": "deployment",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/vercel/vercel-plugin.git",
+    "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
+   },
+   "homepage": "https://github.com/vercel/vercel-plugin",
+   "keywords": [
+    "vercel",
+    "vercel deploy",
+    "deploy to vercel"
+   ],
+   "domains": [
+    "vercel.com"
+   ]
   },
-  "plugins": [
-    {
-      "name": "vercel",
-      "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
-      "category": "deployment",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/vercel/vercel-plugin.git",
-        "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
-      },
-      "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
-    },
-    {
-      "name": "sentry",
-      "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
-      "category": "monitoring",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/getsentry/plugin-grok.git",
-        "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
-      },
-      "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
-    },
-    {
-      "name": "chrome-devtools",
-      "description": "Chrome DevTools integration. Control and inspect a live Chrome browser. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
-        "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
-      },
-      "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
-    },
-    {
-      "name": "cloudflare",
-      "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/cloudflare/skills.git",
-        "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
-      },
-      "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
-    },
-    {
-      "name": "superpowers",
-      "description": "Core skills library for software development: test-driven development, systematic debugging, collaboration patterns, and proven engineering workflows and techniques.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/obra/superpowers.git",
-        "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
-      },
-      "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
-    },
-    {
-      "name": "base44",
-      "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/base44/skills.git",
-        "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
-      },
-      "homepage": "https://docs.base44.com",
-      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
-      "domains": ["base44.com", "docs.base44.com"]
-    },
-    {
-      "name": "mongodb",
-      "description": "Official plugin for MongoDB (Self-Managed MCP Server + Skills). Connect to any MongoDB deployment (Community, Enterprise Advanced, local dev container via Atlas CLI, or Atlas clusters) through a self-managed MongoDB MCP Server using your connection string. Explore data, manage collections, optimize queries, and generate reliable code with MongoDB best practices.",
-      "category": "database",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/mongodb/agent-skills.git",
-        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
-        "path": "plugins/mongodb"
-      },
-      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
-      "domains": ["mongodb.com"]
-    },
-    {
-      "name": "mongodb-atlas",
-      "description": "Official plugin for MongoDB Atlas (Managed MCP Server + Skills). Sign in with your Atlas account to explore data, manage collections, optimize queries, generate reliable code with MongoDB best practices, and manage Atlas resources such as clusters, projects, database users, and network access.",
-      "category": "database",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/mongodb/agent-skills.git",
-        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
-        "path": "plugins/mongodb-atlas"
-      },
-      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
-    },
-    {
-      "name": "axiom",
-      "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
-      "category": "observability",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/axiomhq/skills.git",
-        "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
-      },
-      "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
-    },
-    {
-      "name": "neon",
-      "description": "Neon Serverless Postgres integration (MCP Server + Skills). Get started with Neon, manage projects and databases, pick connection methods, and create branches for migration testing and isolated development.",
-      "category": "database",
-      "source": {
-        "type": "local",
-        "path": "./external_plugins/neon"
-      },
-      "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
-    },
-    {
-      "name": "wix",
-      "description": "Build, manage, and deploy Wix sites and apps (MCP Server + Skills). Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/wix/skills.git",
-        "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
-      },
-      "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
-      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
-    },
-    {
-      "name": "netlify",
-      "description": "Skills for the Netlify platform: serverless and edge functions, Blobs storage, managed Postgres, Image CDN, forms, identity, caching, AI Gateway, framework adapters, and the Netlify CLI and deploys.",
-      "category": "deployment",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/netlify/context-and-tools.git",
-        "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
-      },
-      "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
-      "domains": ["netlify.com", "app.netlify.com"]
-    },
-    {
-      "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
-        "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
-      },
-      "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
-    },
-    {
-      "name": "figma",
-      "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/figma/mcp-server-guide.git",
-        "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
-      },
-      "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
-    },
-    {
-      "name": "exa",
-      "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/exa-labs/exa-grok-plugin.git",
-        "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
-      },
-      "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
-    },
-    {
-      "name": "tavily",
-      "description": "Web search, content extraction, website crawling, URL discovery, and deep research via Tavily's hosted MCP server and official skills. Connect with OAuth to access current, source-grounded web information directly from Grok Build.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/tavily-ai/tavily-grok-plugin.git",
-        "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
-      },
-      "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
-    },
-    {
-      "name": "railway",
-      "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
-      "category": "deployment",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/railwayapp/railway-skills.git",
-        "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
-        "path": "plugins/railway"
-      },
-      "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
-    },
-    {
-      "name": "stripe",
-      "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/stripe/ai.git",
-        "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
-        "path": "providers/grok/plugin"
-      },
-      "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
-    },
-    {
-      "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
-        "sha": "89457fba3fa44c7b2227807948628011983ab668",
-        "path": "grok"
-      },
-      "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
-    },
-    {
-      "name": "pstack",
-      "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/cursor/plugins.git",
-        "sha": "bdf7aa355337897f167153e05069aca505dae17c",
-        "path": "pstack"
-      },
-      "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": ["pstack", "poteto-mode", "poteto"]
-    },
-    {
-      "name": "browser-use",
-      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
-      "category": "development",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/browser-use/plugins.git",
-        "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
-        "path": "grok"
-      },
-      "homepage": "https://browser-use.com",
-      "keywords": ["browser use", "browser-use", "browser use cloud"],
-      "domains": ["browser-use.com", "cloud.browser-use.com"]
-    }
-  ]
+  {
+   "name": "sentry",
+   "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
+   "category": "monitoring",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/getsentry/plugin-grok.git",
+    "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
+   },
+   "homepage": "https://github.com/getsentry/sentry-for-ai",
+   "keywords": [
+    "sentry"
+   ],
+   "domains": [
+    "sentry.io"
+   ]
+  },
+  {
+   "name": "chrome-devtools",
+   "description": "Chrome DevTools integration. Control and inspect a live Chrome browser. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
+    "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
+   },
+   "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+   "keywords": [
+    "chrome devtools",
+    "chrome-devtools",
+    "devtools mcp"
+   ]
+  },
+  {
+   "name": "cloudflare",
+   "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/cloudflare/skills.git",
+    "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
+   },
+   "homepage": "https://github.com/cloudflare/skills",
+   "keywords": [
+    "cloudflare",
+    "wrangler",
+    "cloudflare workers"
+   ],
+   "domains": [
+    "cloudflare.com"
+   ]
+  },
+  {
+   "name": "superpowers",
+   "description": "Core skills library for software development: test-driven development, systematic debugging, collaboration patterns, and proven engineering workflows and techniques.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/obra/superpowers.git",
+    "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
+   },
+   "homepage": "https://github.com/obra/superpowers",
+   "keywords": [
+    "superpowers"
+   ]
+  },
+  {
+   "name": "base44",
+   "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/base44/skills.git",
+    "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
+   },
+   "homepage": "https://docs.base44.com",
+   "keywords": [
+    "base44",
+    "base44 cli",
+    "base44 sdk",
+    "base44 app",
+    "base44 deploy"
+   ],
+   "domains": [
+    "base44.com",
+    "docs.base44.com"
+   ]
+  },
+  {
+   "name": "mongodb",
+   "description": "Official plugin for MongoDB (Self-Managed MCP Server + Skills). Connect to any MongoDB deployment (Community, Enterprise Advanced, local dev container via Atlas CLI, or Atlas clusters) through a self-managed MongoDB MCP Server using your connection string. Explore data, manage collections, optimize queries, and generate reliable code with MongoDB best practices.",
+   "category": "database",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/mongodb/agent-skills.git",
+    "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+    "path": "plugins/mongodb"
+   },
+   "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+   "keywords": [
+    "mongodb community",
+    "mongo",
+    "mongosh",
+    "mongodb local mcp",
+    "enterprise advanced"
+   ],
+   "domains": [
+    "mongodb.com"
+   ]
+  },
+  {
+   "name": "mongodb-atlas",
+   "description": "Official plugin for MongoDB Atlas (Managed MCP Server + Skills). Sign in with your Atlas account to explore data, manage collections, optimize queries, generate reliable code with MongoDB best practices, and manage Atlas resources such as clusters, projects, database users, and network access.",
+   "category": "database",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/mongodb/agent-skills.git",
+    "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+    "path": "plugins/mongodb-atlas"
+   },
+   "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+   "keywords": [
+    "mongodb atlas",
+    "atlas",
+    "mongodb",
+    "atlas cluster",
+    "atlas mcp"
+   ],
+   "domains": [
+    "mongodb.com",
+    "cloud.mongodb.com"
+   ]
+  },
+  {
+   "name": "axiom",
+   "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+   "category": "observability",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/axiomhq/skills.git",
+    "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
+   },
+   "homepage": "https://github.com/axiomhq/skills",
+   "keywords": [
+    "axiom"
+   ],
+   "domains": [
+    "axiom.co",
+    "app.axiom.co"
+   ]
+  },
+  {
+   "name": "neon",
+   "description": "Neon Serverless Postgres integration (MCP Server + Skills). Get started with Neon, manage projects and databases, pick connection methods, and create branches for migration testing and isolated development.",
+   "category": "database",
+   "source": {
+    "type": "local",
+    "path": "./external_plugins/neon"
+   },
+   "homepage": "https://neon.com",
+   "keywords": [
+    "neon",
+    "neon postgres",
+    "neon database",
+    "neon branch"
+   ],
+   "domains": [
+    "neon.tech",
+    "neon.com",
+    "console.neon.tech"
+   ]
+  },
+  {
+   "name": "wix",
+   "description": "Build, manage, and deploy Wix sites and apps (MCP Server + Skills). Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/wix/skills.git",
+    "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
+   },
+   "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
+   "keywords": [
+    "wix",
+    "wix cli",
+    "wix mcp",
+    "wix apps",
+    "wix headless"
+   ],
+   "domains": [
+    "wix.com",
+    "dev.wix.com",
+    "manage.wix.com"
+   ]
+  },
+  {
+   "name": "netlify",
+   "description": "Skills for the Netlify platform: serverless and edge functions, Blobs storage, managed Postgres, Image CDN, forms, identity, caching, AI Gateway, framework adapters, and the Netlify CLI and deploys.",
+   "category": "deployment",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/netlify/context-and-tools.git",
+    "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
+   },
+   "homepage": "https://github.com/netlify/context-and-tools",
+   "keywords": [
+    "netlify",
+    "netlify deploy",
+    "deploy to netlify"
+   ],
+   "domains": [
+    "netlify.com",
+    "app.netlify.com"
+   ]
+  },
+  {
+   "name": "firecrawl",
+   "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
+    "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
+   },
+   "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
+   "keywords": [
+    "firecrawl",
+    "fire crawl"
+   ],
+   "domains": [
+    "firecrawl.dev",
+    "docs.firecrawl.dev"
+   ]
+  },
+  {
+   "name": "figma",
+   "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/figma/mcp-server-guide.git",
+    "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
+   },
+   "homepage": "https://github.com/figma/mcp-server-guide",
+   "keywords": [
+    "figma",
+    "figma mcp"
+   ],
+   "domains": [
+    "figma.com",
+    "www.figma.com"
+   ]
+  },
+  {
+   "name": "exa",
+   "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/exa-labs/exa-grok-plugin.git",
+    "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
+   },
+   "homepage": "https://exa.ai",
+   "keywords": [
+    "exa",
+    "exa search",
+    "exa ai"
+   ],
+   "domains": [
+    "exa.ai",
+    "dashboard.exa.ai",
+    "docs.exa.ai"
+   ]
+  },
+  {
+   "name": "tavily",
+   "description": "Web search, content extraction, website crawling, URL discovery, and deep research via Tavily's hosted MCP server and official skills. Connect with OAuth to access current, source-grounded web information directly from Grok Build.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/tavily-ai/tavily-grok-plugin.git",
+    "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
+   },
+   "homepage": "https://www.tavily.com",
+   "keywords": [
+    "tavily",
+    "tavily search",
+    "tavily ai"
+   ],
+   "domains": [
+    "tavily.com",
+    "www.tavily.com",
+    "app.tavily.com",
+    "docs.tavily.com"
+   ]
+  },
+  {
+   "name": "railway",
+   "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
+   "category": "deployment",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/railwayapp/railway-skills.git",
+    "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
+    "path": "plugins/railway"
+   },
+   "homepage": "https://github.com/railwayapp/railway-skills",
+   "keywords": [
+    "railway",
+    "railway deploy",
+    "deploy to railway"
+   ],
+   "domains": [
+    "railway.com",
+    "railway.app"
+   ]
+  },
+  {
+   "name": "stripe",
+   "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/stripe/ai.git",
+    "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
+    "path": "providers/grok/plugin"
+   },
+   "homepage": "https://github.com/stripe/ai",
+   "keywords": [
+    "stripe",
+    "stripe payments",
+    "stripe connect",
+    "stripe mcp",
+    "stripe billing"
+   ],
+   "domains": [
+    "stripe.com",
+    "docs.stripe.com",
+    "dashboard.stripe.com"
+   ]
+  },
+  {
+   "name": "tinyfish",
+   "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
+    "sha": "89457fba3fa44c7b2227807948628011983ab668",
+    "path": "grok"
+   },
+   "homepage": "https://www.tinyfish.ai",
+   "keywords": [
+    "tinyfish",
+    "tinyfish agent",
+    "tinyfish web agent",
+    "agentql"
+   ],
+   "domains": [
+    "tinyfish.ai",
+    "agent.tinyfish.ai",
+    "docs.tinyfish.ai"
+   ]
+  },
+  {
+   "name": "pstack",
+   "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/cursor/plugins.git",
+    "sha": "bdf7aa355337897f167153e05069aca505dae17c",
+    "path": "pstack"
+   },
+   "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
+   "keywords": [
+    "pstack",
+    "poteto-mode",
+    "poteto"
+   ]
+  },
+  {
+   "name": "browser-use",
+   "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+   "category": "development",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/browser-use/plugins.git",
+    "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
+    "path": "grok"
+   },
+   "homepage": "https://browser-use.com",
+   "keywords": [
+    "browser use",
+    "browser-use",
+    "browser use cloud"
+   ],
+   "domains": [
+    "browser-use.com",
+    "cloud.browser-use.com"
+   ]
+  },
+  {
+   "name": "reecopedia",
+   "description": "Cited search over EU product and sustainability law (ESPR, Digital Product Passport, CSRD, CBAM, EU ETS, CWA 18291). Public remote MCP, no authentication.",
+   "source": {
+    "source": "url",
+    "url": "https://github.com/halleluiaman-ux/reecopedia-mcp.git",
+    "sha": "48890290ae115be6581ac396975ba2280bf184ae"
+   },
+   "homepage": "https://ia.reeco.eco/reecopedia",
+   "keywords": [
+    "reecopedia",
+    "reeco"
+   ],
+   "domains": [
+    "ia.reeco.eco",
+    "reeco.eco"
+   ]
+  }
+ ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,448 +1,297 @@
 {
- "name": "xai-official",
- "description": "Official xAI plugin marketplace",
- "owner": {
-  "name": "xAI"
- },
- "plugins": [
-  {
-   "name": "vercel",
-   "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
-   "category": "deployment",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/vercel/vercel-plugin.git",
-    "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
-   },
-   "homepage": "https://github.com/vercel/vercel-plugin",
-   "keywords": [
-    "vercel",
-    "vercel deploy",
-    "deploy to vercel"
-   ],
-   "domains": [
-    "vercel.com"
-   ]
+  "name": "xai-official",
+  "description": "Official xAI plugin marketplace",
+  "owner": {
+    "name": "xAI"
   },
-  {
-   "name": "sentry",
-   "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
-   "category": "monitoring",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/getsentry/plugin-grok.git",
-    "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
-   },
-   "homepage": "https://github.com/getsentry/sentry-for-ai",
-   "keywords": [
-    "sentry"
-   ],
-   "domains": [
-    "sentry.io"
-   ]
-  },
-  {
-   "name": "chrome-devtools",
-   "description": "Chrome DevTools integration. Control and inspect a live Chrome browser. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
-    "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
-   },
-   "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-   "keywords": [
-    "chrome devtools",
-    "chrome-devtools",
-    "devtools mcp"
-   ]
-  },
-  {
-   "name": "cloudflare",
-   "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/cloudflare/skills.git",
-    "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
-   },
-   "homepage": "https://github.com/cloudflare/skills",
-   "keywords": [
-    "cloudflare",
-    "wrangler",
-    "cloudflare workers"
-   ],
-   "domains": [
-    "cloudflare.com"
-   ]
-  },
-  {
-   "name": "superpowers",
-   "description": "Core skills library for software development: test-driven development, systematic debugging, collaboration patterns, and proven engineering workflows and techniques.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/obra/superpowers.git",
-    "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
-   },
-   "homepage": "https://github.com/obra/superpowers",
-   "keywords": [
-    "superpowers"
-   ]
-  },
-  {
-   "name": "base44",
-   "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/base44/skills.git",
-    "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
-   },
-   "homepage": "https://docs.base44.com",
-   "keywords": [
-    "base44",
-    "base44 cli",
-    "base44 sdk",
-    "base44 app",
-    "base44 deploy"
-   ],
-   "domains": [
-    "base44.com",
-    "docs.base44.com"
-   ]
-  },
-  {
-   "name": "mongodb",
-   "description": "Official plugin for MongoDB (Self-Managed MCP Server + Skills). Connect to any MongoDB deployment (Community, Enterprise Advanced, local dev container via Atlas CLI, or Atlas clusters) through a self-managed MongoDB MCP Server using your connection string. Explore data, manage collections, optimize queries, and generate reliable code with MongoDB best practices.",
-   "category": "database",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/mongodb/agent-skills.git",
-    "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
-    "path": "plugins/mongodb"
-   },
-   "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-   "keywords": [
-    "mongodb community",
-    "mongo",
-    "mongosh",
-    "mongodb local mcp",
-    "enterprise advanced"
-   ],
-   "domains": [
-    "mongodb.com"
-   ]
-  },
-  {
-   "name": "mongodb-atlas",
-   "description": "Official plugin for MongoDB Atlas (Managed MCP Server + Skills). Sign in with your Atlas account to explore data, manage collections, optimize queries, generate reliable code with MongoDB best practices, and manage Atlas resources such as clusters, projects, database users, and network access.",
-   "category": "database",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/mongodb/agent-skills.git",
-    "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
-    "path": "plugins/mongodb-atlas"
-   },
-   "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-   "keywords": [
-    "mongodb atlas",
-    "atlas",
-    "mongodb",
-    "atlas cluster",
-    "atlas mcp"
-   ],
-   "domains": [
-    "mongodb.com",
-    "cloud.mongodb.com"
-   ]
-  },
-  {
-   "name": "axiom",
-   "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
-   "category": "observability",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/axiomhq/skills.git",
-    "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
-   },
-   "homepage": "https://github.com/axiomhq/skills",
-   "keywords": [
-    "axiom"
-   ],
-   "domains": [
-    "axiom.co",
-    "app.axiom.co"
-   ]
-  },
-  {
-   "name": "neon",
-   "description": "Neon Serverless Postgres integration (MCP Server + Skills). Get started with Neon, manage projects and databases, pick connection methods, and create branches for migration testing and isolated development.",
-   "category": "database",
-   "source": {
-    "type": "local",
-    "path": "./external_plugins/neon"
-   },
-   "homepage": "https://neon.com",
-   "keywords": [
-    "neon",
-    "neon postgres",
-    "neon database",
-    "neon branch"
-   ],
-   "domains": [
-    "neon.tech",
-    "neon.com",
-    "console.neon.tech"
-   ]
-  },
-  {
-   "name": "wix",
-   "description": "Build, manage, and deploy Wix sites and apps (MCP Server + Skills). Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/wix/skills.git",
-    "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
-   },
-   "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-   "keywords": [
-    "wix",
-    "wix cli",
-    "wix mcp",
-    "wix apps",
-    "wix headless"
-   ],
-   "domains": [
-    "wix.com",
-    "dev.wix.com",
-    "manage.wix.com"
-   ]
-  },
-  {
-   "name": "netlify",
-   "description": "Skills for the Netlify platform: serverless and edge functions, Blobs storage, managed Postgres, Image CDN, forms, identity, caching, AI Gateway, framework adapters, and the Netlify CLI and deploys.",
-   "category": "deployment",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/netlify/context-and-tools.git",
-    "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
-   },
-   "homepage": "https://github.com/netlify/context-and-tools",
-   "keywords": [
-    "netlify",
-    "netlify deploy",
-    "deploy to netlify"
-   ],
-   "domains": [
-    "netlify.com",
-    "app.netlify.com"
-   ]
-  },
-  {
-   "name": "firecrawl",
-   "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
-    "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
-   },
-   "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-   "keywords": [
-    "firecrawl",
-    "fire crawl"
-   ],
-   "domains": [
-    "firecrawl.dev",
-    "docs.firecrawl.dev"
-   ]
-  },
-  {
-   "name": "figma",
-   "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/figma/mcp-server-guide.git",
-    "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
-   },
-   "homepage": "https://github.com/figma/mcp-server-guide",
-   "keywords": [
-    "figma",
-    "figma mcp"
-   ],
-   "domains": [
-    "figma.com",
-    "www.figma.com"
-   ]
-  },
-  {
-   "name": "exa",
-   "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/exa-labs/exa-grok-plugin.git",
-    "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
-   },
-   "homepage": "https://exa.ai",
-   "keywords": [
-    "exa",
-    "exa search",
-    "exa ai"
-   ],
-   "domains": [
-    "exa.ai",
-    "dashboard.exa.ai",
-    "docs.exa.ai"
-   ]
-  },
-  {
-   "name": "tavily",
-   "description": "Web search, content extraction, website crawling, URL discovery, and deep research via Tavily's hosted MCP server and official skills. Connect with OAuth to access current, source-grounded web information directly from Grok Build.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/tavily-ai/tavily-grok-plugin.git",
-    "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
-   },
-   "homepage": "https://www.tavily.com",
-   "keywords": [
-    "tavily",
-    "tavily search",
-    "tavily ai"
-   ],
-   "domains": [
-    "tavily.com",
-    "www.tavily.com",
-    "app.tavily.com",
-    "docs.tavily.com"
-   ]
-  },
-  {
-   "name": "railway",
-   "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
-   "category": "deployment",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/railwayapp/railway-skills.git",
-    "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
-    "path": "plugins/railway"
-   },
-   "homepage": "https://github.com/railwayapp/railway-skills",
-   "keywords": [
-    "railway",
-    "railway deploy",
-    "deploy to railway"
-   ],
-   "domains": [
-    "railway.com",
-    "railway.app"
-   ]
-  },
-  {
-   "name": "stripe",
-   "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/stripe/ai.git",
-    "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
-    "path": "providers/grok/plugin"
-   },
-   "homepage": "https://github.com/stripe/ai",
-   "keywords": [
-    "stripe",
-    "stripe payments",
-    "stripe connect",
-    "stripe mcp",
-    "stripe billing"
-   ],
-   "domains": [
-    "stripe.com",
-    "docs.stripe.com",
-    "dashboard.stripe.com"
-   ]
-  },
-  {
-   "name": "tinyfish",
-   "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
-    "sha": "89457fba3fa44c7b2227807948628011983ab668",
-    "path": "grok"
-   },
-   "homepage": "https://www.tinyfish.ai",
-   "keywords": [
-    "tinyfish",
-    "tinyfish agent",
-    "tinyfish web agent",
-    "agentql"
-   ],
-   "domains": [
-    "tinyfish.ai",
-    "agent.tinyfish.ai",
-    "docs.tinyfish.ai"
-   ]
-  },
-  {
-   "name": "pstack",
-   "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/cursor/plugins.git",
-    "sha": "bdf7aa355337897f167153e05069aca505dae17c",
-    "path": "pstack"
-   },
-   "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-   "keywords": [
-    "pstack",
-    "poteto-mode",
-    "poteto"
-   ]
-  },
-  {
-   "name": "browser-use",
-   "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
-   "category": "development",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/browser-use/plugins.git",
-    "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
-    "path": "grok"
-   },
-   "homepage": "https://browser-use.com",
-   "keywords": [
-    "browser use",
-    "browser-use",
-    "browser use cloud"
-   ],
-   "domains": [
-    "browser-use.com",
-    "cloud.browser-use.com"
-   ]
-  },
-  {
-   "name": "reecopedia",
-   "description": "Cited search over EU product and sustainability law (ESPR, Digital Product Passport, CSRD, CBAM, EU ETS, CWA 18291). Public remote MCP, no authentication.",
-   "source": {
-    "source": "url",
-    "url": "https://github.com/halleluiaman-ux/reecopedia-mcp.git",
-    "sha": "48890290ae115be6581ac396975ba2280bf184ae"
-   },
-   "homepage": "https://ia.reeco.eco/reecopedia",
-   "keywords": [
-    "reecopedia",
-    "reeco"
-   ],
-   "domains": [
-    "ia.reeco.eco",
-    "reeco.eco"
-   ]
-  }
- ]
+  "plugins": [
+    {
+      "name": "vercel",
+      "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vercel/vercel-plugin.git",
+        "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
+      },
+      "homepage": "https://github.com/vercel/vercel-plugin",
+      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
+      "domains": ["vercel.com"]
+    },
+    {
+      "name": "sentry",
+      "description": "Sentry error monitoring integration. Access error reports, analyze stack traces, search issues by fingerprint, and debug production errors directly from your development environment.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/getsentry/plugin-grok.git",
+        "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
+      },
+      "homepage": "https://github.com/getsentry/sentry-for-ai",
+      "keywords": ["sentry"],
+      "domains": ["sentry.io"]
+    },
+    {
+      "name": "chrome-devtools",
+      "description": "Chrome DevTools integration. Control and inspect a live Chrome browser. Record performance traces, analyze network requests, check console messages with source-mapped stack traces, and automate browser actions.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
+        "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
+      },
+      "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+    },
+    {
+      "name": "cloudflare",
+      "description": "Skills for the Cloudflare developer platform: Workers, Durable Objects, Agents SDK, MCP servers, Wrangler CLI, and web performance.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cloudflare/skills.git",
+        "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
+      },
+      "homepage": "https://github.com/cloudflare/skills",
+      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
+      "domains": ["cloudflare.com"]
+    },
+    {
+      "name": "superpowers",
+      "description": "Core skills library for software development: test-driven development, systematic debugging, collaboration patterns, and proven engineering workflows and techniques.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/obra/superpowers.git",
+        "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
+      },
+      "homepage": "https://github.com/obra/superpowers",
+      "keywords": ["superpowers"]
+    },
+    {
+      "name": "base44",
+      "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/base44/skills.git",
+        "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
+      },
+      "homepage": "https://docs.base44.com",
+      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
+      "domains": ["base44.com", "docs.base44.com"]
+    },
+    {
+      "name": "mongodb",
+      "description": "Official plugin for MongoDB (Self-Managed MCP Server + Skills). Connect to any MongoDB deployment (Community, Enterprise Advanced, local dev container via Atlas CLI, or Atlas clusters) through a self-managed MongoDB MCP Server using your connection string. Explore data, manage collections, optimize queries, and generate reliable code with MongoDB best practices.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mongodb/agent-skills.git",
+        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+        "path": "plugins/mongodb"
+      },
+      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
+      "domains": ["mongodb.com"]
+    },
+    {
+      "name": "mongodb-atlas",
+      "description": "Official plugin for MongoDB Atlas (Managed MCP Server + Skills). Sign in with your Atlas account to explore data, manage collections, optimize queries, generate reliable code with MongoDB best practices, and manage Atlas resources such as clusters, projects, database users, and network access.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mongodb/agent-skills.git",
+        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+        "path": "plugins/mongodb-atlas"
+      },
+      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
+      "domains": ["mongodb.com", "cloud.mongodb.com"]
+    },
+    {
+      "name": "axiom",
+      "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+      "category": "observability",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/axiomhq/skills.git",
+        "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
+      },
+      "homepage": "https://github.com/axiomhq/skills",
+      "keywords": ["axiom"],
+      "domains": ["axiom.co", "app.axiom.co"]
+    },
+    {
+      "name": "neon",
+      "description": "Neon Serverless Postgres integration (MCP Server + Skills). Get started with Neon, manage projects and databases, pick connection methods, and create branches for migration testing and isolated development.",
+      "category": "database",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/neon"
+      },
+      "homepage": "https://neon.com",
+      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
+      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+    },
+    {
+      "name": "wix",
+      "description": "Build, manage, and deploy Wix sites and apps (MCP Server + Skills). Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/wix/skills.git",
+        "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
+      },
+      "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
+      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
+      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
+    },
+    {
+      "name": "netlify",
+      "description": "Skills for the Netlify platform: serverless and edge functions, Blobs storage, managed Postgres, Image CDN, forms, identity, caching, AI Gateway, framework adapters, and the Netlify CLI and deploys.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/netlify/context-and-tools.git",
+        "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
+      },
+      "homepage": "https://github.com/netlify/context-and-tools",
+      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
+      "domains": ["netlify.com", "app.netlify.com"]
+    },
+    {
+      "name": "firecrawl",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
+        "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
+      },
+      "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
+      "keywords": ["firecrawl", "fire crawl"],
+      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+    },
+    {
+      "name": "figma",
+      "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/figma/mcp-server-guide.git",
+        "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
+      },
+      "homepage": "https://github.com/figma/mcp-server-guide",
+      "keywords": ["figma", "figma mcp"],
+      "domains": ["figma.com", "www.figma.com"]
+    },
+    {
+      "name": "exa",
+      "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/exa-labs/exa-grok-plugin.git",
+        "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
+      },
+      "homepage": "https://exa.ai",
+      "keywords": ["exa", "exa search", "exa ai"],
+      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+    },
+    {
+      "name": "tavily",
+      "description": "Web search, content extraction, website crawling, URL discovery, and deep research via Tavily's hosted MCP server and official skills. Connect with OAuth to access current, source-grounded web information directly from Grok Build.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tavily-ai/tavily-grok-plugin.git",
+        "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
+      },
+      "homepage": "https://www.tavily.com",
+      "keywords": ["tavily", "tavily search", "tavily ai"],
+      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+    },
+    {
+      "name": "railway",
+      "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/railwayapp/railway-skills.git",
+        "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
+        "path": "plugins/railway"
+      },
+      "homepage": "https://github.com/railwayapp/railway-skills",
+      "keywords": ["railway", "railway deploy", "deploy to railway"],
+      "domains": ["railway.com", "railway.app"]
+    },
+    {
+      "name": "stripe",
+      "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/stripe/ai.git",
+        "sha": "1dc126b93cc62e28aff7e00e51406dfeb8ac88d5",
+        "path": "providers/grok/plugin"
+      },
+      "homepage": "https://github.com/stripe/ai",
+      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
+      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+    },
+    {
+      "name": "tinyfish",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
+        "sha": "89457fba3fa44c7b2227807948628011983ab668",
+        "path": "grok"
+      },
+      "homepage": "https://www.tinyfish.ai",
+      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
+      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+    },
+    {
+      "name": "pstack",
+      "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cursor/plugins.git",
+        "sha": "bdf7aa355337897f167153e05069aca505dae17c",
+        "path": "pstack"
+      },
+      "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
+      "keywords": ["pstack", "poteto-mode", "poteto"]
+    },
+    {
+      "name": "browser-use",
+      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/browser-use/plugins.git",
+        "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
+        "path": "grok"
+      },
+      "homepage": "https://browser-use.com",
+      "keywords": ["browser use", "browser-use", "browser use cloud"],
+      "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "reecopedia",
+      "description": "Cited search over EU product and sustainability law (ESPR, Digital Product Passport, CSRD, CBAM, EU ETS, CWA 18291). Public remote MCP, no authentication.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/halleluiaman-ux/reecopedia-mcp.git",
+        "sha": "48890290ae115be6581ac396975ba2280bf184ae"
+      },
+      "homepage": "https://ia.reeco.eco/reecopedia",
+      "keywords": ["reecopedia", "reeco"],
+      "domains": ["ia.reeco.eco", "reeco.eco"]
+    }
+  ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -741,6 +741,17 @@
         ]
       }
     },
+    "reecopedia": {
+      "sha": "48890290ae115be6581ac396975ba2280bf184ae",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "reecopedia",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
       "version": "1.3.2",


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

- Plugin name: `reecopedia`
- Type: remote source
- Source URL + pinned SHA (remote): `https://github.com/halleluiaman-ux/reecopedia-mcp.git` @ `48890290ae115be6581ac396975ba2280bf184ae`
- Homepage: https://ia.reeco.eco/reecopedia

Adds **reecopedia** to the Grok Build catalog. It is a public Streamable HTTP MCP at `https://ia.reeco.eco/mcp`: cited search over EU product and sustainability law (ESPR, Digital Product Passport, CSRD, CBAM, EU ETS, CWA 18291). No authentication.

Also listed on the official MCP Registry as `eco.reeco/reecopedia` (1.4.0) and on [cursor.directory/plugins/reecopedia](https://cursor.directory/plugins/reecopedia).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

The packaging repo is under the personal GitHub account `halleluiaman-ux` (Stefano Cipriani / Reeco). The live MCP is first-party Reeco infrastructure at `ia.reeco.eco`. Same GitHub account already publishes the Cursor directory plugin. There is not yet a `reeco` GitHub org hosting this packaging repo; happy to move the source there if that unblocks review.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: MIT, in `LICENSE` of the source repo (Copyright 2026 Stefano Cipriani Studio).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://ia.reeco.eco/mcp` only — the public Reecopedia MCP (Streamable HTTP). Search/fetch tools query that server; they do not scrape arbitrary hosts from the plugin config.
- Credentials/permissions it requires (and why): none. The remote MCP is unauthenticated.

This is a **remote URL MCP**, not a local stdio server. The plugin does not install hooks, skills, or local binaries. Index generation reports a single `mcpServers` component (`reecopedia`).

## Notes for reviewers

- Keywords/domains are brand-scoped (`reecopedia`, `reeco`, `ia.reeco.eco`, `reeco.eco`), not generic legal terms.
- Pinned SHA is current `HEAD` of `reecopedia-mcp` and includes root `.mcp.json` pointing at the same public URL already used by the nested Cursor plugin under `plugins/reecopedia/`.
- Net diff vs `main` is +23 lines (one catalog entry + generated index block).

## Test plan

- [ ] CI `validate-catalog.py` and `generate-plugin-index.py --check` green
- [ ] After merge, `grok plugin marketplace list` shows `reecopedia`
- [ ] `grok plugin install reecopedia --trust` connects to `https://ia.reeco.eco/mcp`


Made with [Cursor](https://cursor.com)