### PR TITLE
Add CloudSprite plugin (remote SHA pin)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "cloudsprite",
+      "description": "Talk to CloudSprite as the signed-in user: search datasets and docs, set org/team/project scope, and file product feedback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cloudsprite-io/cloudsprite-plugin.git",
+        "sha": "4c474d082ae3c8bcb68822f9c147f15656d35dd1"
+      },
+      "homepage": "https://github.com/cloudsprite-io/cloudsprite-plugin",
+      "keywords": ["cloudsprite", "cloudsprite mcp", "s-parameters", "mixed-mode"],
+      "domains": ["cloudsprite.io", "api.cloudsprite.io", "docs.cloudsprite.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,40 @@
         ]
       }
     },
+    "cloudsprite": {
+      "sha": "4c474d082ae3c8bcb68822f9c147f15656d35dd1",
+      "version": "0.1.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "cloudsprite",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "datasets",
+            "description": "Query CloudSprite datasets, parameters, tags, and notebook membership through MCP read tools. Use when the user asks wh…"
+          },
+          {
+            "name": "feedback",
+            "description": "File a bug, feature request, or other product note with CloudSprite. Use when the user says /feedback, reports somethin…"
+          },
+          {
+            "name": "mixed-mode-analysis",
+            "description": "Compute or explain mixed-mode (differential/common-mode) S-parameters from single-ended 2-port Touchstone pairs. Use fo…"
+          },
+          {
+            "name": "platform-howtos",
+            "description": "How to use CloudSprite from this plugin: sign in, set org/team/project scope, search datasets and product docs, and fil…"
+          },
+          {
+            "name": "waveform-correlation",
+            "description": "Detect outlier waveforms in a CloudSprite project with pairwise Pearson correlation and describe a clean average of the…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `cloudsprite`
- Type: remote source
- Source URL + pinned SHA: https://github.com/cloudsprite-io/cloudsprite-plugin.git @ `4c474d082ae3c8bcb68822f9c147f15656d35dd1`
- Homepage: https://github.com/cloudsprite-io/cloudsprite-plugin

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://api.cloudsprite.io/mcp` — remote Streamable HTTP MCP
  - `https://api.cloudsprite.io/.well-known/oauth-authorization-server` — OAuth 2.1 discovery
  - `https://api.cloudsprite.io/.well-known/oauth-protected-resource` — protected-resource metadata
  - Authorization / token / JWKS URLs from that metadata (Cognito Hosted UI PKCE). Hosts are not hardcoded in the plugin.
- Credentials/permissions it requires (and why):
  - OAuth 2.1 PKCE (`openid email profile`). No client secret and no API key in the repo. Tokens stay in the Grok client (`~/.grok/mcp_credentials.json`). The plugin is read-only plus `submit_feedback`.

## Notes for reviewers

CloudSprite is a measurement-data platform (RF / signal integrity). The plugin slug is `cloudsprite`; the GitHub org is `cloudsprite-io` because `cloudsprite` was taken. Source is the official org, not a personal account. No files vendored under `external_plugins/`.


Made with [Cursor](https://cursor.com)