### PR TITLE
feat(plugins): add you-com

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "you-com",
+      "description": "You.com web search, URL content extraction, and cited research via the hosted You.com MCP server and official skills. Works with no API key and no account on the keyless free tier; add a key, OAuth, or x402/MPP payment for higher limits and the managed Research and Finance Research APIs. Each search result carries several extracted passages from the page rather than a single snippet.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/youdotcom-oss/agent-skills.git",
+        "sha": "78e20fd40bfdccbf91a5aaa67c2e46ba4ed2bbaa"
+      },
+      "homepage": "https://you.com",
+      "keywords": ["you.com", "youcom", "you.com search", "ydc"],
+      "domains": ["you.com", "docs.you.com", "api.you.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1251,6 +1251,34 @@
           }
         ]
       }
+    },
+    "you-com": {
+      "sha": "78e20fd40bfdccbf91a5aaa67c2e46ba4ed2bbaa",
+      "version": "0.5.0",
+      "components": {
+        "skills": [
+          {
+            "name": "you-discover",
+            "description": "Route You.com integration planning through the you-discover MCP tool, Docs MCP, and direct API options."
+          },
+          {
+            "name": "you-finance",
+            "description": "Route finance questions to an existing local script, a new You.com Finance Research API call, or an MCP payment-aware f…"
+          },
+          {
+            "name": "you-free",
+            "description": "Use the free You.com MCP profile for unauthenticated basic web search with `you-search` only."
+          },
+          {
+            "name": "you-research",
+            "description": "Route research tasks between a cost-conscious agentic search workflow, You.com Research API scripts, and managed or pay…"
+          },
+          {
+            "name": "you-web",
+            "description": "Use You.com MCP tools for current web search, URL content extraction, cited web synthesis, and x402-aware web access."
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds You.com as a new plugin: web search, URL content extraction, and cited research through the hosted You.com MCP server plus five official skills.

- Plugin name: `you-com`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/youdotcom-oss/agent-skills.git` @ `78e20fd40bfdccbf91a5aaa67c2e46ba4ed2bbaa`
- Homepage: https://you.com

The pinned commit is the merge commit of [youdotcom-oss/agent-skills#54](https://github.com/youdotcom-oss/agent-skills/pull/54), which added the `.grok-plugin/` manifests specifically for Grok Build.

Ships five skills, no hooks, no commands, no agents, and no bundled `.mcp.json` — the skills route the agent to whichever You.com access path fits (keyless, API key, OAuth, or x402/MPP), rather than pinning one server config for everyone.

What differentiates it from the search plugins already in the catalog: the free tier needs **no API key and no account**, and each result carries several extracted passages from the page rather than a single snippet, so an agent can usually ground an answer without a second fetch.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`youdotcom-oss` is You.com's official OSS org. The same plugin is published from this repo to the Claude Code, Cursor, Codex, Copilot CLI, and Kimi Code marketplaces.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT, declared in `.grok-plugin/plugin.json` and `LICENSE` in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):**

| Host | Why |
|---|---|
| `api.you.com/mcp` | hosted MCP server — `you-search`, `you-contents`, `you-research`, `you-finance`. `?profile=free` is the keyless variant. |
| `api.you.com/v1/*` | direct REST equivalents (`/search`, `/contents`, `/research`, `/finance_research`) when a script fits better than MCP |
| `you.com/docs/_mcp/server` | You.com's public docs MCP (`searchDocs`), keyless — used to check current API guidance before writing a call |

**Credentials/permissions it requires (and why):** none are required. `YDC_API_KEY` is optional and only lifts rate limits and unlocks the managed Research and Finance Research APIs; OAuth and x402/MPP are alternative optional paths. The skills read `YDC_API_KEY` from the environment when present and otherwise fall back to the keyless endpoint. Nothing else in the environment is read, and no credential is transmitted anywhere except to `api.you.com`.

## Notes for reviewers

Two things worth flagging up front, since the source repo is a multi-surface monorepo rather than a single-plugin repo:

1. **The source repo's root `package.json` has a `prepare` script** — `git config core.hooksPath .hooks`. It exists for contributors working in a dev checkout and sets a local git hooks path; it fetches and executes nothing. Grok Build clones the plugin's files and reads `skills/`, so no npm lifecycle script runs at install time. Calling it out because a static audit will see it.

2. **The repo also contains `packages/` (npm/PyPI adapters for other agent hosts), `scripts/`, and `tests/`.** None of it is part of the plugin surface — the generated `plugin-index.json` entry lists skills only, and there are no `hooks/`, `commands/`, or `agents/` directories. Happy to move the plugin under a subdirectory and pin with `"path"` instead if you'd prefer a narrower clone.