### PR TITLE
feat: add Vettly content moderation plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,20 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "vettly",
+      "description": "Policy-governed content moderation and trust-and-safety workflows for text, image, and video content through Vettly's MCP server.",
+      "category": "monitoring",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/nextauralabs/vettly.git",
+        "sha": "b40da3314080526273aa7088e46149ad83f88e2d",
+        "path": "packages/mcp/grok-plugin"
+      },
+      "homepage": "https://vettly.dev",
+      "keywords": ["vettly", "vettly moderation", "ugc moderation", "trust and safety", "policy enforcement"],
+      "domains": ["vettly.dev", "api.vettly.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1226,6 +1226,24 @@
         ]
       }
     },
+    "vettly": {
+      "sha": "b40da3314080526273aa7088e46149ad83f88e2d",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "vettly",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "vettly-moderation",
+            "description": "Use Vettly to make policy-governed, auditable moderation decisions for text, image, and video content. Trigger when dec…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "572357b791a91a5138c050e08eb718b150be21cb",
       "version": "1.18.1",


### PR DESCRIPTION
## Summary

Add Vettly as a third-party content moderation and trust-and-safety plugin for Grok Build.

The plugin source is hosted in the official Vettly repository and pinned to commit `2cc5d6343371b58b3ab6e81d8e0b91f4569c2733`.

It provides:
- A hosted Streamable HTTP MCP server at `https://api.vettly.dev/mcp`
- Policy-governed moderation for text, image URLs, and video URLs
- Policy discovery and validation
- Recent decision review and usage statistics
- A focused `vettly-moderation` skill

Authentication uses the `VETTLY_API_KEY` environment variable and the plugin does not read local files or execute shell commands.

## Verification

- `python3 scripts/validate-catalog.py`
- `python3 scripts/generate-plugin-index.py --check`

Both pass locally.
