### PR TITLE
Add orgora plugin (SDK AI Hub)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "orgora",
+      "description": "Private org charts for sales, marketing, consultants, and managers. Map buying committees and client orgs on your Mac; Grok reads them locally and can build a chart from your inbox MCP. No Orgora account — charts stay on the device.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sdkorg-apps/orgora-plugin.git",
+        "sha": "a0e2c3497543b775008d1213d6179ae3f13bc061"
+      },
+      "homepage": "https://sdkaihub.com/orgora-charts/",
+      "keywords": ["orgora", "orgora charts", "sdkaihub"],
+      "domains": ["sdkaihub.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -528,6 +528,24 @@
         ]
       }
     },
+    "orgora": {
+      "sha": "a0e2c3497543b775008d1213d6179ae3f13bc061",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "orgora-charts",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "orgora",
+            "description": "Work with Orgora Charts on this Mac — private org charts for sales, marketing, consultants, and managers. Use when the…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "b9ddc83c32972210b8a94d389130713e8eed346e",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: orgora
- Type: remote source
- Source URL + pinned SHA: https://github.com/sdkorg-apps/orgora-plugin.git @ a0e2c3497543b775008d1213d6179ae3f13bc061
- Homepage: https://sdkaihub.com/orgora-charts/

Adds Orgora Charts to the public Grok Build marketplace. The plugin is for sales, marketing, consultants, and managers who map buying committees and client orgs on a Mac. Grok reads local Orgora charts over stdio and can populate a chart from a separate inbox MCP.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Official org: **sdkorg-apps** (SDK AI Hub / SDK Equipment LLC). Plugin repo is public: https://github.com/sdkorg-apps/orgora-plugin

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT on the plugin. The Mac app is a separate product.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): none. The MCP server is local stdio (`~/.orgora/orgora-mcp`), installed by the Orgora Charts Mac app (More → MCP connector → Enable). The plugin does not download a binary.
- Credentials/permissions it requires (and why): none. Mail is optional and uses a *separate* inbox MCP the user already enabled in Grok; Orgora never takes those passwords.

## Notes for reviewers

`grok plugin validate` on the source repo reports: 1 skill dir, MCP server `orgora-charts`. Keywords are brand-scoped (`orgora`, `orgora charts`, `sdkaihub`) so the CTA does not fire on generic sales/org-chart prompts. macOS only — Grok spawns a local helper.