### PR TITLE
Add kairogen plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,30 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "kairogen",
+      "description": "Generate images, videos, and audio with Kairogen — one account and one credit wallet in front of Seedream, Flux, Nano Banana, GPT Image, Sora, Veo, Kling, Seedance, KairoClone, and Topaz. Connects over OAuth to Kairogen's hosted MCP server; skills cover model selection, cost control, reference workflows, narration, and dubbing.",
+      "category": "media",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/kairogenai/kairogen-grok-plugin.git",
+        "sha": "fa3a85f4f94b2c1814efdbec8dab6505f0ff3e7e"
+      },
+      "homepage": "https://kairogen.ai",
+      "keywords": [
+        "kairogen",
+        "kairogen image",
+        "kairogen video",
+        "kairogen audio",
+        "kairogen mcp"
+      ],
+      "domains": [
+        "kairogen.ai",
+        "app.kairogen.ai",
+        "api.kairogen.ai",
+        "mcp.kairogen.ai"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -345,6 +345,46 @@
         ]
       }
     },
+    "kairogen": {
+      "sha": "fa3a85f4f94b2c1814efdbec8dab6505f0ff3e7e",
+      "version": "1.0.0",
+      "components": {
+        "commands": [
+          {
+            "name": "kairogen-tutorial",
+            "description": "Guided first run of the Kairogen plugin — connect, browse models, generate an image"
+          },
+          {
+            "name": "models",
+            "description": "Browse the Kairogen model catalog with prices, filtered by what you need"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "kairogen",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "kairogen",
+            "description": "Entry point for Kairogen — generate images, videos, and audio from Grok Build. Use whenever \"Kairogen\" is mentioned, an…"
+          },
+          {
+            "name": "kairogen-audio",
+            "description": "Generate speech, sound effects, and music with Kairogen, and add audio to video — narration, dubbing, and voice replace…"
+          },
+          {
+            "name": "kairogen-image",
+            "description": "Generate, edit, and upscale images with Kairogen. Use for \"generate an image\", \"create a picture\", \"make me a logo/post…"
+          },
+          {
+            "name": "kairogen-video",
+            "description": "Generate video with Kairogen — text-to-video and image-to-video. Use for \"make a video\", \"animate this image\", \"turn th…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
       "version": "1.2.0",


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

New plugin

- Plugin name: kairogen
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/kairogenai/kairogen-grok-plugin.git@fa3a85f4f94b2c1814efdbec8dab6505f0ff3e7e
- Homepage: https://kairogen.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

Declaration-only plugin: no hooks, no local binaries, no stdio MCP. One hosted HTTP MCP server.

- Network endpoints this plugin calls (and why):
  - `mcp.kairogen.ai` — hosted MCP (`https://mcp.kairogen.ai/mcp`)
  - `api.kairogen.ai` — OAuth issuer, DCR, and token
  - `app.kairogen.ai` — OAuth consent and web app
  - `kairogen.ai` — homepage / docs
- Credentials/permissions it requires (and why):
  OAuth 2.0 in the browser on first connect (`/mcp` → kairogen → `i`). No API key. Generations debit the signed-in account's credit wallet.

## Notes for reviewers

Official Kairogen plugin, sourced from `kairogenai/kairogen-grok-plugin` (same org as kairogen.ai). Category is `media` (new in this catalog). Keywords are brand-scoped.
