### PR TITLE
Add timeln plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "timeln",
+      "description": "Timeln AI memory layer. Save articles, notes, and URLs into your personal knowledge graph, then ask questions in natural language and get answers cited back to the sources. Also exposes the graph itself: centrality ranking, community detection, shortest paths between ideas, and hybrid semantic + keyword entity search.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Timelnapp/timeln-grok-plugin.git",
+        "sha": "b10a8d305907833c51ca14c61e56695a4fa901ff"
+      },
+      "homepage": "https://timeln.app",
+      "keywords": ["timeln", "timeln memory", "timeln knowledge graph", "timeln mcp"],
+      "domains": ["timeln.app", "app.timeln.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -993,6 +993,38 @@
         ]
       }
     },
+    "timeln": {
+      "sha": "b10a8d305907833c51ca14c61e56695a4fa901ff",
+      "version": "1.0.0",
+      "components": {
+        "commands": [
+          {
+            "name": "timeln-save",
+            "description": "Save the current finding, note, or URL into the user's Timeln knowledge graph"
+          },
+          {
+            "name": "timeln-setup",
+            "description": "Connect this plugin to a Timeln account and verify the API token works"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "timeln",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "timeln",
+            "description": "Read from and write to the user's Timeln knowledge graph — their personal AI memory of everything they have saved. Use…"
+          },
+          {
+            "name": "timeln-graph",
+            "description": "Analyze the structure of the user's Timeln knowledge graph rather than just its contents. Use for questions about shape…"
+          }
+        ]
+      }
+    },
     "tinyfish": {
       "sha": "89457fba3fa44c7b2227807948628011983ab668",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds Timeln — an AI memory layer backed by a personal knowledge graph. You save articles, notes and URLs to it; it extracts entities, links them into a graph, and answers questions with citations back to the sources. The plugin also exposes the graph structure itself (centrality, community detection, shortest paths between ideas, hybrid semantic + keyword entity search).

- Plugin name: `timeln`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Timelnapp/timeln-grok-plugin.git` @ `b10a8d305907833c51ca14c61e56695a4fa901ff`
- Homepage: https://timeln.app

Ships 2 skills (`timeln` for capture/recall, `timeln-graph` for graph analysis), 2 commands (`/timeln-setup`, `/timeln-save`), and 1 hosted MCP server over Streamable HTTP with 21 tools.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`Timelnapp`, the org behind timeln.app).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

The plugin contains no hooks, no install scripts, no bundled binaries and no executable code of any kind — it is Markdown skills, Markdown commands, one `.mcp.json`, and a logo.

**Network endpoints this plugin calls (and why):** exactly one — `https://mcp.timeln.app/mcp`, the hosted Timeln MCP server. Every tool call goes there; it proxies to the Timeln API using the user's own token. No other host is contacted.

**Credentials/permissions it requires (and why):** one environment variable, `TIMELN_API_TOKEN`, sent as an `Authorization: Bearer` header. It is a signed JWT the user mints themselves at https://app.timeln.app/settings/api-tokens, and it grants access only to that single Timeln account — there is no cross-account or admin scope. It is read from the environment at server startup, never written to disk by the plugin and never passed as a tool argument. Users can revoke it at any time, effective server-side immediately. 2 of the 21 tools write (`ingest_text`, `ingest_url`); the other 19 are read-only, and the `graph_cypher` escape hatch rejects mutating statements server-side and caps results at 1000 rows.

## Notes for reviewers

`Timelnapp` is the official org for timeln.app (see the org homepage). The MCP endpoint is on our own branded domain rather than a hosting-provider hostname.