### PR TITLE
Add web-search-plus (source-only multi-provider web search + extraction)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "web-search-plus",
+      "description": "Web Search Plus: source-only multi-provider web search and bounded URL extraction (MCP server + skill). Routes across Serper, Exa, Tavily, Linkup, You.com, Firecrawl, Parallel, Brave and more with your own provider keys; returns ranked sources and extracted page text, never synthesized answers.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/robbyczgw-cla/web-search-plus-mcp.git",
+        "sha": "01fa793b9fa561244c904c283c0d1b32e6309413"
+      },
+      "homepage": "https://websearchplus.xyz",
+      "keywords": ["web search plus", "websearchplus", "web-search-plus-mcp", "wsp search"],
+      "domains": ["websearchplus.xyz"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1226,6 +1226,24 @@
         ]
       }
     },
+    "web-search-plus": {
+      "sha": "01fa793b9fa561244c904c283c0d1b32e6309413",
+      "version": "4.0.4",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "web-search-plus",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "web-search-plus",
+            "description": "Use the Web Search Plus MCP tools (web_search, web_extract) for source-backed web research: current events, prices, rel…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "572357b791a91a5138c050e08eb718b150be21cb",
       "version": "1.18.1",


### PR DESCRIPTION
Adds **web-search-plus** as a remote-source third-party plugin.

## What it is

Source-only multi-provider web search and bounded URL extraction for Grok Build. The plugin ships one stdio MCP server (`web_search`, `web_extract`) started through `uvx` with an exact PyPI version pin, plus a skill that tells Grok when to use the tools, which parameters matter, and how to set up provider keys. It routes across Serper, Exa, Tavily, Linkup, You.com, Firecrawl, Parallel, Brave, SearXNG and others using the user's own keys. It returns ranked sources and extracted page text; it never synthesizes answers.

## Provenance

- Same author and engine as [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) (390 stars, 29 forks), the Web Search Plus plugin for Hermes Agent. `web-search-plus-mcp` is the standalone MCP packaging of that engine, published on PyPI as [`web-search-plus-mcp`](https://pypi.org/project/web-search-plus-mcp/) (4.0.3, MIT) and listed on Glama.
- Project site: https://websearchplus.xyz
- Source repository: https://github.com/robbyczgw-cla/web-search-plus-mcp (pinned commit `3a48e0fb74b2c93ab6c6783c87cec28ba27113ea`)

## Security notes

- No provider keys are shipped or read from files; the server reads keys from the process environment the user sets. Without keys `web_search` returns a typed "no provider configured" error.
- No hooks, no agents, no commands. Components: 1 MCP server (stdio), 1 skill.
- `uvx --from web-search-plus-mcp==4.0.3 web-search-plus-mcp` installs the pinned PyPI release into uv's isolated cache. No `curl | bash`, no postinstall scripts.
- `web_extract` refuses private/internal targets (loopback, RFC1918, cloud metadata hosts) before calling any provider.

## Checklist

- [x] One entry added to `.grok-plugin/marketplace.json`, kebab-case name, unique
- [x] Remote source pinned to a full 40-char commit SHA, public and reachable
- [x] `.grok-plugin/plugin-index.json` regenerated (`generate-plugin-index.py`, `--check` passes)
- [x] `validate-catalog.py` passes
- [x] `homepage`, `description`, brand-scoped `keywords` and `domains` (`websearchplus.xyz`)
- [x] MIT licensed, stated in the repository
- [x] Live-tested with Grok Build 0.2.111: install, `grok mcp doctor` healthy, `web_search` call returns results with provider and routing metadata
