### PR TITLE
Add ASO Skill plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -6,6 +6,19 @@
   },
   "plugins": [
     {
+      "name": "aso-skill",
+      "description": "Research current Apple App Store keywords, rankings, popularity, and competitor metadata through a secure hosted MCP connection.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ASO-Skill/aso-skill.git",
+        "sha": "c25656d1e2ae6a9ab5a5eb576372c2476748a037"
+      },
+      "homepage": "https://www.asoskill.com",
+      "keywords": ["aso skill", "asoskill", "asosuite"],
+      "domains": ["asoskill.com"]
+    },
+    {
       "name": "vercel",
       "description": "Vercel deployment platform integration. Manage deployments, check build status, access logs, configure domains, and control your frontend infrastructure directly from Grok.",
       "category": "deployment",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,23 @@
 {
   "version": 1,
   "plugins": {
+    "aso-skill": {
+      "sha": "c25656d1e2ae6a9ab5a5eb576372c2476748a037",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "aso-skill",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "aso-skill",
+            "description": "Query ASO Skill for current Apple App Store search rankings, keyword difficulty and popularity, app metadata, credit ba…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary

Adds ASO Skill as a remote third-party plugin sourced from the official public ASO Skill organization and pinned to an immutable commit.

ASO Skill provides a focused Agent Skill and hosted Streamable HTTP MCP connection for current Apple App Store rankings, keyword popularity, app metadata, and account credit information.

## Source

- repository: https://github.com/ASO-Skill/aso-skill
- pinned commit: `c25656d1e2ae6a9ab5a5eb576372c2476748a037`
- website: https://www.asoskill.com
- hosted MCP: https://api.asoskill.com/mcp
- authentication: OAuth; no credentials are embedded in the plugin
- license: MIT

## Validation

- `python3 scripts/generate-plugin-index.py`
- `python3 scripts/validate-catalog.py`
- `python3 scripts/generate-plugin-index.py --check`

The generated index detects the `aso-skill` skill and the `aso-skill` MCP server from the pinned public source.