### PR TITLE
Add Sequenzy plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "sequenzy",
+      "description": "Sequenzy email marketing integration for Grok Build (hosted MCP server + agent skills). Manage permission-based lifecycle campaigns, sequences, subscribers, templates, transactional email, and delivery analytics.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Sequenzy/skills.git",
+        "sha": "498b399a0fb5a23d75642a2b26ae4933d073f057"
+      },
+      "homepage": "https://sequenzy.com",
+      "keywords": ["sequenzy", "sequenzy email marketing", "sequenzy mcp"],
+      "domains": ["sequenzy.com", "api.sequenzy.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -795,6 +795,80 @@
         ]
       }
     },
+    "sequenzy": {
+      "sha": "498b399a0fb5a23d75642a2b26ae4933d073f057",
+      "version": "1.8.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "sequenzy",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "claudeemailmarketing",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "claudeemailskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "codexemailskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "dripcampaignskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emailagentskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emailautomationskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emailcampaignskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emaildeliverabilityskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emaildesignskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "emailworkflowskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "hermesemailskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "newsletterskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "openclawemailskill",
+            "description": "Use when Codex, Hermes, OpenClaw, Claude Code, Cowork, or another AI agent needs to plan, review, implement, audit, or…"
+          },
+          {
+            "name": "sequenzy",
+            "description": "Generic compatibility guide for Sequenzy operations. Use for broad Sequenzy references, but prefer sequenzy-email-marke…"
+          },
+          {
+            "name": "sequenzy-email-marketing",
+            "description": "Primary agent guide for operating Sequenzy as an email-marketing platform. Use when Codex needs to authenticate, inspec…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "9f39fa607a63582d8c5b62aaf6fa4898b9c7caac",
       "version": "0.6.2",


### PR DESCRIPTION
## What this PR does

Adds the official Sequenzy plugin so Grok Build can operate permission-based lifecycle, campaign, transactional email, and analytics workflows through Sequenzy's hosted MCP server and agent skills.

- Plugin name: `sequenzy`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Sequenzy/skills.git` at `498b399a0fb5a23d75642a2b26ae4933d073f057`
- Homepage: https://sequenzy.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name.
- [x] The remote source pins a public, reachable 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set.
- [x] The source repository states its MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks are installed. The MCP connection uses Sequenzy OAuth and permission-scoped tools.
- Network endpoints this plugin calls: `https://api.sequenzy.com/v1/mcp` for the hosted MCP server and `https://www.sequenzy.com` for OAuth authorization and dashboard links.
- Credentials/permissions: a Sequenzy account authorizes the hosted MCP connection in the browser. No API key is embedded or stored in the plugin. Users approve the Sequenzy permissions granted to the connection.

## Notes for reviewers

The source is maintained in the official `Sequenzy` GitHub organization. Its Grok manifest, MCP configuration, license, authorization guidance, and mutation safeguards were added in Sequenzy/skills#9. The generated index discovers version 1.8.0, one HTTP MCP server, and 15 skills.
