### PR TITLE
Add Glide plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "glide",
+      "description": "Glide's official MCP server. Build, manage, and operate GlideOS apps: create and manage projects, query and modify app databases, run workflows, publish and roll back apps, and read, write, and search project files.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/glideapps/mcp.git",
+        "sha": "e1112b3bd4dc7031efd155503e1fe6effe7fa65c",
+        "path": "plugins/glide"
+      },
+      "homepage": "https://www.glideapps.com/docs/os/mcp",
+      "keywords": ["glide", "glideos", "glide apps", "glideapps"],
+      "domains": ["glideapps.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,24 @@
         ]
       }
     },
+    "glide": {
+      "sha": "e1112b3bd4dc7031efd155503e1fe6effe7fa65c",
+      "version": "1.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "glide",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "glideos-development",
+            "description": "Conventions for building and operating GlideOS apps, data, and workflows through the Glide MCP server. Use when working…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
Adds Glide's official MCP server as a plugin. Glide is a no-code app platform; the plugin gives Grok Build tools to create and manage GlideOS projects, query and modify app databases, run workflows, publish apps, and read and write project files.

- Source: github.com/glideapps/mcp, pinned to a commit on main, path plugins/glide
- Components: one hosted MCP server (streamable HTTP at https://mcp.glideapps.dev/mcp, OAuth 2.1 sign-in, no API keys or credential variables) and one skill
- No hooks, no shell execution, no install scripts, no telemetry
- Licensed MIT; the plugin directory carries its own LICENSE
- Validated locally: validate-catalog.py, generate-plugin-index.py, and generate-plugin-index.py --check all pass

## What this PR does

- Plugin name: glide
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/glideapps/mcp.git @ e1112b3bd4dc7031efd155503e1fe6effe7fa65c (path: plugins/glide)
- Homepage: https://www.glideapps.com/docs/os/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is the official Glide org: github.com/glideapps/mcp.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT. The plugin directory carries its own LICENSE.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://mcp.glideapps.dev/mcp — hosted Glide MCP server (streamable HTTP) used to create and manage GlideOS projects, query and modify app databases, run workflows, publish and roll back apps, and read/write/search project files.
- Credentials/permissions it requires (and why): OAuth 2.1 sign-in with a Glide account on first connection. No API keys or credential variables.

No hooks, no shell execution, no install scripts, no telemetry.

## Notes for reviewers

Glide is a no-code app platform. The plugin gives Grok Build tools to create and manage GlideOS projects, query and modify app databases, run workflows, publish apps, and read and write project files.

Index components at the pinned SHA:
- MCP server: `glide` (http)
- Skill: `glideos-development`