### PR TITLE
Add gsc-wizard plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "gsc-wizard",
+      "description": "Google Search Console analysis and SEO workflows powered by GSC Wizard: rankings, content decay, cannibalization, CTR curves, and opportunity scoring, all computed server-side.",
+      "category": "analytics",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/gscwizard/grok-plugin.git",
+        "sha": "573d0a1da6749fa39045460f46fa006080b6aa78"
+      },
+      "homepage": "https://gscwizard.com",
+      "keywords": ["gsc wizard", "gscwizard", "gsc wizard mcp"],
+      "domains": ["gscwizard.com", "mcp.gscwizard.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,76 @@
         ]
       }
     },
+    "gsc-wizard": {
+      "sha": "573d0a1da6749fa39045460f46fa006080b6aa78",
+      "version": "0.1.0",
+      "components": {
+        "agents": [
+          {
+            "name": "seo-analyst",
+            "description": "Search Console and SEO performance analyst powered by GSC Wizard. Use for any question about organic search performance…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "gsc-cannibalization",
+            "description": "Find and triage query cannibalization for a property via GSC Wizard"
+          },
+          {
+            "name": "gsc-decay",
+            "description": "Find decaying content and prioritize refresh candidates via GSC Wizard"
+          },
+          {
+            "name": "gsc-opportunities",
+            "description": "Rank near-term organic growth opportunities for a property via GSC Wizard"
+          },
+          {
+            "name": "gsc-rankings",
+            "description": "Analyze ranking winners and losers for a property via GSC Wizard"
+          },
+          {
+            "name": "gsc-report",
+            "description": "Run the weekly SEO report for a Search Console property via GSC Wizard"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "gsc-wizard",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "cannibalization",
+            "description": "Find and triage query cannibalization (multiple pages competing for one query) with GSC Wizard's server-side entropy-sc…"
+          },
+          {
+            "name": "content-decay",
+            "description": "Find pages losing organic traffic over time with GSC Wizard's decay detection, classify the decay type (ranking, demand…"
+          },
+          {
+            "name": "ctr-opportunities",
+            "description": "Find queries and pages with lower CTR than expected for their ranking position using GSC Wizard's CTR-curve benchmark,…"
+          },
+          {
+            "name": "gsc-wizard-mcp",
+            "description": "Core rules for using the GSC Wizard MCP well - choosing the right tool out of 100+, date defaults and the settled-data…"
+          },
+          {
+            "name": "ranking-changes",
+            "description": "Explain what gained or lost rankings and why organic traffic moved, using GSC Wizard's ranking-change analysis. Use for…"
+          },
+          {
+            "name": "seo-opportunities",
+            "description": "Rank near-term organic growth opportunities for a property using GSC Wizard's impression-weighted opportunity scoring a…"
+          },
+          {
+            "name": "weekly-seo-report",
+            "description": "Produce a repeatable weekly SEO review for one Search Console property from GSC Wizard data — performance vs the prior…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds the GSC Wizard plugin: Google Search Console analysis and SEO workflows for Grok Build,
backed by the existing production GSC Wizard MCP server. Catalog entry only, remote source.

- Plugin name: `gsc-wizard`
- Type: remote source
- Source URL + pinned SHA: https://github.com/gscwizard/grok-plugin.git @ `573d0a1da6749fa39045460f46fa006080b6aa78`
- Homepage: https://www.gscwizard.com

Contents: 7 skills, 5 slash commands, 1 agent, and one remote MCP server registration. No hooks,
no scripts, no binaries, no install step.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`github.com/gscwizard`, the org behind
      gscwizard.com).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin is Markdown
      (skills, commands, agent) plus a single `.mcp.json`; nothing executes locally.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. The plugin ships no
      credentials and reads none from the machine.
- [x] Hooks and MCP scope are least-privilege. No hooks. One MCP server, HTTPS only.
- Network endpoints this plugin calls (and why): `https://mcp.gscwizard.com/mcp` only, the GSC
  Wizard MCP server, which reads the user's own Google Search Console and GA4 data on their behalf.
- Credentials/permissions it requires (and why): the user authenticates at connect time to their
  own GSC Wizard account, either through OAuth 2.1 (authorization code + PKCE, with dynamic client
  registration; the consent screen names the requested scopes) or a `gscw_live_` API key they
  generate themselves. Google credentials never reach the plugin or the model: GSC Wizard holds the
  Google OAuth tokens server-side. The server offers `mcp:read` and `mcp:write` scopes; read-only
  grants cannot invoke write tools, and the skills instruct the model to use write tools only on
  explicit user intent.

## Notes for reviewers

- The MCP endpoint is an existing production service (also used by our Claude and ChatGPT
  integrations), not something stood up for this submission. Analysis is computed server-side; the
  model orchestrates and interprets.
- The OAuth flow has been verified end to end against Grok's custom-connector UI, including
  discovery, dynamic client registration, consent, and tool calls.
- `keywords`/`domains` are deliberately brand-scoped so the plugin CTA only fires on GSC Wizard
  intent rather than on generic SEO or Search Console requests.
- Working end to end today: the same MCP server connected as a Grok custom connector,
resolving "last Friday" against the settled data window and answering from the GSC
Wizard warehouse rather than web search.

<img width="1380" height="902" alt="grok-working-proof" src="https://github.com/user-attachments/assets/22f1efa6-9a00-4fa7-9d51-b716c35ce011" />
