### PR TITLE
Add Doublespeed plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "doublespeed",
+      "description": "Create and post TikTok, Instagram, and Facebook slideshows and videos from Grok via the Doublespeed MCP server. Connect with OAuth; no API key to paste.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/SyedUmaidAhmed/doublespeed-plugin.git",
+        "sha": "44e1cf3e56204262088ef8737d726a9aefd4c3b6"
+      },
+      "homepage": "https://doublespeed.ai",
+      "keywords": ["doublespeed", "doublespeed mcp", "tiktok slideshows"],
+      "domains": ["doublespeed.ai", "app.doublespeed.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,28 @@
         ]
       }
     },
+    "doublespeed": {
+      "sha": "44e1cf3e56204262088ef8737d726a9aefd4c3b6",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "doublespeed",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "content-creator",
+            "description": "End-to-end social content creation (TikTok, Instagram, Facebook) through the doublespeed MCP. Pulls brand context and p…"
+          },
+          {
+            "name": "slideshows",
+            "description": "Build slideshow (photo carousel) posts for TikTok, Instagram, and Facebook through the doublespeed MCP: pick a template…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## Summary

Adds the Doublespeed agent plugin to the official Grok marketplace catalog.

- **Source:** https://github.com/SyedUmaidAhmed/doublespeed-plugin (MIT)
- **Pinned SHA:** `44e1cf3e56204262088ef8737d726a9aefd4c3b6`
- **MCP:** hosted Streamable HTTP at `https://doublespeed.ai/api/mcp` (OAuth; no API key)
- **Skills:** `content-creator`, `slideshows`

Validators run locally: `generate-plugin-index.py`, `validate-catalog.py`, and `--check`.

Note: the public plugin currently lives under a personal GitHub account because CreateRepository on `doublespeed-main` was unavailable. Prefer transferring to `doublespeed-main/doublespeed-plugin` and bumping the SHA afterward if xAI requires an official-org source.

## Ownership

- Plugin owned by Doublespeed (homepage https://doublespeed.ai)
- Contact: zuhair@doublespeed.ai

## Security

- No shell hooks
- MCP points only at `https://doublespeed.ai/api/mcp`
- No secrets committed; auth is browser OAuth


Made with [Cursor](https://cursor.com)