### PR TITLE
Add Soon plugin (workforce scheduling, remote MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "soon",
+      "description": "Manage Soon work schedules from Grok. Read rosters and coverage, find who can cover a shift, create and publish draft shifts, handle leave, and resolve schedule change requests. Connects to Soon over OAuth and enforces your real team and board permissions.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/SoonHQ/soon-claude-plugin.git",
+        "sha": "ff4d46be6f70b60a9e2a2c9361e860f88fe68cd5",
+        "path": "plugins/soon"
+      },
+      "homepage": "https://soon.works",
+      "keywords": ["soon", "soon schedule", "soon shifts", "soon roster"],
+      "domains": ["soon.works", "app.soon.works"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -795,6 +795,32 @@
         ]
       }
     },
+    "soon": {
+      "sha": "ff4d46be6f70b60a9e2a2c9361e860f88fe68cd5",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "soon",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "intraday-design",
+            "description": "Use when the user wants to organize the activities (lunch, breaks, admin blocks, calls) that happen WITHIN each shift —…"
+          },
+          {
+            "name": "leave-management",
+            "description": "Use when the user asks about leave, time off, PTO, holidays, who's off, or wants to create, approve, reject, or cancel…"
+          },
+          {
+            "name": "schedule-overview",
+            "description": "Use when the user asks what the schedule looks like, who is working, how many people or hours are scheduled, where the…"
+          }
+        ]
+      }
+    },
     "stripe": {
       "sha": "9f39fa607a63582d8c5b62aaf6fa4898b9c7caac",
       "version": "0.6.2",


### PR DESCRIPTION
## What this PR does

Adds the Soon plugin. Soon is a workforce scheduling platform (shifts, rosters, coverage, leave). The plugin bundles a remote MCP server plus three skills, so Grok can read and manage a user's real Soon schedule.

- Plugin name: `soon`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/SoonHQ/soon-claude-plugin.git` @ `ff4d46be6f70b60a9e2a2c9361e860f88fe68cd5`, `path: plugins/soon`
- Homepage: https://soon.works

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`SoonHQ`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated — proprietary, in `LICENSE` at the source repo root. It explicitly permits installing and using the plugin to connect to a Soon account; redistribution and derivative works need written permission.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin ships no scripts, hooks, or binaries — it is a `.mcp.json`, a manifest, a README, and three `SKILL.md` files.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars. Nothing reads the filesystem or environment.
- [x] Hooks and MCP scope are least-privilege. No hooks at all. The MCP server is a single remote HTTP endpoint.

**Network endpoints this plugin calls (and why):** exactly one, `https://mcp.soon.works/mcp` — Soon's hosted MCP server, which is how the plugin reads and writes the user's schedule. No other host is contacted.

**Credentials/permissions it requires (and why):** none stored locally. The user authorizes over OAuth at connect time and the server enforces their existing Soon team, role, and board permissions. Tools are scoped (for example `schedule:read:all`, `shifts:write`, `roles:write`) and the connector deliberately exposes no admin, billing, or user-lifecycle tools, so it can plan schedules but cannot reconfigure a workspace. Writes that affect published shifts or other people go through an approval card.

## Notes for reviewers

One thing worth explaining up front: the source repo is named `soon-claude-plugin` because it was first published for the Claude Code ecosystem, and it uses `.claude-plugin/plugin.json`, which CONTRIBUTING lists as accepted. The plugin body itself is ecosystem-neutral: a remote MCP server plus skills, with nothing Claude-specific in it. Happy to publish under a neutral repo name if you'd prefer that for a Grok listing.

The `path: plugins/soon` pin is because that repo is itself a small marketplace, so the plugin lives one level down rather than at the root — same shape as the existing `browser-use` entry.
