### PR TITLE
Add walletlink: wallet-to-social resolution over a hosted MCP server

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/starl3xx/walletlink-grok-plugin.git",
-        "sha": "57d3450559bfd14b81e3fe29a0a8bf1243a606fb"
+        "sha": "9e777bbe85e2d1002f3ae925eb204766f4ddae69"
       },
       "homepage": "https://walletlink.social",
       "keywords": ["walletlink", "walletlink social", "walletlink mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "walletlink",
+      "description": "Resolve Ethereum wallets to the X and Farcaster accounts their owners attested, and find the wallets behind a handle (hosted MCP server + skill). Sign in with OAuth or a walletlink.social API key; agents can buy access with USDC, no account needed.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/starl3xx/walletlink-grok-plugin.git",
+        "sha": "92730037fb88dea5ba058907a364123d819b5d20"
+      },
+      "homepage": "https://walletlink.social",
+      "keywords": ["walletlink", "walletlink social", "walletlink mcp"],
+      "domains": ["walletlink.social", "docs.walletlink.social"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/starl3xx/walletlink-grok-plugin.git",
-        "sha": "01379bc102cc79c3e4f77eb1c3fcdcfda98ee5f5"
+        "sha": "57d3450559bfd14b81e3fe29a0a8bf1243a606fb"
       },
       "homepage": "https://walletlink.social",
       "keywords": ["walletlink", "walletlink social", "walletlink mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/starl3xx/walletlink-grok-plugin.git",
-        "sha": "92730037fb88dea5ba058907a364123d819b5d20"
+        "sha": "01379bc102cc79c3e4f77eb1c3fcdcfda98ee5f5"
       },
       "homepage": "https://walletlink.social",
       "keywords": ["walletlink", "walletlink social", "walletlink mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1203,7 +1203,7 @@
       }
     },
     "walletlink": {
-      "sha": "57d3450559bfd14b81e3fe29a0a8bf1243a606fb",
+      "sha": "9e777bbe85e2d1002f3ae925eb204766f4ddae69",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1203,7 +1203,7 @@
       }
     },
     "walletlink": {
-      "sha": "01379bc102cc79c3e4f77eb1c3fcdcfda98ee5f5",
+      "sha": "57d3450559bfd14b81e3fe29a0a8bf1243a606fb",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1202,6 +1202,24 @@
         ]
       }
     },
+    "walletlink": {
+      "sha": "92730037fb88dea5ba058907a364123d819b5d20",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "walletlink",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "walletlink",
+            "description": "Resolve Ethereum wallet addresses to the social accounts their owners published (X, Farcaster, ENS, Lens, GitHub), and…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e",
       "version": "1.17.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1203,7 +1203,7 @@
       }
     },
     "walletlink": {
-      "sha": "92730037fb88dea5ba058907a364123d819b5d20",
+      "sha": "01379bc102cc79c3e4f77eb1c3fcdcfda98ee5f5",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds walletlink, a new third-party plugin: resolve Ethereum wallet addresses to the X and Farcaster accounts their owners attested, and find the wallets behind a handle, through the hosted walletlink.social MCP server.

- Plugin name: `walletlink`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/starl3xx/walletlink-grok-plugin.git` @ `92730037fb88dea5ba058907a364123d819b5d20`
- Homepage: https://walletlink.social

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the plugin repo's LICENSE, README and manifest).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): exactly one, `https://walletlink.social/api/mcp` (streamable HTTP MCP; its tools proxy the documented REST API at `https://walletlink.social/api/v1/*` server-side). The plugin ships no hooks, no commands, no agents and no local code: one `.mcp.json`, one skill, a README.
- Credentials/permissions it requires (and why): none shipped and none read. Authentication happens at the server: OAuth 2.1 with PKCE (consent screen on first tool call; dynamic client registration supported), or an `Authorization: Bearer wts_live_...` API key the user creates at walletlink.social, or an agent can buy access with USDC via x402, no account needed. Tool discovery (`initialize`, `tools/list`) needs no credential and is IP-rate-limited at the server. Endpoints and credentials are declared in the plugin README, per CONTRIBUTING.

## Notes for reviewers

- **Why a personal-account source:** walletlink.social is a solo-operated product and `starl3xx` is its owner's account; there is no separate org. Ownership is verifiable from the brand's own surfaces: the plugin repo is linked from the product docs at https://docs.walletlink.social/mcp-server ("From Grok"), the manifest's `homepage` is walletlink.social, and the product repo `starl3xx/wallet-to-social` (public) implements the server this plugin points at.
- The MCP server is production infrastructure already in use by other clients (Claude, Cursor; it is also published in the MCP registry as `social.walletlink/wallet-identity`). Metering, rate limits and quota reporting are documented at https://docs.walletlink.social.
- `keywords`/`domains` in the catalog entry are brand-scoped per CONTRIBUTING; the plugin repo's CI smoke-tests the manifests and the live server on every push.
