### PR TITLE
Add SEOAgent plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,24 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "seoagent",
+      "description": "The SEO engine for coding agents. Skill plus CLI that audits pages, fixes metadata, and drafts SEO pages in the repo.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Baxter-Inc/seoagent-npm.git",
+        "sha": "08062f34ddc057932f42544f98b524c6d85d8f1e",
+        "path": "plugins/seoagent-cli-bootstrap"
+      },
+      "homepage": "https://seoagent.com",
+      "keywords": [
+        "seoagent"
+      ],
+      "domains": [
+        "seoagent.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -795,6 +795,18 @@
         ]
       }
     },
+    "seoagent": {
+      "sha": "08062f34ddc057932f42544f98b524c6d85d8f1e",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "seoagent-cli-setup",
+            "description": "Install or set up SEOAgent for Claude Code — persistent technical SEO audits, keyword strategy, content briefs, and art…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "9f39fa607a63582d8c5b62aaf6fa4898b9c7caac",
       "version": "0.6.2",


### PR DESCRIPTION
Adds **SEOAgent** as a remote plugin in `.grok-plugin/marketplace.json` and regenerates `.grok-plugin/plugin-index.json`.

SEOAgent is a Skill + CLI (not an MCP server). It audits pages, fixes metadata, and drafts SEO pages in the repo. Optional Autopilot uses Google Search Console and keyword research and queues updates you approve.

- Source: https://github.com/Baxter-Inc/seoagent-npm (MIT), official org Baxter-Inc
- Plugin path: `plugins/seoagent-cli-bootstrap` (ships `.claude-plugin/plugin.json`, accepted per CONTRIBUTING)
- Pinned SHA: `08062f34ddc057932f42544f98b524c6d85d8f1e`
- Homepage: https://seoagent.com
- Keywords/domains: brand-scoped (`seoagent`, `seoagent.com`)
- Contact: support@seoagent.com

Local checks:
- `python3 scripts/validate-catalog.py` — Catalog OK
- `python3 scripts/generate-plugin-index.py --check` — Plugin index OK