### PR TITLE
Add Quo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "quo",
+      "description": "Official Quo MCP for Grok Build. Send individual, group, or bulk SMS; manage contacts and tasks; review message history and call transcripts; and follow up on missed calls through Quo's hosted OAuth MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/OpenPhone/quo-grok-plugin.git",
+        "sha": "64546ee3ee9a6c50abe5af0e69d9742ee4b9368e"
+      },
+      "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
+      "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
+      "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/OpenPhone/quo-grok-plugin.git",
-        "sha": "64546ee3ee9a6c50abe5af0e69d9742ee4b9368e"
+        "sha": "04abd6ef9cd98ffba2105bb7437c13623c26a675"
       },
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -725,6 +725,18 @@
         ]
       }
     },
+    "quo": {
+      "sha": "64546ee3ee9a6c50abe5af0e69d9742ee4b9368e",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "quo",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "railway": {
       "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
       "version": "1.3.7",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -726,7 +726,7 @@
       }
     },
     "quo": {
-      "sha": "64546ee3ee9a6c50abe5af0e69d9742ee4b9368e",
+      "sha": "04abd6ef9cd98ffba2105bb7437c13623c26a675",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds Quo's official hosted MCP server to the xAI plugin marketplace. The plugin lets Grok Build users send individual, group, and bulk SMS; manage contacts and tasks; review message history and call transcripts; and follow up on missed calls through browser-based OAuth.

- Plugin name: `quo`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/OpenPhone/quo-grok-plugin.git` at `04abd6ef9cd98ffba2105bb7437c13623c26a675`
- Homepage: https://github.com/OpenPhone/quo-grok-plugin

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

Quo is the new name for OpenPhone, so the official source remains under the verified `OpenPhone` GitHub organization. Rebrand announcement: https://www.quo.com/blog/next-chapter/

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json` with the kebab-case name `quo`.
- [x] The remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the upstream repo has a detailed README and Apache-2.0 license.

## Security

- [x] No `curl | bash`, remote-code download/exec, `postinstall`, hooks, scripts, or local binaries.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, environment variables, or unrelated filesystem data.
- [x] MCP scope is limited to Quo's official hosted HTTPS endpoint.
- Network endpoints this plugin calls (and why): `https://mcp.quo.com/mcp`, the official Quo MCP endpoint used for all plugin capabilities and OAuth discovery.
- Credentials/permissions it requires (and why): a Quo account authorized through browser-based OAuth. Once approved, the MCP can read the workspace data required by its tools and perform user-requested write actions such as sending messages and creating or updating contacts and tasks. No API key is pasted or stored by the plugin.

The upstream README discloses data handling, service usage/diagnostic events, messaging costs, irreversible group-message behavior.

## Notes for reviewers

The upstream package contains only:

- `.grok-plugin/plugin.json`
- `.mcp.json` pointing to `https://mcp.quo.com/mcp`
- README and Apache-2.0 license

The generated index detects one HTTP MCP server named `quo`, version `1.0.0`.
