### PR TITLE
Add github-talent-mcp plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,29 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "github-talent-mcp",
+      "description": "Search, score, and rank GitHub developers for technical recruiting. 9 tools: plan_search, search_developers, get_developer_profile, rank_candidates, score_against_jd, compare_candidates, bulk_score, generate_outreach, get_repo_contributors.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/carolinacherry/github-talent-mcp.git",
+        "sha": "51f6e90712b24447547518b2fa128feb50be1542"
+      },
+      "version": "0.5.0",
+      "author": {
+        "name": "Daniel An"
+      },
+      "homepage": "https://github.com/carolinacherry/github-talent-mcp",
+      "keywords": [
+        "talent-mcp",
+        "github-talent",
+        "github talent search",
+        "recruiting",
+        "developer sourcing",
+        "technical hiring"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,18 @@
         ]
       }
     },
+    "github-talent-mcp": {
+      "sha": "51f6e90712b24447547518b2fa128feb50be1542",
+      "version": "0.5.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "github-talent",
+            "description": "stdio"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds github-talent-mcp, a plugin for searching, scoring, and ranking GitHub developers for technical recruiting.

- Plugin name: github-talent-mcp
- Type: remote source
- Source URL + pinned SHA: https://github.com/carolinacherry/github-talent-mcp.git @ 51f6e90712b24447547518b2fa128feb50be1542
- Homepage: https://github.com/carolinacherry/github-talent-mcp

## Ownership

I am Daniel An. I own and maintain this plugin. GitHub login: carolinacherry. Source repo: https://github.com/carolinacherry/github-talent-mcp (public, Apache-2.0 license).

This is an independent recruiting tool that reads public GitHub developer data. It is NOT a GitHub Inc. or Microsoft product and is not affiliated with GitHub. The name "github-talent-mcp" describes the data source (public GitHub profiles), not official GitHub branding.

Publishing from a personal account is intentional. There is no org transfer planned. The author field is Daniel An; the homepage and source URL both point to the same public repository under carolinacherry, making first-party ownership verifiable.

What it ships: MCP-only (9 tools). Runtime: `uvx github-talent-mcp`. Credentials: user-supplied `GITHUB_TOKEN` (`read:user` + `public_repo`) for GitHub API rate limits. Network: GitHub API only. No telemetry, no postinstall, no arbitrary code fetch.

Local proof before submit: `grok plugin install carolinacherry/github-talent-mcp --trust` succeeded on macOS (grok 1.0.13). `grok plugin validate` passed. Direct MCP stdio against `uvx github-talent-mcp`: initialize ok (server github-talent 1.29.1), tools/list returns the 9 named tools, `get_developer_profile(torvalds)` returned a full profile (login torvalds, location Portland OR, followers 319831, isError false).

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not above).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): GitHub API (`api.github.com`) for reading public developer profiles, repositories, and contributor data
- Credentials/permissions it requires (and why): `GITHUB_TOKEN` with `read:user` and `public_repo` scopes for GitHub API rate limits (optional but recommended; unauthenticated is 60/hr)

## Notes for reviewers

This plugin is designed for technical recruiting workflows and provides read-only access to public GitHub data. The personal account source (`carolinacherry/github-talent-mcp`) is intentional — this is an independent tool maintained by Daniel An, not a company-backed product. All 9 MCP tools are scoped to read-only GitHub API operations for developer search and profile analysis.
