### PR TITLE
Add postzen plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/postzen-dev/postzen-grok-plugin.git",
-        "sha": "a128f206b314a082f0913ac7af033693124930cf"
+        "sha": "4f71121df5a72fa04304356618403c1aa8a6003b"
       },
       "homepage": "https://www.postzen.dev",
       "keywords": ["postzen", "postzen api", "postzen mcp", "post zen"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/postzen-dev/postzen-grok-plugin.git",
-        "sha": "4f71121df5a72fa04304356618403c1aa8a6003b"
+        "sha": "bcc44eedca4d766974c1efeefe3a590a069a60f8"
       },
       "homepage": "https://www.postzen.dev",
       "keywords": ["postzen", "postzen api", "postzen mcp", "post zen"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "postzen",
+      "description": "PostZen social media scheduling (MCP Server + Skills). Publish, schedule, and queue posts across X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Pinterest, Bluesky, and Telegram, upload media, manage posting queues, connect accounts, and pull analytics reports directly from Grok Build.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/postzen-dev/postzen-grok-plugin.git",
+        "sha": "a128f206b314a082f0913ac7af033693124930cf"
+      },
+      "homepage": "https://www.postzen.dev",
+      "keywords": ["postzen", "postzen api", "postzen mcp", "post zen"],
+      "domains": ["postzen.dev", "www.postzen.dev", "app.postzen.dev", "docs.postzen.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,36 @@
         ]
       }
     },
+    "postzen": {
+      "sha": "a128f206b314a082f0913ac7af033693124930cf",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "postzen",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "postzen-analytics",
+            "description": "Build a social media analytics report from PostZen — post performance, follower growth, daily metrics, and best times t…"
+          },
+          {
+            "name": "postzen-connect",
+            "description": "Connect a new social media account to PostZen (X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Pinterest, B…"
+          },
+          {
+            "name": "postzen-post",
+            "description": "Create, schedule, or queue a social media post with PostZen. Use when the user wants to post, schedule, cross-post, or…"
+          },
+          {
+            "name": "postzen-queue",
+            "description": "Set up and manage PostZen posting queues — recurring time slots that posts fill automatically. Use when the user wants…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "b9ddc83c32972210b8a94d389130713e8eed346e",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -529,8 +529,8 @@
       }
     },
     "postzen": {
-      "sha": "4f71121df5a72fa04304356618403c1aa8a6003b",
-      "version": "1.1.0",
+      "sha": "bcc44eedca4d766974c1efeefe3a590a069a60f8",
+      "version": "1.2.0",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -529,8 +529,8 @@
       }
     },
     "postzen": {
-      "sha": "a128f206b314a082f0913ac7af033693124930cf",
-      "version": "1.0.0",
+      "sha": "4f71121df5a72fa04304356618403c1aa8a6003b",
+      "version": "1.1.0",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

Adds the **PostZen** plugin (new plugin, remote source). PostZen is a social media scheduling and publishing API; the plugin bundles our hosted MCP server plus four workflow skills so Grok Build can draft, schedule, queue, and analyze posts across X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Pinterest, Bluesky, and Telegram.

- Plugin name: `postzen`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): `https://github.com/postzen-dev/postzen-grok-plugin.git` @ `a128f206b314a082f0913ac7af033693124930cf`
- Homepage: https://www.postzen.dev

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`postzen-dev` is PostZen's GitHub org (it also hosts our published SDKs: `postzen-node`, `postzen-python`, `postzen-cli`, and the Claude Code plugin `postzen-claude-plugin`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, `LICENSE` in the plugin repo and `license` in `.grok-plugin/plugin.json`)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.postzen.dev/mcp` only (our hosted MCP server, HTTP transport). The server proxies tool calls to our public API at `https://api.postzen.dev`. Media uploads go via HTTP `PUT` to a presigned upload URL returned by the `createMediaPresign` tool.
- Credentials/permissions it requires (and why): MCP OAuth sign-in to the user's PostZen account (browser flow; the user picks which profiles to expose). The resulting token carries a PostZen API key scoped to those profiles, revocable from the PostZen dashboard. No API keys, env vars, or local files are read. The plugin ships no hooks, commands, agents, or shell execution; it is `.mcp.json` + four `SKILL.md` files.

## Notes for reviewers

- Components: 1 MCP server (`postzen`, http) + 4 skills (`postzen-post`, `postzen-queue`, `postzen-analytics`, `postzen-connect`). Skill names are brand-prefixed to avoid slash-command collisions with generic names like `/post`.
- The skills require explicit user confirmation before anything is published (`publishNow` or near-term `scheduledFor`); drafts don't.
- `keywords` and `domains` are brand-scoped per CONTRIBUTING.md.
- Same MCP server is already listed as a Claude Code plugin (`postzen-dev/postzen-claude-plugin`); this repo is the Grok Build packaging of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
