### PR TITLE
Add Portals Grok Build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "portals-plugin-grok",
+      "description": "Build, manage, and publish Portals browser games from Grok Build with eight platform skills and the Portals web-games MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/portals-labs/portals-plugin-grok.git",
+        "sha": "70530cbaa7adc7a197e95ed12936a7764575e05d",
+        "path": "plugins/portals-plugin-grok"
+      },
+      "homepage": "https://github.com/portals-labs/portals-plugin-grok",
+      "keywords": ["portals", "portals web games", "portals sdk", "portals mcp"],
+      "domains": ["portals.to"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,52 @@
         ]
       }
     },
+    "portals-plugin-grok": {
+      "sha": "70530cbaa7adc7a197e95ed12936a7764575e05d",
+      "version": "0.1.14",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "portals-web-games",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "portals-game-economy",
+            "description": "Sell in-game products for Coins inside a hosted Portals web game with Portals.economy — microtransactions, IAP, durable…"
+          },
+          {
+            "name": "portals-guardian-avatars",
+            "description": "Put the player's Guardian avatar into a Three.js game on Portals — body types, skin/hair/eye colour, hair styles, weara…"
+          },
+          {
+            "name": "portals-multiplayer-and-voice",
+            "description": "Add real-time multiplayer, in-game text chat, and voice chat to a hosted Portals web game with Portals.net and Portals.…"
+          },
+          {
+            "name": "portals-pose-tuner",
+            "description": "Tune procedural animation live inside a Portals web game with the Pose Tuner dev tool — carry tables, grip offsets, rec…"
+          },
+          {
+            "name": "portals-sdk",
+            "description": "Use the Portals SDK in a hosted web game for player identity, Portals sign-in, saved progress, casual scores, leaderboa…"
+          },
+          {
+            "name": "portals-server-scripts",
+            "description": "Add authoritative server-side game logic to a Portals multiplayer game with a root server.js that Portals runs as an in…"
+          },
+          {
+            "name": "portals-server-sim",
+            "description": "Build a server-authoritative real-time game on Portals where server.js simulates the game itself — one shared sim modul…"
+          },
+          {
+            "name": "portals-web-games",
+            "description": "Build, update, synchronize, configure, and publish browser games on Portals with the portals-web-games MCP server. Use…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "fd878692de15a3069c21c8f429eb0b9f2fe178fa",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the first-party Portals plugin for Grok Build as a remote, SHA-pinned source.

- Plugin name: portals-plugin-grok
- Type: remote source
- Source URL + pinned SHA: https://github.com/portals-labs/portals-plugin-grok.git at ba32206bc96527019e07e7480b0cb26ba5f31935, plugin path plugins/portals-plugin-grok
- Homepage: https://github.com/portals-labs/portals-plugin-grok

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org.

## Checklist

- [x] Added exactly one entry in .grok-plugin/marketplace.json with a kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated .grok-plugin/plugin-index.json.
- [x] python3 scripts/validate-catalog.py passes locally.
- [x] python3 scripts/generate-plugin-index.py --check passes locally.
- [x] Homepage and clear description are set.
- [x] The plugin is ISC licensed.

## Security

- [x] No curl-pipe-shell, remote-code download/exec, postinstall script, or lifecycle hooks.
- [x] No secret exfiltration. The MCP reads only the declared Portals-specific settings PORTALS_ACCESS_KEY, API_BASE, and PORTALS_AUTH_TIMEOUT_MS, including conventional .env loading, and does not transmit unrelated environment variables.
- [x] The MCP is product-scoped and has no hooks. Filesystem reads and writes are limited to game project paths supplied to its tools.

Network endpoints:
- https://portals.to for Portals account, game, asset, multiplayer, and economy operations; API_BASE may override this origin for a user-selected development backend.
- Time-limited upload and download URLs issued by that API for selected project and media transfers.
- Portals-managed assets at cdn.theportal.to, addressables-cdn.theportal.to, d365bxku1h71bo.cloudfront.net, and dwh7ute75zx34.cloudfront.net.
- Interactive authentication opens https://portals.to/mcp, binds its callback on loopback, and may load the login background from cdn.theportal.to.

Credentials and permissions:
- PORTALS_ACCESS_KEY, saved credentials at ~/.portals-mcp/auth.json, or interactive Portals browser authentication.
- Tool calls may read or write the explicitly supplied game project path; push, publish, and asset-upload operations transmit selected project or media files.

## Notes for reviewers

The public repository is a symlink-free generated export from the canonical portals-labs/vibes plugin source. The catalog entry now pins public release 0.1.16. Current xAI catalog generation and exact validators pass, and the generated component index reports 8 skills plus the portals-web-games stdio MCP server. Earlier clean Grok marketplace install/runtime validation exercised the same packaging contract; this refresh rebases the catalog entry onto current xAI main and repins the current public release.
