### PR TITLE
Add job.rocks workforce management plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "jobrocks",
+      "description": "job.rocks workforce management integration (remote MCP + skill). Plan staffing projects and shifts, review aggregate staffing progress, and hand sensitive staff-level work back to job.rocks. OAuth authentication required.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/job-rocks/jobrocks-grok-plugin.git",
+        "sha": "97931d9ad042a310d64fee43b058af6774898e1f"
+      },
+      "homepage": "https://job.rocks",
+      "keywords": ["job.rocks", "jobrocks", "job.rocks workforce management", "job.rocks shift planning"],
+      "domains": ["job.rocks", "mcp.jobrocks.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,24 @@
         ]
       }
     },
+    "jobrocks": {
+      "sha": "97931d9ad042a310d64fee43b058af6774898e1f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "jobrocks",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "jobrocks",
+            "description": "Operate an authenticated job.rocks workforce account through its privacy-minimized MCP. Use for staffing projects, cust…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds the official job.rocks workforce management plugin for Grok Build. The plugin connects to the OAuth-protected remote MCP surface and includes a skill for safe project, shift, and aggregate staffing workflows.

- Plugin name: `jobrocks`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/job-rocks/jobrocks-grok-plugin.git` @ `97931d9ad042a310d64fee43b058af6774898e1f`
- Homepage: https://job.rocks

The MCP surface returns privacy-minimized aggregate planning/status data. It supports draft customer/project/role/shift creation and secure job.rocks handoff links. The bundled skill requires explicit user confirmation before publishing applications or sending announcements and keeps staff selection and sensitive personal details inside job.rocks.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`job-rocks`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] No hooks; MCP access is scoped to the authenticated job.rocks account.
- Network endpoints: `https://mcp.jobrocks.ai/mcp` plus OAuth discovery/authorization endpoints on the same host.
- Credentials/permissions: OAuth 2.1 authorization code flow with PKCE using the customer's job.rocks account. No local API key or secret is required.

## Notes for reviewers

The source repo is public under the official job.rocks GitHub organization. Live OAuth authorization-server and protected-resource metadata endpoints were checked successfully before submission.