### PR TITLE
Add Orshot plugin — hosted MCP server + rendering/design skills

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "orshot",
+      "description": "Generate images, PDFs, and videos from your Orshot templates. Bundles the hosted Orshot MCP server plus skills for template rendering, dynamic parameters, brand-kit-aware design, and social publishing.",
+      "category": "design",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Orshot-HQ/orshot-agent-skills.git",
+        "sha": "7aeed68fc15874f17764e36276df5030c4ee4149"
+      },
+      "homepage": "https://orshot.com",
+      "keywords": ["orshot", "orshot templates", "orshot studio"],
+      "domains": ["orshot.com", "mcp.orshot.com", "api.orshot.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "orshot",
-      "description": "Generate images, PDFs, and videos from your Orshot templates. Bundles the hosted Orshot MCP server plus skills for template rendering, dynamic parameters, brand-kit-aware design, and social publishing.",
+      "description": "Automate videos, PDFs, and images from your Orshot templates, post to 15+ social platforms, and track performance to grow. Bundles the hosted Orshot MCP server plus skills for template rendering, dynamic parameters, and on-brand design.",
       "category": "design",
       "source": {
         "source": "url",
         "url": "https://github.com/Orshot-HQ/orshot-agent-skills.git",
-        "sha": "7aeed68fc15874f17764e36276df5030c4ee4149"
+        "sha": "3fd944c169e471ebfa536ece7c7b3f8af66bbcc2"
       },
       "homepage": "https://orshot.com",
       "keywords": ["orshot", "orshot templates", "orshot studio"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "orshot": {
-      "sha": "7aeed68fc15874f17764e36276df5030c4ee4149",
+      "sha": "3fd944c169e471ebfa536ece7c7b3f8af66bbcc2",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,28 @@
         ]
       }
     },
+    "orshot": {
+      "sha": "7aeed68fc15874f17764e36276df5030c4ee4149",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "orshot",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "orshot",
+            "description": "Generate images, PDFs, and videos from templates with Orshot — via the REST API, SDKs (Node/Python/PHP/Ruby), the remot…"
+          },
+          {
+            "name": "orshot-design",
+            "description": "Design trendy, professional, on-brand Orshot studio templates. Use when creating or refining a template design via the…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official **Orshot** plugin (new plugin, remote source).

- Plugin name: `orshot`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Orshot-HQ/orshot-agent-skills.git` @ `7aeed68fc15874f17764e36276df5030c4ee4149`
- Homepage: https://orshot.com

Orshot is a visual content generation platform: design templates once, then render images, PDFs, and videos with dynamic data. The plugin bundles the hosted Orshot MCP server (`.mcp.json`) plus two skills — `orshot` (API/rendering integration: dynamic parameters, multi-page, video gotchas) and `orshot-design` (craft rules so generated templates look professionally designed).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (Orshot-HQ; I'm the founder, submitting from my personal GitHub account).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, LICENSE file in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks, no local executables — a single hosted HTTP MCP server).
- Network endpoints this plugin calls (and why):
  - `https://mcp.orshot.com/mcp` — the hosted Orshot MCP server (streamable HTTP), the plugin's only MCP entry.
  - `https://api.orshot.com` — OAuth authorization server for the MCP connection; also the REST API base if the user follows the skill's direct-API instructions.
  - `https://orshot.com/docs/*` — documentation pages the skills may fetch as markdown.
- Credentials/permissions it requires (and why): OAuth 2.0 (authorization code + PKCE, dynamic client registration) against the user's Orshot account, scoped to their workspaces; tokens stay in the MCP client. A workspace API key as bearer token is the headless alternative. Full disclosure in the repo README.

## Notes for reviewers

The source repo also serves as Orshot's agent-skills distribution (`npx skills add orshot-hq/orshot-agent-skills`) and carries a `.cursor-plugin/plugin.json` for the Cursor marketplace — same dual-use pattern as `mongodb/agent-skills` and `cloudflare/skills` in this catalog. Orshot's hosted MCP server is the same one already live in the ChatGPT app directory and used by Claude/Cursor connectors.
