### PR TITLE
Add Porte remote-control plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/alexander-zuev/porte.git",
-        "sha": "7c534caa60f318dd7659293f428c5e0aa757b434",
+        "sha": "c795498b2983f1a2294018bb47df80153f18749d",
         "path": "plugins/grok"
       },
       "homepage": "https://useporte.dev",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "porte",
+      "description": "Remote control for local Grok sessions from your phone. Pair a machine, open its Grok sessions, send prompts, and answer permission requests through Porte.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/alexander-zuev/porte.git",
+        "sha": "e32453506526ffdd03984e6c1ca3565897bd3381",
+        "path": "plugins/grok"
+      },
+      "homepage": "https://useporte.dev",
+      "keywords": ["porte", "useporte", "porte remote control"],
+      "domains": ["useporte.dev"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/alexander-zuev/porte.git",
-        "sha": "0cac9c619e8cff5faf5943cfab6ff0495f3b1d6d",
+        "sha": "5bf2737d5005ca59f0c0fbaa5fa145db85ad8783",
         "path": "plugins/grok"
       },
       "homepage": "https://useporte.dev",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/alexander-zuev/porte.git",
-        "sha": "e32453506526ffdd03984e6c1ca3565897bd3381",
+        "sha": "0cac9c619e8cff5faf5943cfab6ff0495f3b1d6d",
         "path": "plugins/grok"
       },
       "homepage": "https://useporte.dev",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/alexander-zuev/porte.git",
-        "sha": "5bf2737d5005ca59f0c0fbaa5fa145db85ad8783",
+        "sha": "213f488d416f1091dbd7adc30f0c8c2adb6662c5",
         "path": "plugins/grok"
       },
       "homepage": "https://useporte.dev",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/alexander-zuev/porte.git",
-        "sha": "213f488d416f1091dbd7adc30f0c8c2adb6662c5",
+        "sha": "7c534caa60f318dd7659293f428c5e0aa757b434",
         "path": "plugins/grok"
       },
       "homepage": "https://useporte.dev",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "porte": {
-      "sha": "5bf2737d5005ca59f0c0fbaa5fa145db85ad8783",
+      "sha": "213f488d416f1091dbd7adc30f0c8c2adb6662c5",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "porte": {
-      "sha": "213f488d416f1091dbd7adc30f0c8c2adb6662c5",
+      "sha": "7c534caa60f318dd7659293f428c5e0aa757b434",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -524,6 +524,23 @@
         ]
       }
     },
+    "porte": {
+      "sha": "e32453506526ffdd03984e6c1ca3565897bd3381",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "porte",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "remote-control",
+            "description": "Run this machine's Grok sessions from your phone via Porte. Pairs the machine, then toggles remote control on or off."
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "bdf7aa355337897f167153e05069aca505dae17c",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "porte": {
-      "sha": "e32453506526ffdd03984e6c1ca3565897bd3381",
+      "sha": "0cac9c619e8cff5faf5943cfab6ff0495f3b1d6d",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "porte": {
-      "sha": "0cac9c619e8cff5faf5943cfab6ff0495f3b1d6d",
+      "sha": "5bf2737d5005ca59f0c0fbaa5fa145db85ad8783",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -525,7 +525,7 @@
       }
     },
     "porte": {
-      "sha": "7c534caa60f318dd7659293f428c5e0aa757b434",
+      "sha": "c795498b2983f1a2294018bb47df80153f18749d",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: `porte`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/alexander-zuev/porte.git` @ `c795498b2983f1a2294018bb47df80153f18749d` (release 0.3.3)
- Source path: `plugins/grok`
- Homepage: https://useporte.dev

Porte lets a user control local Grok sessions from a phone. The user can read transcripts live, send prompts, and answer permission requests. A turn started in the terminal streams to the phone, and a turn started on the phone streams to the terminal.

Indexed components:

- `remote-control` skill: pairs the machine, turns remote control on or off, reports status, shows or hides the Porte status row, and removes the pairing.
- `porte` stdio MCP server: exposes zero tools. It binds the Porte daemon lifetime to the Grok session.

## Ownership

- [x] I own this plugin and have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Porte does not have a GitHub organization. Alexander Zuev created and maintains Porte. The public `alexander-zuev/porte` repository is the canonical source for the domain and the `@porte/cli` npm package.

## Checklist

- [x] Added exactly one `porte` entry to `.grok-plugin/marketplace.json`.
- [x] The remote source pins a public, full 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `scripts/validate-catalog.py` passes.
- [x] `scripts/generate-plugin-index.py --check` passes.
- [x] Homepage and description are set.
- [x] The source repository states its Apache-2.0 license in `LICENSE`.

## Security

- [x] No `curl | bash`, downloaded binary, `eval`, or postinstall script.
- [x] No SSH file, project `.env` file, or credential discovery.
- [x] The skill and MCP server use the fixed `@porte/cli@0.3.3` package version.
- [x] The skill passes only these words to the CLI: none, `on`, `off`, `status`, `status-line`, `status-line on`, `status-line off`, `unpair`. Any other word prints a fixed "Unknown option" line. It does not append arbitrary prompt text to the command.
- [x] The stdio MCP server exposes zero tools.
- [x] Both the MCP server and the skill run `npx` from `$HOME` (`cd "$HOME" && exec npx -y @porte/cli@0.3.3 …`), so npm never resolves a project's own `devEngines` or `.npmrc`.

Network endpoints:

- The configured npm registry fetches `@porte/cli@0.3.3` on first use. The default registry is `registry.npmjs.org`.
- `https://useporte.dev` pairs the machine, authenticates it, and relays Grok session events.
- `PORTE_URL` lets the user select a different Porte deployment.

Credentials and permissions:

- Porte stores its bearer credential in `~/.porte/credentials.json` with owner-only access.
- The CLI sends that credential only to the selected Porte deployment for authentication.
- The CLI never sends the user's Grok credential to Porte.
- Porte runs `grok agent --leader stdio` per conversation: a client of Grok's own shared session process, so the terminal and the phone see one session.
- Porte relays session transcripts, tool output, diffs, and permission requests to the paired Porte account.
- Porte does not scan or upload the repository. File content can appear when Grok includes it in the session transcript.

Changes to `~/.grok/config.toml` (line edits; the rest of the file is untouched):

- `[cli] use_leader = true`, so every Grok process on the machine shares one session backend. Written when the daemon starts; removed by `/remote-control unpair`.
- `[ui.status_line]` pointing at `~/.porte/statusline.sh`, a Porte status row in Grok (on, connecting, off, or the error and its fix). Written only when the file has no status line, or one that is already Porte's; a user's own status line is left alone. `/remote-control status-line off` removes it; `unpair` removes it.

Optional local files:

- Instant mode is off by default. `porte rc enable-hook` adds one global `UserPromptSubmit` hook.
- The hook exits for ordinary prompts. It sends `/remote-control` prompts to the fixed CLI version.
- `porte rc disable-hook` removes the hook config and script.

## Notes for reviewers

Grok invokes slash skills through the model, so the default `/remote-control` path uses one model turn. Optional instant mode avoids that turn.

Grok displays an intercepted prompt as `Prompt blocked`. Porte reports this behavior when the user enables instant mode.

Grok reads `use_leader` and the status line at start, so both take effect at the next Grok start. The CLI prints a one-line restart hint when it writes the status row.
