### PR TITLE
Add buses-and-trains plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "buses-and-trains",
+      "description": "Live UK public transport from the Buses & Trains API: real-time bus and train departures and arrivals, live vehicle positions, multi-modal journey planning, and rail fares with railcard discounts across England, Scotland and Wales.",
+      "category": "travel",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/BusesAndTrains/busesandtrains-mcp.git",
+        "sha": "87a7f42f82ac30bba75a2f9dd3efcfab3510a3d1"
+      },
+      "homepage": "https://busesandtrains.co.uk",
+      "keywords": ["buses and trains", "busesandtrains", "uk bus times", "uk train times", "uk journey planner"],
+      "domains": ["busesandtrains.co.uk"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,24 @@
         ]
       }
     },
+    "buses-and-trains": {
+      "sha": "87a7f42f82ac30bba75a2f9dd3efcfab3510a3d1",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "buses-and-trains",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "uk-public-transport",
+            "description": "Answer questions about UK buses and trains - live departures, where a bus is now, journey planning across Great Britain…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",


### PR DESCRIPTION
## What this PR does

Adds the Buses & Trains plugin: live UK public transport data for Grok Bot. Bus
and train departures and arrivals, live vehicle positions, multi-modal journey
planning, and rail fares with railcard discounts, covering England, Scotland and
Wales.

- Plugin name: `buses-and-trains`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/BusesAndTrains/busesandtrains-mcp.git` @ `87a7f42f82ac30bba75a2f9dd3efcfab3510a3d1`
- Homepage: https://busesandtrains.co.uk

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The `BusesAndTrains` org owns `busesandtrains.co.uk` and operates the API the
plugin talks to.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

- Network endpoints this plugin calls (and why): `https://api.busesandtrains.co.uk/mcp`
  only. That is the plugin's MCP server, operated by us, and it is the sole host
  the bundle references. No other network access.

- Credentials/permissions it requires (and why): one Buses & Trains API key,
  supplied by the installing user as a bearer token and sent only to
  `api.busesandtrains.co.uk`. It authenticates that user's own account for rate
  limiting and usage metering. The plugin ships no credentials, reads no
  environment variables beyond the key the user configures, and defines no hooks
  or scripts.

  The server exposes eight read-only tools: stop search, bus departures, rail
  station search, rail departures, rail arrivals, journey planning, rail fares,
  and live vehicle positions. Nothing writes, and the API's account, billing and
  admin endpoints are deliberately not exposed as tools.

## Notes for reviewers

**The source repo intentionally contains no server code.** It is six files: the
manifest, `.mcp.json`, one skill, a README and a licence. The MCP server itself
runs inside our API rather than in the plugin, so the repo is the bundle a client
installs, not the implementation. An empty-looking repo here is the design, not
an omission.

**`category: "travel"` is new to this catalogue.** Every existing entry is
developer infrastructure. Happy to move it to whichever category you prefer, or
to drop the field, if a consumer-facing category is not something you want to
open up yet.

The skill teaches the model to resolve place names to NaPTAN ATCO codes and
3-letter CRS codes before requesting times (guessing an opaque code silently
returns the wrong stop), to state whether a board is live or timetabled, and to
decline anything outside Great Britain. Every tool taking coordinates rejects
locations outside the UK before making a request.
