### PR TITLE
Add SDP Platform plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "sdp",
+      "description": "Official SDP plugin. Build websites with Latte components and administer product, listing, and custom-order catalogs through hosted MCP. Authenticate with OAuth; never invent catalog ids.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sharasolns/sdp-plugins.git",
+        "sha": "e7b7e581fc0150cf8c0aa4149152907e650afa1b"
+      },
+      "homepage": "https://github.com/sharasolns/sdp-plugins",
+      "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],
+      "domains": ["sdp-platform.com", "sdp-api.sdp-platform.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "e7b7e581fc0150cf8c0aa4149152907e650afa1b"
+        "sha": "9d6f84c449d2042a263f5dcd98bf280d816173f0"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "42278ac4acdf61fa53fbaf169b5ee42cbe8f5e77"
+        "sha": "b5d104a80f826a5084e6018e99267bea62275a73"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "9d6f84c449d2042a263f5dcd98bf280d816173f0"
+        "sha": "42278ac4acdf61fa53fbaf169b5ee42cbe8f5e77"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -334,12 +334,12 @@
     },
     {
       "name": "sdp",
-      "description": "Official SDP plugin. Build websites with Latte components and administer product, listing, and custom-order catalogs through hosted MCP. Authenticate with OAuth; never invent catalog ids.",
+      "description": "Official SDP Platform plugin. Build websites with Latte components and administer product, listing, course, and custom-order catalogs through hosted MCP. Authenticate with OAuth; never invent catalog ids.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "b6d568badab2a06cbc2515c848b1376fe3bb1a71"
+        "sha": "f703259ddc89b3869b881ba636576e5f5cafa8f6"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -333,13 +333,13 @@
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
     },
     {
-      "name": "sdp",
+      "name": "sdp-platform",
       "description": "Official SDP Platform plugin. Build websites with Latte components and administer product, listing, course, and custom-order catalogs through hosted MCP. Authenticate with OAuth; never invent catalog ids.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "f703259ddc89b3869b881ba636576e5f5cafa8f6"
+        "sha": "7d6f840a81dd6311e7b67012d63c3e92d95f2368"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/sharasolns/sdp-plugins.git",
-        "sha": "b5d104a80f826a5084e6018e99267bea62275a73"
+        "sha": "b6d568badab2a06cbc2515c848b1376fe3bb1a71"
       },
       "homepage": "https://github.com/sharasolns/sdp-plugins",
       "keywords": ["sdp", "sdp-platform", "sdp website builder", "sdp listings"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -749,6 +749,48 @@
         ]
       }
     },
+    "sdp": {
+      "sha": "e7b7e581fc0150cf8c0aa4149152907e650afa1b",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "sdp-custom-forms",
+            "description": "http"
+          },
+          {
+            "name": "sdp-listings",
+            "description": "http"
+          },
+          {
+            "name": "sdp-products",
+            "description": "http"
+          },
+          {
+            "name": "sdp-website-builder",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "sdp-custom-forms",
+            "description": "Administer SDP custom order types through Custom Forms MCP on the themes host. Use for types, fields, pricing items, de…"
+          },
+          {
+            "name": "sdp-listings",
+            "description": "Administer SDP listing catalogs through Listings MCP on the themes host. Use for listing types, custom fields, brands,…"
+          },
+          {
+            "name": "sdp-products",
+            "description": "Administer SDP product catalogs through Products MCP on the themes host. Use for product types, brands, categories, col…"
+          },
+          {
+            "name": "sdp-website-builder",
+            "description": "Build, compose, inspect, or safely edit SDP CMS websites through the SDP/Arawa Website Builder MCP. Use for component s…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -750,8 +750,8 @@
       }
     },
     "sdp": {
-      "sha": "42278ac4acdf61fa53fbaf169b5ee42cbe8f5e77",
-      "version": "0.1.1",
+      "sha": "b5d104a80f826a5084e6018e99267bea62275a73",
+      "version": "0.1.2",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -750,7 +750,7 @@
       }
     },
     "sdp": {
-      "sha": "9d6f84c449d2042a263f5dcd98bf280d816173f0",
+      "sha": "42278ac4acdf61fa53fbaf169b5ee42cbe8f5e77",
       "version": "0.1.1",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -750,8 +750,8 @@
       }
     },
     "sdp": {
-      "sha": "e7b7e581fc0150cf8c0aa4149152907e650afa1b",
-      "version": "0.1.0",
+      "sha": "9d6f84c449d2042a263f5dcd98bf280d816173f0",
+      "version": "0.1.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -815,8 +815,8 @@
       }
     },
     "sdp": {
-      "sha": "b6d568badab2a06cbc2515c848b1376fe3bb1a71",
-      "version": "0.1.7",
+      "sha": "f703259ddc89b3869b881ba636576e5f5cafa8f6",
+      "version": "0.1.8",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -750,10 +750,14 @@
       }
     },
     "sdp": {
-      "sha": "b5d104a80f826a5084e6018e99267bea62275a73",
-      "version": "0.1.2",
+      "sha": "b6d568badab2a06cbc2515c848b1376fe3bb1a71",
+      "version": "0.1.7",
       "components": {
         "mcpServers": [
+          {
+            "name": "sdp-courses",
+            "description": "http"
+          },
           {
             "name": "sdp-custom-forms",
             "description": "http"
@@ -772,6 +776,10 @@
           }
         ],
         "skills": [
+          {
+            "name": "sdp-courses",
+            "description": "Administer SDP courses through Courses MCP on the themes host. Use for course types, collections, covers, videos, chapt…"
+          },
           {
             "name": "sdp-custom-forms",
             "description": "Administer SDP custom order types through Custom Forms MCP on the themes host. Use for types, fields, pricing items, de…"

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -814,8 +814,8 @@
         ]
       }
     },
-    "sdp": {
-      "sha": "f703259ddc89b3869b881ba636576e5f5cafa8f6",
+    "sdp-platform": {
+      "sha": "7d6f840a81dd6311e7b67012d63c3e92d95f2368",
       "version": "0.1.8",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

- Plugin name: sdp-platform
- Type: remote source
- Source URL + pinned SHA: https://github.com/sharasolns/sdp-plugins.git @ 7d6f840a81dd6311e7b67012d63c3e92d95f2368
- Homepage: https://github.com/sharasolns/sdp-plugins

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our GitHub org (`sharasolns`). SDP Platforms currently publishes GitHub work from this org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (hosted MCP only; no local shell MCP or hooks).
- Network endpoints this plugin calls (and why):
  - https://sdp-api.sdp-platform.com/mcp/website-builder
  - https://themes-production.sdp-platform.com/mcp/products
  - https://themes-production.sdp-platform.com/mcp/listings
  - https://themes-production.sdp-platform.com/mcp/courses
  - https://themes-production.sdp-platform.com/mcp/custom-forms
  Streamable HTTP MCP with OAuth.
- Credentials/permissions it requires (and why): SDP OAuth scope `mcp:use` so the user can administer their own websites and catalogs. Users must have an account at https://sdp-platform.com first.

## Notes for reviewers

The plugin package is https://github.com/sharasolns/sdp-plugins. It bundles skills plus `.mcp.json` pointing at hosted SDP MCP servers. No secrets are stored in the plugin repo.
