### PR TITLE
Add flaremail plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "flaremail",
+      "description": "Read, draft, and send mail from a FlareMail account via the hosted MCP server. Sign in with OAuth on first connect; Grok uses the same mailbox as the FlareMail app.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/travisrr/flaremail-grok-plugin.git",
+        "sha": "d1a980d44f311b0fb81bb8a68277a6bb544e31c7"
+      },
+      "homepage": "https://sendwithflare.com",
+      "keywords": ["flaremail", "flare mail", "sendwithflare", "flaremail mcp"],
+      "domains": ["sendwithflare.com", "app.sendwithflare.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,24 @@
         ]
       }
     },
+    "flaremail": {
+      "sha": "d1a980d44f311b0fb81bb8a68277a6bb544e31c7",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "flaremail",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "flaremail",
+            "description": "Use the FlareMail MCP to read, draft, and send email for the signed-in mailbox. Trigger when the user mentions FlareMai…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds **FlareMail** to the Grok Build plugin marketplace so Grok can read, draft, and send mail from a user's FlareMail account (same mailbox as the FlareMail app).

- Plugin name: `flaremail`
- Type: remote source
- Source URL + pinned SHA: https://github.com/travisrr/flaremail-grok-plugin.git @ `d1a980d44f311b0fb81bb8a68277a6bb544e31c7`
- Homepage: https://sendwithflare.com

The plugin ships a hosted MCP server (`https://flaremail-api.tcrxx0.workers.dev/mcp`) and one skill that prefers drafts until the user confirms recipients.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

FlareMail (sendwithflare.com) is built in a private product repo (`travisrr/flare-mail`). The marketplace source is a **public** plugin repo under the same GitHub account that owns the product: [travisrr/flaremail-grok-plugin](https://github.com/travisrr/flaremail-grok-plugin). There is not yet a separate GitHub org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://flaremail-api.tcrxx0.workers.dev/mcp` — FlareMail's hosted Streamable HTTP MCP (read/draft/send for the signed-in account). OAuth discovery via `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server` on the same origin.
- Credentials/permissions it requires (and why): OAuth 2.1 + PKCE in the browser on first connect (no API key in the plugin). The token can read and send as the user's FlareMail mailbox. Revoke from FlareMail Settings → Bots & MCP.

## Notes for reviewers

Keywords/domains are brand-scoped (`flaremail`, `sendwithflare.com`) so the plugin CTA does not fire on generic "email" / "gmail" requests.

Install after merge: `/marketplace` → FlareMail, or `grok mcp add --transport http flaremail https://flaremail-api.tcrxx0.workers.dev/mcp`.

Made with [Cursor](https://cursor.com)