### PR TITLE
Add PostSyncer plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "postsyncer",
+      "description": "PostSyncer social media scheduling and analytics. Create, schedule, draft, and repeat posts across X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Threads, Bluesky, Mastodon, Pinterest, and Telegram; manage media, campaigns, labels, comment moderation, and performance analytics through the PostSyncer MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/PostSyncer/claude-plugin.git",
+        "sha": "3a0319ad97322bdc8c26772f3583918bc6278bc3"
+      },
+      "homepage": "https://postsyncer.com",
+      "keywords": ["postsyncer", "postsyncer api", "postsyncer mcp"],
+      "domains": ["postsyncer.com", "docs.postsyncer.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,24 @@
         ]
       }
     },
+    "postsyncer": {
+      "sha": "3a0319ad97322bdc8c26772f3583918bc6278bc3",
+      "version": "1.0.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "postsyncer",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "postsyncer",
+            "description": "Schedule, publish, and analyze social media posts with PostSyncer across 11 platforms — X (Twitter), Instagram, Faceboo…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "b9ddc83c32972210b8a94d389130713e8eed346e",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official **PostSyncer** plugin: social media scheduling and analytics from Grok Build. Create, schedule, draft, and repeat posts across X, Instagram, Facebook, LinkedIn, TikTok, YouTube, Threads, Bluesky, Mastodon, Pinterest, and Telegram; manage media, campaigns, labels, comment moderation, and performance analytics through the PostSyncer MCP server.

- Plugin name: `postsyncer`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/PostSyncer/claude-plugin.git @ `3a0319ad97322bdc8c26772f3583918bc6278bc3`
- Homepage: https://postsyncer.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://postsyncer.com/mcp` (the remote Streamable HTTP MCP server; every tool call goes here) and `https://postsyncer.com/oauth/*` (OAuth 2.0 authorization when the user picks the OAuth login flow). Documented in the repo README under "Network and permissions".
- Credentials/permissions it requires (and why): an OAuth grant from the login flow, or a PostSyncer API token the user creates and configures as a Bearer token. Needed to read/write the user's own PostSyncer workspaces. No hooks, scripts, or local binaries; the plugin ships only `.mcp.json`, `.claude-plugin/plugin.json`, and one skill file.

## Notes for reviewers

The source repo lives under the official PostSyncer GitHub org and is the same plugin published in the ChatGPT/Codex plugin directory (PostSyncer LLC). The manifest is Claude-format (`.claude-plugin/plugin.json`), which this marketplace accepts. Contact: abdulmejid@postsyncer.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
