### PR TITLE
Add the FoundRole plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "foundrole",
+      "description": "AI job search and application tracker. Search live openings from company career pages by title, location, salary, and remote or on-site, and see each posting checked against real data: pay versus the market, ghost-posting risk, and visa sponsorship history. Track applications on a Kanban board, set reminders, and subscribe to email alerts. Free, OAuth sign-in, no API key.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/foundrole/jobs-mcp-proxy.git",
+        "sha": "d046ee0d48f75e71ffc03537980c90e15340db9e"
+      },
+      "homepage": "https://www.foundrole.com/ai-search-mcp",
+      "keywords": ["foundrole", "foundrole jobs", "foundrole job search", "foundrole tracker"],
+      "domains": ["foundrole.com", "www.foundrole.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,18 @@
         ]
       }
     },
+    "foundrole": {
+      "sha": "d046ee0d48f75e71ffc03537980c90e15340db9e",
+      "version": "1.1.10",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "foundrole",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

Adds FoundRole — an AI job search and application tracker — as a remote-source plugin.

- Plugin name: `foundrole`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/foundrole/jobs-mcp-proxy.git` @ `d046ee0d48f75e71ffc03537980c90e15340db9e`
- Homepage: https://www.foundrole.com/ai-search-mcp

FoundRole searches live openings pulled hourly from company career pages and checks each
posting against real data: pay versus what employers in that market actually file,
ghost-posting risk, and whether the company has sponsored visas before. It also carries a
Kanban application tracker, follow-up reminders with calendar invites, and email job alerts.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`github.com/foundrole`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (ISC).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin ships **one hosted MCP server and nothing else** — no hooks, no skills, no
commands, no agents, no local process. The generated index reflects this:

```json
"foundrole": {
  "sha": "d046ee0d48f75e71ffc03537980c90e15340db9e",
  "version": "1.1.10",
  "components": { "mcpServers": [{ "name": "foundrole", "description": "http" }] }
}
```

- Network endpoints this plugin calls (and why): `https://www.foundrole.com/mcp` — the
  FoundRole MCP endpoint, streamable HTTP. It is the only host contacted, and it serves
  the job search, the fact-checks, the tracker, reminders, and alerts.
- Credentials/permissions it requires (and why): standard OAuth to a free FoundRole
  account, initiated by the client on first connection. There is no API key to store and
  nothing is read from the user's machine — no filesystem, env var, or credential access.

## Notes for reviewers

The source repo is the same one behind our published integrations elsewhere: the npm
package `@foundrole/ai-job-search-mcp`, the MCP Registry entry
`io.github.foundrole/jobs-mcp-proxy`, and the Claude and Cursor plugin manifests that live
in the same repo. `.grok-plugin/plugin.json` is the Grok-specific manifest, and its version
is kept in step with the npm release by the repo's `version` lifecycle hook, so the daily
SHA bumper sees each release.
