### PR TITLE
feat: add adlicio plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "adlicio",
+      "description": "Customer-voice research for marketing and ad work. Scrape comments and reviews from Reddit, YouTube, Amazon, TikTok, Instagram, Trustpilot, app stores and 20+ other sources, search Reddit and YouTube, pull top-performing TikTok and Instagram videos with their on-screen hooks, find competitor ads in the Meta Ad Library, and build brand and voice-of-customer reports. Hosted MCP server over OAuth, no API key to paste.",
+      "category": "research",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/daniel-ddtech/adlicio-plugin.git",
+        "sha": "312d8e82dfa965a4656abdb6fbd04099e538293f"
+      },
+      "homepage": "https://tryadlicio.com/mcp",
+      "keywords": ["adlicio", "adlicio research", "tryadlicio"],
+      "domains": ["tryadlicio.com", "mcp.tryadlicio.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/daniel-ddtech/adlicio-plugin.git",
-        "sha": "312d8e82dfa965a4656abdb6fbd04099e538293f"
+        "sha": "6e1cdb0b88fa4e67ff3beeec13371e681278fe9d"
       },
       "homepage": "https://tryadlicio.com/mcp",
       "keywords": ["adlicio", "adlicio research", "tryadlicio"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,24 @@
 {
   "version": 1,
   "plugins": {
+    "adlicio": {
+      "sha": "312d8e82dfa965a4656abdb6fbd04099e538293f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "adlicio",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "adlicio-customer-research",
+            "description": "Research what real people say about a topic, product, company, or problem using the Adlicio MCP tools. Use for customer…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "adlicio": {
-      "sha": "312d8e82dfa965a4656abdb6fbd04099e538293f",
+      "sha": "6e1cdb0b88fa4e67ff3beeec13371e681278fe9d",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds one new plugin entry for Adlicio, a customer-voice research tool for marketers and ad operators. The plugin ships the hosted Adlicio MCP server plus one skill that tells the agent how to run a research pass and report it with sources.

- Plugin name: `adlicio`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/daniel-ddtech/adlicio-plugin.git` at `312d8e82dfa965a4656abdb6fbd04099e538293f`
- Homepage: https://tryadlicio.com/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (explained below).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` and description set.
- [x] License is stated (MIT, in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls: `https://mcp.tryadlicio.com/mcp` only. The plugin is a `.mcp.json` pointing at that hosted server plus one `SKILL.md`. No hooks, no commands, no agents, no scripts, no local process.
- Credentials it requires: none to install. The server uses OAuth 2.1 with dynamic client registration, so the host stores no API key and the user signs in to their own Adlicio account on first call.

## Notes for reviewers

Adlicio is a small independent product and the source repo is under the founder's personal GitHub account, `daniel-ddtech`, because there is no separate GitHub org. The account is the same one that publishes the `commentscraper` npm CLI and the `com.tryadlicio/adlicio` entry in the official MCP Registry, and the repo links back to https://tryadlicio.com. Happy to move it to an org if you prefer that before merge.

Contact: daniel@tryadlicio.com
