### PR TITLE
Add Fudge design research plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -187,6 +187,19 @@
       "domains": ["figma.com", "www.figma.com"]
     },
     {
+      "name": "fudge",
+      "description": "Search captured website references and inspect their typography, colors, layout, components, and design tokens through Fudge's hosted MCP server and design-research skill.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/scroobius-pip/fudge-mcp.git",
+        "sha": "684b8137f6853492e1d66a07eaca1914bf86c405"
+      },
+      "homepage": "https://design.withfudge.com/mcp",
+      "keywords": ["fudge", "fudge mcp", "fudge design"],
+      "domains": ["design.withfudge.com", "api.withfudge.com", "pin.fontofweb.com"]
+    },
+    {
       "name": "exa",
       "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,24 @@
         ]
       }
     },
+    "fudge": {
+      "sha": "684b8137f6853492e1d66a07eaca1914bf86c405",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "fudge",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "fudge-design-research",
+            "description": "Use Fudge when a user asks Grok Build to find website references, inspect how a captured website is designed, identify…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

- Plugin name: Fudge
- Type: remote source
- Source URL + pinned SHA: `https://github.com/scroobius-pip/fudge-mcp.git` at `684b8137f6853492e1d66a07eaca1914bf86c405`
- Homepage: https://design.withfudge.com/mcp

Fudge gives Grok Build a searchable library of captured website references and the design details behind them, including typography, colors, layout, components, spacing, borders, shadows, gradients, media, and page context. The remote package contains one OAuth-protected hosted MCP server and one narrowly scoped design-research skill.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is the public canonical Fudge MCP repository maintained by the product owner. The account/brand relationship is explained below.

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] Pinned a public, reachable, full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] The source includes a clear README, `.grok-plugin/plugin.json`, and `.mcp.json`.
- [x] The source is licensed under MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, `postinstall`, or other local code execution.
- [x] No reading or exfiltration of secrets, tokens, `.env`, environment variables, or project files.
- [x] No hooks, commands, agents, binaries, or filesystem permissions. The package contains only a hosted MCP configuration and a Markdown skill.

Network endpoints:

- `https://api.withfudge.com/mcp` - the hosted Fudge MCP endpoint declared by the plugin.
- The hosted service may return product links and visual previews from Fudge-owned `design.withfudge.com`, `api.withfudge.com`, and `pin.fontofweb.com` domains.

Credentials and permissions:

- Authentication uses the MCP OAuth flow with `fudge:query`, `openid`, and `email` scopes.
- Users sign in to their Fudge account in the browser. The plugin requires no API key and does not read local credentials.

## Notes for reviewers

`scroobius-pip` is the GitHub account of Fudge's owner and maintains the product's public MCP repository. The repository is already the public source named by Fudge's MCP Registry metadata and links back to the product-controlled `design.withfudge.com` domain. The main application repository is private; this small public repository exists so MCP clients and reviewers can inspect the complete installed package without receiving application source.

The pinned source exposes these generated components:

- MCP server: `fudge` (`http` transport)
- Skill: `fudge-design-research`
- Plugin version: `1.0.0`
