### PR TITLE
Add AlertForge plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,24 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "alertforge",
+      "description": "Create coordinated stream branding, animated overlay packs, AI stream alerts, and transparent video assets through AlertForge's hosted MCP server and guided workflow skill. Connects with OAuth and preserves credit quotes and user-approval checkpoints.",
+      "category": "design",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/kasunjith713/alertforge-agent-plugin.git",
+        "sha": "bd3d63193f49dc0ba1955ba0a0745ceadb8b6524"
+      },
+      "homepage": "https://alertforge.ai/ai-agents",
+      "keywords": [
+        "alertforge",
+        "alertforge overlays",
+        "alertforge alerts",
+        "alertforge ai"
+      ],
+      "domains": ["alertforge.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,24 @@
 {
   "version": 1,
   "plugins": {
+    "alertforge": {
+      "sha": "bd3d63193f49dc0ba1955ba0a0745ceadb8b6524",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "alertforge",
+            "description": "streamable-http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "create-stream-branding",
+            "description": "Create coordinated streaming brand assets with AlertForge, including Style Sheets, animated overlay packs, AI stream al…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `alertforge`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/kasunjith713/alertforge-agent-plugin.git` at `bd3d63193f49dc0ba1955ba0a0745ceadb8b6524`
- Homepage: https://alertforge.ai/ai-agents

Adds AlertForge's hosted Streamable HTTP MCP server and guided stream-branding skill for overlay packs, stream alerts, and transparent video assets.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

AlertForge does not currently have a GitHub organization, so the official integration repository is published from the product maintainer's GitHub account. The package identifies `https://alertforge.ai`, `support@alertforge.ai`, and the product policies as its ownership and support surfaces.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; the remote plugin includes a `README.md` and manifests.
- [x] License is stated (MIT for the integration package).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. The package has no hooks, scripts, dependencies, or local filesystem access.
- Network endpoints this plugin calls (and why): `https://alertforge.ai/api/mcp` for the hosted MCP server; OAuth metadata and authorization endpoints are discovered under the same `alertforge.ai` origin.
- Credentials/permissions it requires (and why): no static credentials. Account tools use AlertForge OAuth 2.1 with PKCE and require an eligible AlertForge account; paid creation uses the user's AlertForge credit balance only after quote and approval checkpoints.

## Notes for reviewers

The public source contains only manifests, one MCP definition, documentation, and one workflow skill. `claude plugin validate .` passes, and the xAI catalog validator and generated-index check both pass locally.