### PR TITLE
Add neuruh-public-micro-plugins (remote, NeuruhAI official org)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "neuruh-public-micro-plugins",
+      "description": "Compile a bounded agent context packet, pick the cheapest capable execution route, and emit a public-safe proof card. Offline stdio MCP. No account, no API key.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/NeuruhAI/neuruh-sovereign-agent-starter.git",
+        "sha": "c40fcd4dd763a14ee9b3601a8315fef58a66a40a"
+      },
+      "homepage": "https://github.com/NeuruhAI/neuruh-sovereign-agent-starter",
+      "keywords": ["neuruh", "neuruh context pack", "neuruh proof card", "neuruh handoff"],
+      "domains": ["neuruh.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/NeuruhAI/neuruh-sovereign-agent-starter.git",
-        "sha": "c40fcd4dd763a14ee9b3601a8315fef58a66a40a"
+        "sha": "9a9a5329805f94ca5f8833f17873e87f076cb4f0"
       },
       "homepage": "https://github.com/NeuruhAI/neuruh-sovereign-agent-starter",
       "keywords": ["neuruh", "neuruh context pack", "neuruh proof card", "neuruh handoff"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,36 @@
         ]
       }
     },
+    "neuruh-public-micro-plugins": {
+      "sha": "c40fcd4dd763a14ee9b3601a8315fef58a66a40a",
+      "version": "0.1.7-alpha",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "neuruh-public-micro-plugins",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "neuruh-cheap-route",
+            "description": "Choose the highest net-value execution route above a capability floor. Use when comparing candidate routes, layers L0-L…"
+          },
+          {
+            "name": "neuruh-context-pack",
+            "description": "Compile a bounded pointer-heavy execution packet from known mission fields. Use when you need a compact execution conte…"
+          },
+          {
+            "name": "neuruh-handoff-pack",
+            "description": "Compile a bounded agent-to-agent continuation packet from previous and current public state. Use when handing a mission…"
+          },
+          {
+            "name": "neuruh-proof-card",
+            "description": "Project an internal-looking record through the public proof-card allowlist. Use when publishing a receipt, status card,…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "b9ddc83c32972210b8a94d389130713e8eed346e",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,8 +537,8 @@
       }
     },
     "neuruh-public-micro-plugins": {
-      "sha": "c40fcd4dd763a14ee9b3601a8315fef58a66a40a",
-      "version": "0.1.7-alpha",
+      "sha": "9a9a5329805f94ca5f8833f17873e87f076cb4f0",
+      "version": "0.1.9-alpha",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: neuruh-public-micro-plugins
- Type: remote source
- Source URL + pinned SHA: https://github.com/NeuruhAI/neuruh-sovereign-agent-starter.git `9a9a5329805f94ca5f8833f17873e87f076cb4f0`
- Homepage: https://github.com/NeuruhAI/neuruh-sovereign-agent-starter
- Plugin version at pin: `0.1.9-alpha` (MCP stdio newline-delimited framing)

Adds one remote catalog entry for Neuruh public micro-plugins (official org `NeuruhAI`). Offline stdio MCP. No account, no API key.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`NeuruhAI/neuruh-sovereign-agent-starter`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (Apache-2.0 on the source plugin).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (stdio MCP only; no hooks).
- Network endpoints this plugin calls (and why): none at runtime. Install-time pip may fetch public GitHub tags for public-commons libraries.
- Credentials/permissions it requires (and why): none.

## Notes for reviewers

- Plugin identity: `neuruh-public-micro-plugins` version `0.1.9-alpha`.
- MCP server: stdio `python3 -m neuruh_sovereign_agent_starter.mcp_server` (tools `context_pack`, `cheap_route`, `proof_card`).
- Skills: `neuruh-context-pack`, `neuruh-cheap-route`, `neuruh-proof-card`, `neuruh-handoff-pack`.
- xAI scanner paths: `.grok-plugin/plugin.json` + `.mcp.json`. Cursor Agent Plugin files (`plugin.json` / `mcp.json`) remain in the source repo and are not used by this catalog.
- Keywords are brand-scoped (`neuruh`, `neuruh context pack`, `neuruh proof card`, `neuruh handoff`). Domain: `neuruh.com`.
- Pin history: original candidate `c40fcd4` hung on newline-delimited MCP `initialize`; bumped to `9a9a532` so Grok Build handshake works. Do not revert to `c40fcd4`.
- Branch rebased/merged onto current marketplace main; no parallel duplicate entry.
