### PR TITLE
Add graph-advocate plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,27 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "graph-advocate",
+      "description": "Onchain data routing for The Graph. Live data from 15,500+ subgraphs, Token API (EVM/Solana/TON), Polymarket, Hyperliquid, x402 analytics, and ERC-8004 agent reputation via the Graph Advocate MCP. No private key; paid tools return a structured 402 for the caller wallet to settle.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/PaulieB14/graph-advocate.git",
+        "sha": "f63c93e36c77dc03ce260d10a45aa82aa60a3ad0",
+        "path": "plugins/graph-advocate"
+      },
+      "homepage": "https://graphadvocate.com",
+      "keywords": [
+        "graph-advocate",
+        "the graph",
+        "graphadvocate",
+        "x402"
+      ],
+      "domains": [
+        "graphadvocate.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/PaulieB14/graph-advocate.git",
-        "sha": "f63c93e36c77dc03ce260d10a45aa82aa60a3ad0",
+        "sha": "ab775257c394f7897bbaf580868ff1e2b6d59420",
         "path": "plugins/graph-advocate"
       },
       "homepage": "https://graphadvocate.com",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -346,7 +346,7 @@
       }
     },
     "graph-advocate": {
-      "sha": "f63c93e36c77dc03ce260d10a45aa82aa60a3ad0",
+      "sha": "ab775257c394f7897bbaf580868ff1e2b6d59420",
       "version": "2.11.1",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,24 @@
         ]
       }
     },
+    "graph-advocate": {
+      "sha": "f63c93e36c77dc03ce260d10a45aa82aa60a3ad0",
+      "version": "2.11.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "graph-advocate",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "graph-advocate",
+            "description": "Route any blockchain data question to the right Graph Protocol service. Returns live data from 15,500+ subgraphs, Token…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `graph-advocate`
- Type: remote source
- Source URL + pinned SHA: https://github.com/PaulieB14/graph-advocate.git @ `f63c93e36c77dc03ce260d10a45aa82aa60a3ad0` (`path`: `plugins/graph-advocate`)
- Homepage: https://graphadvocate.com

Adds Graph Advocate to the Grok Build catalog. MCP is stdio via `npx -y graph-advocate-mcp`. No private key; paid tools return a structured HTTP 402 for the caller wallet to settle x402.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

Official product is Graph Advocate (https://graphadvocate.com), built and published by Graphtronauts / PaulieB14. The canonical source is `PaulieB14/graph-advocate` — there is no separate org repo yet. Same account owns the domain, the live service, and this plugin.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (`MIT-0` in `plugins/graph-advocate/.grok-plugin/plugin.json`)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://graphadvocate.com` (override `GRAPH_ADVOCATE_URL`) — the Graph Advocate MCP HTTP target. Documented in `plugins/graph-advocate/README.md`.
- Credentials/permissions it requires (and why): none required. Optional public `GRAPH_ADVOCATE_SENDER` (`0x` address, not a key). The MCP does not ship or use a private key and will not sign x402 payments.

## Notes for reviewers

Index extract at the pinned SHA:

- version `2.11.1`
- MCP `graph-advocate` (stdio)
- skill `graph-advocate`

Plugin files live under `plugins/graph-advocate/` in the product repo (same layout as Railway/Mongo).