### PR TITLE
Add Stellary hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "stellary",
+      "description": "AI-native project piloting via Stellary's hosted MCP server: boards, documents, cockpit, and governed agent missions. Connect over Streamable HTTP at https://api.stellary.co/mcp with a Bearer personal access token (not OAuth). Create a PAT in Stellary under Account settings → API tokens.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Anymfah/stellary-mcp.git",
+        "sha": "ef3f697eb124ec07f92f697f85cefa6ae24270c1"
+      },
+      "homepage": "https://stellary.co",
+      "keywords": ["stellary", "stellary mcp", "stellary project"],
+      "domains": ["stellary.co", "app.stellary.co", "api.stellary.co"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -795,6 +795,18 @@
         ]
       }
     },
+    "stellary": {
+      "sha": "ef3f697eb124ec07f92f697f85cefa6ae24270c1",
+      "version": "0.12.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "stellary",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "9f39fa607a63582d8c5b62aaf6fa4898b9c7caac",
       "version": "0.6.2",


### PR DESCRIPTION
## Plugin

Remote catalog entry for Stellary. Plugin files live in the public repo `Anymfah/stellary-mcp` (not vendored here), pinned to commit `ef3f697eb124ec07f92f697f85cefa6ae24270c1` (tag `0.12.1`).

- [x] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` in kebab-case and unique.
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] `.grok-plugin/plugin-index.json` regenerated and committed (`python3 scripts/generate-plugin-index.py` + `--check`).
- [x] Homepage and description present; brand-scoped keywords/domains; category `development`.
- [x] Plugin is MIT-licensed (stated in upstream `plugin.json` / `.grok-plugin/plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (thin HTTP MCP config only; no hooks/scripts).
- Network endpoints this plugin calls (and why): `https://api.stellary.co/mcp` — official Stellary Streamable HTTP MCP server for boards, documents, cockpit, and governed agent missions.
- Credentials/permissions it requires (and why): Bearer personal access token (`STELLARY_API_TOKEN`), not OAuth. Users create a PAT in Stellary (Account settings → API tokens). Token is never shipped in this repo.

## Notes for reviewers

`.mcp.json` points at the hosted endpoint. Auth is Bearer PAT. Docs: https://stellary.co/docs/mcp/