### PR TITLE
Add TraderSpy plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "traderspy",
+      "description": "Read-only crypto futures research: AI trading signals with a public track record, smart-money and whale positions across Binance, Hyperliquid, Bybit and OKX, live prices, candles and 13 technical indicators, plus the user's own TraderSpy account. Bundles the hosted TraderSpy MCP server (mcp.traderspy.app) and three skills. Every tool is read-only — the plugin has no order, withdrawal or transfer tool.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/target1m/traderspy-mcp.git",
+        "sha": "2a48dc1d6747471da7a89d78f1efc2bfdd2120a6"
+      },
+      "homepage": "https://traderspy.app/mcp",
+      "keywords": ["traderspy", "trader spy", "traderspy signals", "traderspy smart money"],
+      "domains": ["traderspy.app", "mcp.traderspy.app", "blog.traderspy.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1007,6 +1007,32 @@
         ]
       }
     },
+    "traderspy": {
+      "sha": "2a48dc1d6747471da7a89d78f1efc2bfdd2120a6",
+      "version": "1.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "traderspy",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "market-data",
+            "description": "Query real-time crypto futures prices, OHLCV candle data, and technical indicators (RSI, MACD, EMA, Bollinger, ATR, ADX…"
+          },
+          {
+            "name": "smart-money",
+            "description": "Track smart money / whale traders across crypto exchanges (Binance, Hyperliquid, Bybit, OKX). Use when the user asks ab…"
+          },
+          {
+            "name": "trading-signals",
+            "description": "Query and analyze AI-powered crypto futures trading signals from TraderSpy. Use when the user asks about crypto signals…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6",
       "version": "0.48.1",


### PR DESCRIPTION
## What this PR does

Adds **TraderSpy** — read-only crypto futures research for Grok Build. It bundles the hosted TraderSpy MCP server (15 read-only tools: AI trading signals, smart-money/whale positions across Binance, Hyperliquid, Bybit and OKX, live prices, candles and 13 technical indicators, plus the user's own account) with three skills that tell the agent when to reach for them.

- Plugin name: `traderspy`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/target1m/traderspy-mcp.git` @ `2a48dc1d6747471da7a89d78f1efc2bfdd2120a6`
- Homepage: https://traderspy.app/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`target1m`) — see the note below on why the org name is not `traderspy`.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + description set; MIT licensed, `LICENSE` in the source repo.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. There is no install step at all — the server is remote, so nothing is cloned, built or run locally.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege: no hooks, no commands, no agents, no LSP. One HTTP MCP server and three skills.
- **Network endpoints this plugin calls (and why):** exactly one — `https://mcp.traderspy.app/mcp`, over Streamable HTTP. That is the product's own hosted MCP server; it is where the market data comes from. The skills perform no network access of their own.
- **Credentials/permissions it requires (and why):** a personal TraderSpy key (`mcp_…`) that the user generates themselves at https://traderspy.app/mcp and pastes into the URL, so the server can scope reads to their account and apply their quota. A free account is enough. The key grants **read** access only: the connector exposes no order, withdrawal or transfer tool — those were removed from the server entirely rather than gated, so there is no code path from a plugin tool call to a mutation.

## Notes for reviewers

- **Why the org is `target1m` and not `traderspy`:** `target1m` is the org that publishes TraderSpy; `github.com/Traderspy` is an unrelated account registered in 2017, so the brand-matching org name is not available to us. First-party ownership is verifiable elsewhere: the same server is published to the official MCP Registry as `app.traderspy/traderspy` (namespace proved by a DNS TXT record on `traderspy.app`), to Smithery as `traderspy/traderspy`, and on mcpservers.org as `target1m/traderspy-mcp`.
- **Category:** I used `finance`, which is new to this catalog. Happy to move it under an existing category if you would rather not open one.
- The pinned commit wraps the plugin's `.mcp.json` as `{"mcpServers": {…}}` so `scan_mcp_servers` picks the server up — the previous bare-map form (which Claude Code also accepts) indexed the skills but no server.
