### PR TITLE
Add faceless plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "faceless",
+      "description": "Faceless.so AI faceless video integration (MCP Server + Skills). Create videos from a script or topic with TTS voiceover, AI visuals, captions and music, render them in the cloud, run automated series, and publish or schedule to YouTube, TikTok, Instagram, X, Facebook, LinkedIn and Threads.",
+      "category": "media",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Side-Products/faceless-claude-plugin.git",
+        "sha": "b2c8fb1e4654cf38ba2286c51669afe301db403f"
+      },
+      "homepage": "https://faceless.so/developers",
+      "keywords": ["faceless", "faceless.so", "faceless video", "faceless mcp"],
+      "domains": ["faceless.so"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -223,6 +223,24 @@
         ]
       }
     },
+    "faceless": {
+      "sha": "b2c8fb1e4654cf38ba2286c51669afe301db403f",
+      "version": "1.1.9",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "faceless",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "faceless",
+            "description": "Create, render and publish AI faceless videos with Faceless.so. Use when the user asks about creating faceless videos,…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3",
       "version": "2.2.96",


### PR DESCRIPTION
## What this PR does

New plugin.

- Plugin name: `faceless`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/Side-Products/faceless-claude-plugin.git @ `b2c8fb1e4654cf38ba2286c51669afe301db403f`
- Homepage: https://faceless.so/developers

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the plugin manifest and repo LICENSE).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://faceless.so/api/v1/*` only. The bundled MCP server is the published `faceless-mcp` npm package (stdio, `npx -y faceless-mcp`), a thin client over the public Faceless REST API. No hooks, no scripts.
- Credentials/permissions it requires (and why): a Faceless API key in `FACELESS_API_KEY` (created by the user at https://faceless.so/team), sent as `Authorization: Bearer` to faceless.so only. Keys carry per-scope permissions chosen by the user at creation time.

## Notes for reviewers

Side-Products is the company behind Faceless.so (https://faceless.so). The same plugin repo is generated from our public API registry and is what we submit to the Claude Code community marketplace; `.claude-plugin/plugin.json` is the manifest, `skills/faceless/` the skill, `.mcp.json` the MCP config. The MCP server source and CLI live in the main product repo and ship as `faceless-mcp` / `faceless-cli` on npm. Docs: https://faceless.so/developers, OpenAPI: https://faceless.so/api/v1/openapi.json.