### PR TITLE
Add Locus plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "locus",
+      "description": "Official Locus plugin. Pay-per-use APIs for agents: cited web research, paid data and API lookups, and thousands of metered provider endpoints billed to one prepaid workspace credit balance through the Locus MCP server, with executable cost quotes and idempotent billing.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/locus-technologies/locus-pro-plugin.git",
+        "sha": "d2080a51e5f5de0c8c2f6d714c01d296d6462ecc"
+      },
+      "homepage": "https://github.com/locus-technologies/locus-pro-plugin",
+      "keywords": ["locus", "pay with locus", "paywithlocus", "locus credits", "locus mcp"],
+      "domains": ["paywithlocus.com", "api.paywithlocus.com", "platform.paywithlocus.com", "docs.paywithlocus.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,28 @@
         ]
       }
     },
+    "locus": {
+      "sha": "d2080a51e5f5de0c8c2f6d714c01d296d6462ecc",
+      "version": "0.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "locus",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "locus",
+            "description": "Pay-per-use APIs through the Locus MCP server. Cited web research, paid data and API lookups, and metered provider endp…"
+          },
+          {
+            "name": "locus-setup",
+            "description": "Create and fund a Locus workspace from an agent. Signup (human or agent-owned), OAuth connection, capability selection,…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds Locus's official hosted plugin: pay-per-use APIs for agents, including cited web research, paid data/API lookups, and metered provider endpoints billed to one prepaid workspace balance.

- Plugin name: `locus`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/locus-technologies/locus-pro-plugin.git` at `d2080a51e5f5de0c8c2f6d714c01d296d6462ecc`
- Homepage: https://github.com/locus-technologies/locus-pro-plugin

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official `locus-technologies` organization.

The repository is the official Locus Technologies plugin source and is MIT licensed.

## Checklist

- [x] Added exactly one kebab-case entry to `.grok-plugin/marketplace.json`.
- [x] The remote source pins a public, reachable, full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] License is stated.

## Security

- [x] No end-user install-time or runtime `curl | bash`, remote-code download/exec, `postinstall`, hooks, or local binaries. The hosted HTTPS MCP server and Markdown skills are the runtime components. Repository CI separately downloads xAI's Grok installer to a file for validation only.
- [x] No indiscriminate reading or exfiltration of secrets, tokens, `.env` files, or unrelated environment variables. Ordinary use is browser OAuth. Optional agent-owned setup reads only its specifically named credentials from an approved secret store and sends each only to its documented service.
- [x] MCP scope is limited to `https://api.paywithlocus.com/api/credits/mcp`.
- Network endpoints: `https://api.paywithlocus.com` for MCP, OAuth, agent registration, capability selection, and funding-session APIs; `https://api.agentmail.to`, `https://api.auth.agentid.com`, and `https://auth.agentid.com` only during a user-approved optional agent-owned identity flow. A server-returned Stripe Checkout URL is presented only when the user requests funding; the user opens and completes it.
- Credentials/permissions: browser OAuth for ordinary use. Optional agent-owned setup may use `LOCUS_AGENT_CREDENTIAL`, `AGENTMAIL_API_KEY`, and a locally generated AgentID P-256 private key. Each remains in the runtime's approved secret store; the private key is never sent.
- Telemetry: MCP configurations may send the static `X-Source-Name` attribution header for anonymous format-adoption telemetry, as disclosed in the README.
- Paid behavior: discovery, quotes, and balance checks are free; provider executions debit prepaid workspace credits. The skills use idempotency keys, surface charges, quote significant calls, and require the user's confirmation before the first billed execution a task did not explicitly authorize and before unusually large spends. Funding requires an explicit request, amount confirmation, and user-completed Stripe checkout; the plugin never receives card data.

## Notes for reviewers

The source contains declarative manifests, two Markdown skills, hosted MCP configuration, validation scripts, and documentation. It contains no runtime package dependencies, hooks, local MCP executable, or embedded credentials.