### PR TITLE
Add dely plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "dely",
+      "description": "Delivery protocol for coding agents. Brings a request to an approved design contract, then dispatches implementation and review to fresh worker sessions on different harnesses so nothing reviews its own diff, and prepares an exact-HEAD pull request. Two human gates only: approve the contract, merge the PR. Requires Orca as the execution plane.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/hieuphung97/dely.git",
+        "sha": "c2fc1a96dce4eabc5b8c9ee9dafbb66fb371d785"
+      },
+      "homepage": "https://github.com/hieuphung97/dely",
+      "keywords": ["dely", "dely delivery", "dely setup"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,22 @@
         ]
       }
     },
+    "dely": {
+      "sha": "c2fc1a96dce4eabc5b8c9ee9dafbb66fb371d785",
+      "version": "0.17.0",
+      "components": {
+        "skills": [
+          {
+            "name": "delivery",
+            "description": "Deliver a change through an approved design contract, sequential implementation, independent review and exact-HEAD rele…"
+          },
+          {
+            "name": "setup",
+            "description": "Configure a project's AGENTS.md with one managed Dely block — per-phase harness, model and effort for implement and rev…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds one catalog entry for `dely`, a delivery protocol for coding agents: it brings a request to an approved design contract, then dispatches implementation and review to fresh worker sessions on different harnesses so nothing reviews its own diff, and prepares an exact-HEAD pull request. Two human gates only — approve the contract, merge the PR.

- Plugin name: `dely`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/hieuphung97/dely.git` @ `c2fc1a96dce4eabc5b8c9ee9dafbb66fb371d785`
- Homepage: https://github.com/hieuphung97/dely

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

The source repo is a personal account, not an org: `dely` is an individual open-source project (MIT), published and maintained by its author at `github.com/hieuphung97/dely`. There is no organization behind it to publish from.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: MIT. Remote source, so nothing is vendored here; the plugin manifest is `.claude-plugin/plugin.json`, which CONTRIBUTING.md accepts for Claude-ecosystem plugins.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin ships **two skills and nothing else** — no `hooks/`, no `.mcp.json`, no `.lsp.json`, no `bin/`, no install scripts. The whole payload is `skills/delivery/SKILL.md`, `skills/setup/SKILL.md` and their reference files.

- Network endpoints this plugin calls (and why): none of its own. The skills instruct the agent to use tools the user already has — `git` and `gh` against the user's own repository and its GitHub remote when preparing the pull request, and the local `orca` CLI, which is the execution plane that launches the worker sessions.
- Credentials/permissions it requires (and why): none requested or stored by the plugin. It relies on the user's existing `git`/`gh` authentication and their local Orca runtime.

## Notes for reviewers

`dely` is a control protocol rather than an integration: it drives coding-agent CLIs against a git repository and stops at a prepared pull request. It is packaged for several CLIs today (Claude Code, Codex CLI, Cursor Agent CLI, Grok Build, GitHub Copilot CLI among them), with further harnesses added as they ship. Grok Build is one of the harnesses it can dispatch implementation or review to, pinned per phase in the project's `AGENTS.md`.

Note that Orca is a hard dependency: without it the skill preflights and stops rather than running degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsyPh9MiUPZXjebkP63reB