### PR TITLE
Add Budgey plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,10 +288,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/budgey-platforms/budgey-agent-plugin.git",
-        "sha": "faac5c73b9ebe45026ef53871f78c59f19beca84"
+        "sha": "a31a64c55067771cf9d2f083d98cd2b7920e0f57"
       },
       "homepage": "https://www.budgeyapp.com/developers",
-      "keywords": ["budgey", "budgeyapp"],
+      "keywords": ["budgey", "budgeyapp", "budgey budget", "budgey mcp"],
       "domains": ["budgeyapp.com", "www.budgeyapp.com"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "budgey",
+      "description": "Connect any agent to your Budgey budget: see what's left this period, log spending, and manage categories, goals, and recurring bills.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/budgey-platforms/budgey-agent-plugin.git",
+        "sha": "faac5c73b9ebe45026ef53871f78c59f19beca84"
+      },
+      "homepage": "https://www.budgeyapp.com/developers",
+      "keywords": ["budgey", "budgeyapp"],
+      "domains": ["budgeyapp.com", "www.budgeyapp.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -90,7 +90,7 @@
       }
     },
     "budgey": {
-      "sha": "faac5c73b9ebe45026ef53871f78c59f19beca84",
+      "sha": "a31a64c55067771cf9d2f083d98cd2b7920e0f57",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,24 @@
         ]
       }
     },
+    "budgey": {
+      "sha": "faac5c73b9ebe45026ef53871f78c59f19beca84",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "budgey",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "budgeting-with-budgey",
+            "description": "How to work with a user's Budgey budget through the Budgey MCP tools — the paycheck-period model, choosing the right re…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",


### PR DESCRIPTION
## What this PR does

New third-party plugin: **Budgey**. It connects Grok Build to a user's Budgey budget over a hosted MCP server — what's left this paycheck period, logging spending, and managing categories, goals, and recurring bills. Ships one HTTP MCP server (`https://www.budgeyapp.com/mcp`) and one skill (`budgeting-with-budgey`). Nothing is vendored into `external_plugins/`.

- Plugin name: `budgey`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/budgey-platforms/budgey-agent-plugin.git` @ `faac5c73b9ebe45026ef53871f78c59f19beca84`
- Homepage: https://www.budgeyapp.com/developers

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

[Budgey](https://www.budgeyapp.com) is a paycheck-based budgeting app from [Budgey Platforms, LLC](https://budgeyapp.com). [budgey-platforms/budgey-agent-plugin](https://github.com/budgey-platforms/budgey-agent-plugin) is the official plugin repo (MIT).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The pinned commit is `main` HEAD on a public repo (`git ls-remote` matches). The plugin includes `README.md`, `.grok-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `.mcp.json` (`version: 1.0.0`, MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin is Markdown + JSON only; the MCP server is a remote HTTP endpoint, not a local process.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. One MCP server; no hooks, no LSP servers, no local shell.
- Network endpoints this plugin calls (and why):
  - `https://www.budgeyapp.com/mcp` — hosted Streamable HTTP MCP server (OAuth 2.1 with dynamic client registration)
- Credentials/permissions it requires (and why):
  - OAuth sign-in to the user's Budgey account on first use (browser-based). Clients without OAuth can use a personal API key (`budgey_sk_…`) from https://www.budgeyapp.com/account/agents. The plugin ships no secrets or API keys.

## Notes for reviewers

**Category.** Existing catalog categories are `development`, `deployment`, `monitoring`, `database`, and `observability`. None of those fit a personal-finance budgeting plugin, so this entry uses `productivity`. Happy to drop the field if you'd rather keep the category set closed.

**Keywords and domains** are brand-scoped (`budgey`, `budgeyapp`, and the two `budgeyapp.com` hosts) so the plugin CTA does not fire on generic budgeting or paycheck questions. That matches CONTRIBUTING and the plugin's own README.

**Verification.** `git ls-remote https://github.com/budgey-platforms/budgey-agent-plugin.git HEAD` returns `faac5c73b9ebe45026ef53871f78c59f19beca84`. `validate-catalog.py` and `generate-plugin-index.py --check` both pass locally. Generated index records the HTTP MCP server and the `budgeting-with-budgey` skill at that pin.