### PR TITLE
Add CodeRifts plugin (API governance MCP server + skill)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Third-party OOXML schemas (ECMA-376 / ISO-IEC 29500 XSDs) vendored with the
+# docx/pptx default skills. Collapsed in diffs and excluded from language stats.
+default-skills/*/scripts/office/schemas/** linguist-vendored
+
+# Pre-built PPTX design templates and the generated taxonomy index. Bulk assets,
+# not meant for line-by-line review.
+default-skills/pptx/templates/** linguist-vendored
+default-skills/pptx/template_taxonomy.json linguist-generated

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+Adding or updating a plugin? Read CONTRIBUTING.md first.
+Run these locally before opening the PR — they're exactly what CI checks:
+  python3 scripts/generate-plugin-index.py
+  python3 scripts/validate-catalog.py
+  python3 scripts/generate-plugin-index.py --check
+-->
+
+## What this PR does
+
+<!-- New plugin? Plugin update? Which plugin and what changed? -->
+
+- Plugin name:
+- Type: <!-- remote source / local (external_plugins) -->
+- Source URL + pinned SHA (remote), or vendored path (local):
+- Homepage:
+
+## Ownership
+
+<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->
+
+- [ ] I own this plugin or have the right to distribute it.
+- [ ] The `source` repo is published under our official org (or I've explained why not below).
+
+## Checklist
+
+- [ ] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
+- [ ] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
+- [ ] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
+- [ ] `python3 scripts/validate-catalog.py` passes locally.
+- [ ] `python3 scripts/generate-plugin-index.py --check` passes locally.
+- [ ] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
+- [ ] License is stated.
+
+## Security
+
+<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->
+
+- [ ] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
+- [ ] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
+- [ ] Hooks and MCP scope are least-privilege.
+- Network endpoints this plugin calls (and why):
+- Credentials/permissions it requires (and why):
+
+## Notes for reviewers
+
+<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->

--- a/.github/workflows/bump-plugin-shas.yml
+++ b/.github/workflows/bump-plugin-shas.yml
@@ -1,0 +1,112 @@
+name: Bump plugin SHAs
+
+# Discover url-source pins whose upstream HEAD has moved *and* plugin.json
+# version changed (via shared plugin_catalog extract), regenerate the plugin
+# index at the new SHA, and open a stacked PR set:
+#
+#   main
+#     └── bump/daily-YYYY-MM-DD            (PR → main)
+#           ├── bump/YYYY-MM-DD/<plugin-a> (PR → daily)
+#           ├── bump/YYYY-MM-DD/<plugin-b> (PR → daily)
+#           └── ...
+#
+# All plugin PRs fan out from daily. Only the daily PR targets main, so main
+# history stays one landing per day. Manual review only; no auto-merge.
+#
+# If remote bump/daily-YYYY-MM-DD already exists, the run is a no-op unless
+# workflow_dispatch sets force=true (rebuild from main, force-push stack).
+#
+# Uses the default GITHUB_TOKEN (contents + pull-requests + actions write).
+# PRs opened with GITHUB_TOKEN do not trigger on:pull_request, so after each
+# bump branch we re-dispatch validate-catalog.yml so the required `validate`
+# check can go green on the daily → main PR (and on stack tips).
+#
+# Runs daily at 7am Pacific (15:00 UTC) and on workflow_dispatch.
+
+on:
+  schedule:
+    # 7am Pacific: 15:00 UTC (7am PST / 8am PDT). GitHub cron is UTC-only.
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: Bump only this plugin name (exact catalog name; empty = all stale)
+        required: false
+        default: ""
+      force:
+        description: Rebuild today's stack even if bump/daily-* already exists (force-push)
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: bump-plugin-shas
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    # IP-allowlisted org runners (hosted ubuntu-latest cannot push branches).
+    runs-on: ubuntu-latest-m
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Default GITHUB_TOKEN is enough to push bump/* and open PRs.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Discover stale pins and open stacked bump PRs
+        id: bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          # Pass inputs via env so shell never interpolates untrusted text.
+          ONLY_PLUGIN: ${{ inputs.plugin }}
+          FORCE_BUMP: ${{ inputs.force }}
+          # Avoid scripts/__pycache__ dirtying the worktree (import + index gen).
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: |
+          set -euo pipefail
+          extra=()
+          case "${FORCE_BUMP:-}" in
+            true|True|TRUE|1|yes|YES|on|ON) extra+=(--force) ;;
+          esac
+          python3 -B scripts/bump-plugin-shas.py \
+            --only "${ONLY_PLUGIN}" \
+            --base-branch "${BASE_BRANCH}" \
+            --github-output "$GITHUB_OUTPUT" \
+            "${extra[@]}"
+
+      - name: Dispatch validate-catalog on each stack branch
+        # Run even when the bump step exits 1 after partial success so opened
+        # GITHUB_TOKEN PRs still get the required validate check.
+        if: ${{ !cancelled() && steps.bump.outputs.pr-urls != '' && steps.bump.outputs.pr-urls != '[]' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URLS: ${{ steps.bump.outputs.pr-urls }}
+        run: |
+          set -euo pipefail
+          failures="$(mktemp)"
+          jq -c '.[] | select(.skipped != true)' <<<"$PR_URLS" | while read -r entry; do
+            branch=$(jq -r '.branch' <<<"$entry")
+            name=$(jq -r '.name' <<<"$entry")
+            echo "Dispatching validate-catalog.yml against $branch ($name)"
+            if ! gh workflow run validate-catalog.yml --ref "$branch"; then
+              echo "::error::Failed to dispatch validate-catalog.yml against $branch ($name)"
+              echo "$branch" >> "$failures"
+            fi
+          done
+          if [ -s "$failures" ]; then
+            echo "::error::$(wc -l < "$failures" | tr -d ' ') validate dispatch(es) failed"
+            exit 1
+          fi

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Bump-plugin-shas opens PRs with GITHUB_TOKEN, which does not trigger
+  # on:pull_request. That workflow re-dispatches this one against each
+  # bump/* branch so the required `validate` check can still run.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -12,11 +12,17 @@
       "source": {
         "source": "url",
         "url": "https://github.com/vercel/vercel-plugin.git",
-        "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63"
+        "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -24,12 +30,16 @@
       "category": "monitoring",
       "source": {
         "source": "url",
-        "url": "https://github.com/getsentry/sentry-for-ai.git",
-        "sha": "849303a8411c242d250885ffe714235a3bc2f5fe"
+        "url": "https://github.com/getsentry/plugin-grok.git",
+        "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -38,10 +48,14 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ChromeDevTools/chrome-devtools-mcp.git",
-        "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956"
+        "sha": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -63,23 +83,97 @@
       "source": {
         "source": "url",
         "url": "https://github.com/obra/superpowers.git",
-        "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc"
+        "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
+    },
+    {
+      "name": "base44",
+      "description": "Build and deploy Base44 full-stack apps with CLI project management and JavaScript/TypeScript SDK development skills.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/base44/skills.git",
+        "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
+      },
+      "homepage": "https://docs.base44.com",
+      "keywords": [
+        "base44",
+        "base44 cli",
+        "base44 sdk",
+        "base44 app",
+        "base44 deploy"
+      ],
+      "domains": [
+        "base44.com",
+        "docs.base44.com"
+      ]
     },
     {
       "name": "mongodb",
-      "description": "Official plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
+      "description": "Official plugin for MongoDB (Self-Managed MCP Server + Skills). Connect to any MongoDB deployment (Community, Enterprise Advanced, local dev container via Atlas CLI, or Atlas clusters) through a self-managed MongoDB MCP Server using your connection string. Explore data, manage collections, optimize queries, and generate reliable code with MongoDB best practices.",
       "category": "database",
       "source": {
         "source": "url",
         "url": "https://github.com/mongodb/agent-skills.git",
-        "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393"
+        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+        "path": "plugins/mongodb"
       },
-      "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
-      "keywords": ["mongodb", "mongo", "mongosh", "mongodb atlas", "mongoose"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+      "keywords": [
+        "mongodb community",
+        "mongo",
+        "mongosh",
+        "mongodb local mcp",
+        "enterprise advanced"
+      ],
+      "domains": [
+        "mongodb.com"
+      ]
+    },
+    {
+      "name": "mongodb-atlas",
+      "description": "Official plugin for MongoDB Atlas (Managed MCP Server + Skills). Sign in with your Atlas account to explore data, manage collections, optimize queries, generate reliable code with MongoDB best practices, and manage Atlas resources such as clusters, projects, database users, and network access.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mongodb/agent-skills.git",
+        "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+        "path": "plugins/mongodb-atlas"
+      },
+      "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
+      "keywords": [
+        "mongodb atlas",
+        "atlas",
+        "mongodb",
+        "atlas cluster",
+        "atlas mcp"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
+    },
+    {
+      "name": "axiom",
+      "description": "Official Axiom observability integration (MCP Server + Skills). Query logs and metrics with APL, run hypothesis-driven SRE investigations, build dashboards, manage monitors and alerts, translate Splunk SPL queries, and analyze and optimize costs.",
+      "category": "observability",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/axiomhq/skills.git",
+        "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
+      },
+      "homepage": "https://github.com/axiomhq/skills",
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -90,8 +184,250 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
+    },
+    {
+      "name": "wix",
+      "description": "Build, manage, and deploy Wix sites and apps (MCP Server + Skills). Includes CLI development skills and Wix MCP server for site management, eCommerce, CMS, dashboard extensions, and more.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/wix/skills.git",
+        "sha": "abff05613bf82101095a96b43b033150bfd8e145"
+      },
+      "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
+      "keywords": [
+        "wix",
+        "wix cli",
+        "wix mcp",
+        "wix apps",
+        "wix headless"
+      ],
+      "domains": [
+        "wix.com",
+        "dev.wix.com",
+        "manage.wix.com"
+      ]
+    },
+    {
+      "name": "netlify",
+      "description": "Skills for the Netlify platform: serverless and edge functions, Blobs storage, managed Postgres, Image CDN, forms, identity, caching, AI Gateway, framework adapters, and the Netlify CLI and deploys.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/netlify/context-and-tools.git",
+        "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
+      },
+      "homepage": "https://github.com/netlify/context-and-tools",
+      "keywords": [
+        "netlify",
+        "netlify deploy",
+        "deploy to netlify"
+      ],
+      "domains": [
+        "netlify.com",
+        "app.netlify.com"
+      ]
+    },
+    {
+      "name": "firecrawl",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/firecrawl/firecrawl-grok-plugin.git",
+        "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282"
+      },
+      "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
+    },
+    {
+      "name": "figma",
+      "description": "Official Figma MCP server and skills for design-to-code workflows. Read design context from Figma files, implement designs, use Code Connect, write to the canvas, and generate Figma designs from web pages.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/figma/mcp-server-guide.git",
+        "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3"
+      },
+      "homepage": "https://github.com/figma/mcp-server-guide",
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
+    },
+    {
+      "name": "exa",
+      "description": "Exa is the fastest and most accurate web search for AI. It searches the web in real time, reads relevant pages, and answers with up-to-date sources. Use it to find the latest code docs, news, company information, and much more. Use the exa-search skill for deep research, and sign up for Exa to get free credits.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/exa-labs/exa-grok-plugin.git",
+        "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
+      },
+      "homepage": "https://exa.ai",
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
+    },
+    {
+      "name": "tavily",
+      "description": "Web search, content extraction, website crawling, URL discovery, and deep research via Tavily's hosted MCP server and official skills. Connect with OAuth to access current, source-grounded web information directly from Grok Build.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tavily-ai/tavily-grok-plugin.git",
+        "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
+      },
+      "homepage": "https://www.tavily.com",
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
+    },
+    {
+      "name": "railway",
+      "description": "Railway deployment platform integration (MCP server + skill). Create projects, provision services and databases, deploy code, manage environments, variables, volumes, object storage buckets, and feature flags, configure domains, troubleshoot build failures, and check status and metrics directly from Grok.",
+      "category": "deployment",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/railwayapp/railway-skills.git",
+        "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
+        "path": "plugins/railway"
+      },
+      "homepage": "https://github.com/railwayapp/railway-skills",
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
+    },
+    {
+      "name": "stripe",
+      "description": "Stripe development plugin for Grok Build: best practices, API/SDK upgrade guidance, and the Stripe MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/stripe/ai.git",
+        "sha": "453dacd48aac27d751aa3cb7e410256efb3fcfca",
+        "path": "providers/grok/plugin"
+      },
+      "homepage": "https://github.com/stripe/ai",
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
+    },
+    {
+      "name": "tinyfish",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tinyfish-io/tinyfish-web-agent-integrations.git",
+        "sha": "89457fba3fa44c7b2227807948628011983ab668",
+        "path": "grok"
+      },
+      "homepage": "https://www.tinyfish.ai",
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
+    },
+    {
+      "name": "pstack",
+      "description": "pstack (poteto-mode): rigorous agent playbooks and principles for writing less, higher-quality code. Investigation, design, review, verification, and parallel subagent workflows.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/cursor/plugins.git",
+        "sha": "46125561306434d8a1d7745d540d8932ab0cd2a2",
+        "path": "pstack"
+      },
+      "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
+      "keywords": [
+        "pstack",
+        "poteto-mode",
+        "poteto"
+      ]
+    },
+    {
+      "name": "coderifts",
+      "description": "CodeRifts API governance for agents (MCP Server + Skill). Three tools: preflight_change_set returns an ALLOW/WARN/REQUIRE_APPROVAL/BLOCK decision plus execution_action for a base→head contract change set (OpenAPI, GraphQL, gRPC, AsyncAPI, MCP manifest, agent tool schemas) and can mint an Ed25519-signed chain receipt; verify_receipt checks a receipt you already hold, offline-verifiable, for authenticity and current authorization; get_decision_details retrieves a past decision by id. Use before a tool call, merge, deploy, or publish.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/coderifts"
+      },
+      "homepage": "https://coderifts.com",
+      "keywords": [
+        "coderifts",
+        "api governance",
+        "breaking change",
+        "openapi diff",
+        "contract safety",
+        "api contract",
+        "signed receipt",
+        "agent safety"
+      ],
+      "domains": [
+        "coderifts.com",
+        "app.coderifts.com"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,8 +1,79 @@
 {
   "version": 1,
   "plugins": {
+    "axiom": {
+      "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "axiom",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "axiom-alerting",
+            "description": "Create and manage Axiom monitors and notifiers via the v2 public API. Use when building alerting, routing notifications…"
+          },
+          {
+            "name": "axiom-sre",
+            "description": "Expert SRE investigator for incidents and debugging. Uses hypothesis-driven methodology and systematic triage. Can quer…"
+          },
+          {
+            "name": "building-dashboards",
+            "description": "Designs and builds Axiom dashboards via API. Covers chart types, APL and metrics/MPL query patterns, SmartFilters, layo…"
+          },
+          {
+            "name": "controlling-costs",
+            "description": "Analyzes Axiom query patterns to find unused data, then builds dashboards and monitors for cost optimization. Use when…"
+          },
+          {
+            "name": "query-metrics",
+            "description": "Runs metrics queries against Axiom MetricsDB via scripts. Discovers available metrics, tags, and tag values. Use when a…"
+          },
+          {
+            "name": "spl-to-apl",
+            "description": "Translates Splunk SPL queries to Axiom APL. Provides command mappings, function equivalents, and syntax transformations…"
+          },
+          {
+            "name": "writing-evals",
+            "description": "Scaffolds evaluation suites for the Axiom AI SDK. Generates eval files, scorers, flag schemas, and config from natural-…"
+          }
+        ]
+      }
+    },
+    "base44": {
+      "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
+      "version": "1.0.0-beta.1",
+      "components": {
+        "skills": [
+          {
+            "name": "base44-cli",
+            "description": "The base44 CLI is used for EVERYTHING related to base44 projects: resource configuration (entities, backend functions,…"
+          },
+          {
+            "name": "base44-remote-dev",
+            "description": "Develop a Base44 app remotely from your own coding agent (Claude Code, claude.ai, or any MCP client) by connecting it t…"
+          },
+          {
+            "name": "base44-sandbox",
+            "description": "Develop a Base44 app remotely inside Base44's cloud sandbox using your own agent — no local checkout and no deploy/push…"
+          },
+          {
+            "name": "base44-sdk",
+            "description": "The base44 SDK is the library to communicate with base44 services. In projects, you use it to communicate with remote r…"
+          },
+          {
+            "name": "base44-troubleshooter",
+            "description": "Troubleshoot production issues using backend function logs. Use when investigating app errors, debugging function calls…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
-      "sha": "a1612be8e01401cf1711c64bc2ef5da5763ba956",
+      "sha": "073d4a39e9c96b17936d3cdc4bdea69977f0cca6",
+      "version": "1.7.0",
       "components": {
         "mcpServers": [
           {
@@ -40,6 +111,7 @@
     },
     "cloudflare": {
       "sha": "60147cbb773649eadca89cee92b4e0caf02234b4",
+      "version": "1.0.0",
       "components": {
         "commands": [
           {
@@ -109,8 +181,171 @@
         ]
       }
     },
+    "coderifts": {
+      "components": {
+        "mcpServers": [
+          {
+            "name": "coderifts",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "api-governance",
+            "description": "Before merging or shipping any API or tool-contract change: preflight the change set, then branch on execution_action."
+          }
+        ]
+      }
+    },
+    "exa": {
+      "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
+      "version": "1.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "tutorial",
+            "description": "Interactive tutorial for Exa web search in Grok Build"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "exa",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "exa-search",
+            "description": "Deep research powered by Exa. Use for lead generation, literature reviews, deep dives, competitive analysis, or any que…"
+          }
+        ]
+      }
+    },
+    "figma": {
+      "sha": "7f6562c4900fafb46e5e8fd3cc8ced954779bab3",
+      "version": "2.2.96",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "figma",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "figma-code-connect",
+            "description": "Creates and maintains Figma Code Connect template files that map Figma components to code snippets. Use when the user m…"
+          },
+          {
+            "name": "figma-create-new-file",
+            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `create_new_file` tool call. NEVER call `create_ne…"
+          },
+          {
+            "name": "figma-design-to-code",
+            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE calling the `get_design_context` Figma MCP tool. You MUS…"
+          },
+          {
+            "name": "figma-generate-design",
+            "description": "Use this skill alongside figma-use when the task involves translating an application page, view, or multi-section layou…"
+          },
+          {
+            "name": "figma-generate-diagram",
+            "description": "MANDATORY prerequisite — load this skill BEFORE every `generate_diagram` tool call. NEVER call `generate_diagram` direc…"
+          },
+          {
+            "name": "figma-generate-library",
+            "description": "Build or update a professional-grade design system in Figma from a codebase. Use when the user wants to create variable…"
+          },
+          {
+            "name": "figma-implement-motion",
+            "description": "Translates Figma motion and animations into production-ready application code. Use when implementing animation/motion f…"
+          },
+          {
+            "name": "figma-swiftui",
+            "description": "SwiftUI ↔ Figma translation. Use whenever the user mentions Swift, SwiftUI, iOS, iPhone, or iPad — in EITHER direction…"
+          },
+          {
+            "name": "figma-use",
+            "description": "**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call. NEVER call `use_figma` dire…"
+          },
+          {
+            "name": "figma-use-figjam",
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the FigJam context. Can be used alongside figma-use which has…"
+          },
+          {
+            "name": "figma-use-motion",
+            "description": "Motion / animation context for the `use_figma` MCP tool — animating Figma nodes via manual keyframes, animation styles,…"
+          },
+          {
+            "name": "figma-use-slides",
+            "description": "This skill helps agents use Figma's use_figma MCP tool in the Slides context. Can be used alongside figma-use which has…"
+          }
+        ]
+      }
+    },
+    "firecrawl": {
+      "sha": "af6c6c083ccfd74ae476761068ee4311a56e8282",
+      "version": "1.1.0",
+      "components": {
+        "commands": [
+          {
+            "name": "skill-gen",
+            "description": "Generate a complete Agent Skill from a documentation URL using Firecrawl"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "firecrawl",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "firecrawl",
+            "description": "Search, scrape, and interact with the web via the Firecrawl CLI. Use this skill whenever the user wants to search the w…"
+          },
+          {
+            "name": "firecrawl-agent",
+            "description": "AI-powered autonomous data extraction that navigates complex sites and returns structured JSON. Use this skill when the…"
+          },
+          {
+            "name": "firecrawl-crawl",
+            "description": "Bulk extract content from an entire website or site section. Use this skill when the user wants to crawl a site, extrac…"
+          },
+          {
+            "name": "firecrawl-download",
+            "description": "Download an entire website as local files — markdown, screenshots, or multiple formats per page. Use this skill when th…"
+          },
+          {
+            "name": "firecrawl-interact",
+            "description": "Control and interact with a live browser session on any scraped page — click buttons, fill forms, navigate flows, and e…"
+          },
+          {
+            "name": "firecrawl-map",
+            "description": "Discover and list all URLs on a website, with optional search filtering. Use this skill when the user wants to find a s…"
+          },
+          {
+            "name": "firecrawl-monitor",
+            "description": "Detect when content on a website changes and get notified by webhook or email — no cron jobs, scrapers, or diff scripts…"
+          },
+          {
+            "name": "firecrawl-parse",
+            "description": "Efficiently extract and convert the contents of any local file—such as PDF, DOCX, DOC, ODT, RTF, XLSX, XLS, or HTML—int…"
+          },
+          {
+            "name": "firecrawl-scrape",
+            "description": "Extract clean markdown from any URL, including JavaScript-rendered SPAs. Use this skill whenever the user provides a UR…"
+          },
+          {
+            "name": "firecrawl-search",
+            "description": "Web search with full page content extraction. Use this skill whenever the user asks to search the web, find articles, r…"
+          }
+        ]
+      }
+    },
     "mongodb": {
-      "sha": "9ea7387c7a1638604542c6efd52e5efc6a7fc393",
+      "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+      "version": "1.2.0",
       "components": {
         "mcpServers": [
           {
@@ -150,7 +385,46 @@
         ]
       }
     },
+    "mongodb-atlas": {
+      "sha": "b4ea8150a020b9babaddc6c271c6dc177c06a83f",
+      "version": "1.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mongodb-atlas",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mongodb-atlas-stream-processing",
+            "description": "Manages MongoDB Atlas Stream Processing (ASP) workflows. Handles workspace provisioning, data source/sink connections,…"
+          },
+          {
+            "name": "mongodb-connection",
+            "description": "Optimize MongoDB client connection configuration (pools, timeouts, patterns) for any supported driver language. Use thi…"
+          },
+          {
+            "name": "mongodb-natural-language-querying",
+            "description": "Generate read-only MongoDB queries (find) or aggregation pipelines using natural language, with collection schema conte…"
+          },
+          {
+            "name": "mongodb-query-optimizer",
+            "description": "Help with MongoDB query optimization and indexing. Use only when the user asks for optimization or performance: \"How do…"
+          },
+          {
+            "name": "mongodb-schema-design",
+            "description": "MongoDB schema design patterns and anti-patterns. Use when designing data models, reviewing schemas, migrating from SQL…"
+          },
+          {
+            "name": "mongodb-search-and-ai",
+            "description": "Guides MongoDB users through implementing and optimizing Atlas Search (full-text), Vector Search (semantic), and Hybrid…"
+          }
+        ]
+      }
+    },
     "neon": {
+      "version": "1.0.0",
       "components": {
         "mcpServers": [
           {
@@ -174,15 +448,301 @@
         ]
       }
     },
-    "sentry": {
-      "sha": "849303a8411c242d250885ffe714235a3bc2f5fe",
+    "netlify": {
+      "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c",
+      "version": "1.3.0",
       "components": {
-        "commands": [
+        "mcpServers": [
           {
-            "name": "seer",
-            "description": "Ask natural language questions about your Sentry environment and get detailed insights using the Sentry MCP server"
+            "name": "netlify",
+            "description": "http"
           }
         ],
+        "skills": [
+          {
+            "name": "netlify-access-control",
+            "description": "Picks the right Netlify protection layer for a deployed site and disambiguates the three unrelated things people call \"…"
+          },
+          {
+            "name": "netlify-agent-runner",
+            "description": "Run AI agent tasks remotely on Netlify using Claude, Codex, or Gemini. Use when the user wants to run an AI agent on th…"
+          },
+          {
+            "name": "netlify-ai-gateway",
+            "description": "Use OpenAI, Anthropic, Google Gemini, or OpenRouter models from Netlify Functions or Edge Functions without managing pr…"
+          },
+          {
+            "name": "netlify-blobs",
+            "description": "Store and retrieve unstructured objects, file uploads, and cache-like state on Netlify using the @netlify/blobs key/val…"
+          },
+          {
+            "name": "netlify-caching",
+            "description": "Cache dynamic and static responses on Netlify's CDN from Functions, Edge Functions, and proxies. Use when you add cachi…"
+          },
+          {
+            "name": "netlify-config",
+            "description": "Configure Netlify projects via netlify.toml and the _headers/_redirects files — covering build settings and deploy cont…"
+          },
+          {
+            "name": "netlify-database",
+            "description": "Zero-config Postgres for Netlify apps via @netlify/database — querying data from Functions/Edge Functions, writing sche…"
+          },
+          {
+            "name": "netlify-deploy",
+            "description": "Create and manage Netlify deploys — Git continuous deployment, CLI manual/anonymous deploys, Deploy to Netlify buttons,…"
+          },
+          {
+            "name": "netlify-edge-functions",
+            "description": "Write, configure, and deploy Netlify Edge Functions (Deno runtime at the network edge) in TypeScript/JavaScript. Use wh…"
+          },
+          {
+            "name": "netlify-forms",
+            "description": "Serverless form handling on Netlify-hosted sites — detects HTML forms at deploy time, stores submissions, filters spam,…"
+          },
+          {
+            "name": "netlify-frameworks",
+            "description": "Deploy and configure web frameworks on Netlify — build settings and SSR/edge adapters plus local platform emulation and…"
+          },
+          {
+            "name": "netlify-functions",
+            "description": "Write, configure, and deploy Netlify serverless functions in TypeScript, JavaScript, or Go. Use this when adding an API…"
+          },
+          {
+            "name": "netlify-identity",
+            "description": "Add authentication and user management to a Netlify site with @netlify/identity — signup/login/logout, OAuth social log…"
+          },
+          {
+            "name": "netlify-image-cdn",
+            "description": "Transform, resize, crop, reformat, and optimize images on demand via Netlify Image CDN's /.netlify/images endpoint. Use…"
+          },
+          {
+            "name": "netlify-mcp-servers",
+            "description": "Build, deploy, and secure Model Context Protocol (MCP) servers on Netlify. Use whenever the task involves creating an M…"
+          }
+        ]
+      }
+    },
+    "pstack": {
+      "sha": "46125561306434d8a1d7745d540d8932ab0cd2a2",
+      "components": {
+        "agents": [
+          {
+            "name": "Comment Sicko",
+            "description": "A deranged comment-hater that savors deletion and condemns workaround code."
+          },
+          {
+            "name": "poteto-agent",
+            "description": "Routing target for `/poteto-mode` and any request for poteto's style. Resume an existing `poteto-agent` for the convers…"
+          }
+        ],
+        "skills": [
+          {
+            "name": "Poteto Mode",
+            "description": "poteto's agent style for concise, detailed responses, deliberate subagents, unslopped prose, simple code, and verified…"
+          },
+          {
+            "name": "architect",
+            "description": "Sketch types, signatures, and module structure before code, then stay in the loop while implementation fills in. Use fo…"
+          },
+          {
+            "name": "arena",
+            "description": "Spawn N parallel candidates at the same task, pick a base, graft the strongest parts of the losers into it. Use for /ar…"
+          },
+          {
+            "name": "automate-me",
+            "description": "Use for \\\"automate me\\\", \\\"create/update/refresh my -mode skill\\\", \\\"turn/capture my preferences or working style into…"
+          },
+          {
+            "name": "blast-radius",
+            "description": "Find what a change could break somewhere else before it ships, beyond the diff, and prove the one fact it's safe becaus…"
+          },
+          {
+            "name": "bro",
+            "description": "Restate the last message in plain human language, with no jargon."
+          },
+          {
+            "name": "create-verification-skill",
+            "description": "Generate a project-local verification skill that drives your app the way a user does — any language, framework, or plat…"
+          },
+          {
+            "name": "figure-it-out",
+            "description": "Design an auditable playbook when no narrower one fits: a large migration, an ambitious multi-part change, or work a hu…"
+          },
+          {
+            "name": "how",
+            "description": "Use for \\\"how does X work\\\", code walkthroughs before changing something, and placement / ownership / layering question…"
+          },
+          {
+            "name": "interrogate",
+            "description": "Use for \\\"interrogate\\\", \\\"adversarial review\\\", \\\"multi-model review\\\", \\\"challenge this\\\", \\\"stress test this code\\\",…"
+          },
+          {
+            "name": "maintain-verification-skill",
+            "description": "Periodic pass that keeps a project's verification skill and feature map honest: parallel source readers per feature, on…"
+          },
+          {
+            "name": "no-comments",
+            "description": "Spawn Comment Sicko, fix accepted findings, and offer encodings for claimed constraints."
+          },
+          {
+            "name": "principle-boundary-discipline",
+            "description": "Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, conf…"
+          },
+          {
+            "name": "principle-build-the-lever",
+            "description": "Apply to any non-trivial work, not just bulk work: edits, migrations, analyses, checks. Build the tool that does it or…"
+          },
+          {
+            "name": "principle-encode-lessons-in-structure",
+            "description": "Apply when you catch yourself writing the same instruction a second time, or notice a recurring correction. Encode the…"
+          },
+          {
+            "name": "principle-exhaust-the-design-space",
+            "description": "Apply when facing a novel UI interaction or architectural decision with no precedent in the codebase. Build 2-3 competi…"
+          },
+          {
+            "name": "principle-experience-first",
+            "description": "Apply when product, UX, or feature-scope tradeoffs come up. Choose user delight over implementation convenience; ship f…"
+          },
+          {
+            "name": "principle-fix-root-causes",
+            "description": "Apply when debugging. Trace each symptom to its root cause and fix it there; reproduce first, ask why until you reach i…"
+          },
+          {
+            "name": "principle-foundational-thinking",
+            "description": "Apply before writing logic: choosing core types and data structures, sequencing scaffold-vs-feature work, asking what c…"
+          },
+          {
+            "name": "principle-guard-the-context-window",
+            "description": "Apply when context is filling up: large outputs, long files, repeated reads, fan-out planning. Route bulk to subagents;…"
+          },
+          {
+            "name": "principle-laziness-protocol",
+            "description": "Apply when refactoring, evaluating diff size, or tempted to add abstractions, layers, or signal threading. Bias toward…"
+          },
+          {
+            "name": "principle-make-operations-idempotent",
+            "description": "Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Conve…"
+          },
+          {
+            "name": "principle-migrate-callers-then-delete-legacy-apis",
+            "description": "Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the…"
+          },
+          {
+            "name": "principle-minimize-reader-load",
+            "description": "Apply when reviewing or shaping code that's hard to trace. Count layers between question and answer, and hidden state i…"
+          },
+          {
+            "name": "principle-model-the-domain",
+            "description": "Apply when writing stateful logic, or when code branches a lot or repeats a shape assumption across files. Encode the d…"
+          },
+          {
+            "name": "principle-never-block-on-the-human",
+            "description": "Apply when tempted to ask 'should I do X?' on reversible work. Proceed, present the result, let the human course-correc…"
+          },
+          {
+            "name": "principle-outcome-oriented-execution",
+            "description": "Apply during planned rewrites and migrations with explicit phase boundaries. Converge on the target architecture; don't…"
+          },
+          {
+            "name": "principle-prove-it-works",
+            "description": "Apply after completing a task, before declaring done. Verify against the real artifact (run the feature, read the actua…"
+          },
+          {
+            "name": "principle-redesign-from-first-principles",
+            "description": "Apply when integrating a new requirement into an existing design. Redesign as if the requirement had been a foundationa…"
+          },
+          {
+            "name": "principle-separate-before-serializing-shared-state",
+            "description": "Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; s…"
+          },
+          {
+            "name": "principle-sequence-verifiable-units",
+            "description": "Apply to multi-step work (sweeps, migrations, runs of similar edits) and to how you stack commits and PRs. Break work i…"
+          },
+          {
+            "name": "principle-subtract-before-you-add",
+            "description": "Apply when sequencing an addition, refactor, or rewrite. Remove dead weight, redundant validators, and stub references…"
+          },
+          {
+            "name": "principle-type-system-discipline",
+            "description": "Apply when designing types, reviewing a function signature, or writing code in any statically-typed language. Make ille…"
+          },
+          {
+            "name": "recall",
+            "description": "Reconstruct your recent working context from your own chat history, live state, and the shared record (user reports, pr…"
+          },
+          {
+            "name": "reflect",
+            "description": "Spawn three parallel review subagents over the active transcript, surface learnings, and route each to a concrete edit…"
+          },
+          {
+            "name": "setup-pstack",
+            "description": "Configure which models pstack uses per role. Detects your available models and writes an always-applied rule that overr…"
+          },
+          {
+            "name": "show-me-your-work",
+            "description": "Keep a reviewable decision trail for long-running or unattended work: a TSV log with one row per decision (what, why, e…"
+          },
+          {
+            "name": "swarm",
+            "description": "Fan out N parallel workers, drain them, and return one report. Use for /swarm, 'swarm this', or parallel coverage, race…"
+          },
+          {
+            "name": "tdd",
+            "description": "Use only when the user explicitly asks for TDD, a failing test, or a regression test, OR when the bug has an obvious ch…"
+          },
+          {
+            "name": "teach",
+            "description": "Explain a body of work plainly so a person actually understands it. Runs the `how` and `why` skills and weaves what the…"
+          },
+          {
+            "name": "technical-writing",
+            "description": "Layered technical-writing standard: Diátaxis structure, Google developer style sentences, STE instruction rules, Global…"
+          },
+          {
+            "name": "typescript-best-practices",
+            "description": "TypeScript best practices. Use when reading or editing any .ts or .tsx file."
+          },
+          {
+            "name": "unslop",
+            "description": "Cut AI tells from any writing. Must always apply."
+          },
+          {
+            "name": "why",
+            "description": "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thres…"
+          }
+        ]
+      }
+    },
+    "railway": {
+      "sha": "5d1e97178f86c82795d6737928bd641e0552166a",
+      "version": "1.3.7",
+      "components": {
+        "hooks": [
+          {
+            "name": "PreToolUse",
+            "description": "Bash"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "railway",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "use-railway",
+            "description": "Operate Railway infrastructure: sign up for or sign in to a Railway account, create projects, provision services and da…"
+          }
+        ]
+      }
+    },
+    "sentry": {
+      "sha": "7f9d7823a68a7668867786a573ef587ef2783f7d",
+      "version": "1.3.2",
+      "components": {
         "mcpServers": [
           {
             "name": "sentry",
@@ -191,130 +751,105 @@
         ],
         "skills": [
           {
-            "name": "sentry-android-sdk",
-            "description": "Full Sentry SDK setup for Android. Use when asked to \"add Sentry to Android\", \"install sentry-android\", \"setup Sentry i…"
-          },
-          {
-            "name": "sentry-browser-sdk",
-            "description": "Full Sentry SDK setup for browser JavaScript. Use when asked to \"add Sentry to a website\", \"install @sentry/browser\", o…"
-          },
-          {
-            "name": "sentry-cloudflare-sdk",
-            "description": "Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to \"add Sentry to Cloudflare Workers\", \"install…"
-          },
-          {
-            "name": "sentry-cocoa-sdk",
-            "description": "Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS). Use when asked to \"add Sentry to iOS\",…"
-          },
-          {
-            "name": "sentry-code-review",
-            "description": "Analyze and resolve Sentry comments on GitHub Pull Requests. Use this when asked to review or fix issues identified by…"
-          },
-          {
             "name": "sentry-create-alert",
             "description": "Create Sentry alerts using the workflow engine API. Use when asked to create alerts, set up notifications, configure is…"
           },
           {
-            "name": "sentry-dotnet-sdk",
-            "description": "Full Sentry SDK setup for .NET. Use when asked to \"add Sentry to .NET\", \"install Sentry for C#\", or configure error mon…"
+            "name": "sentry-debug-issue",
+            "description": "Debug and fix a Sentry issue — find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, lo…"
           },
           {
-            "name": "sentry-elixir-sdk",
-            "description": "Full Sentry SDK setup for Elixir. Use when asked to \"add Sentry to Elixir\", \"install sentry for Elixir\", or configure e…"
+            "name": "sentry-fix-stack-traces",
+            "description": "Make Sentry stack traces readable — upload source maps for JavaScript/TypeScript, or debug files for native and mobile…"
           },
           {
-            "name": "sentry-feature-setup",
-            "description": "Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry…"
+            "name": "sentry-get-started",
+            "description": "Guided entry point for using Sentry through your agent. Orients you to your current setup and, for a new project, sets…"
           },
           {
-            "name": "sentry-fix-issues",
-            "description": "Find and fix issues from Sentry using MCP. Use when asked to fix Sentry errors, debug production issues, investigate ex…"
-          },
-          {
-            "name": "sentry-flutter-sdk",
-            "description": "Full Sentry SDK setup for Flutter and Dart. Use when asked to \"add Sentry to Flutter\", \"install sentry_flutter\", \"setup…"
-          },
-          {
-            "name": "sentry-go-sdk",
-            "description": "Full Sentry SDK setup for Go. Use when asked to \"add Sentry to Go\", \"install sentry-go\", \"setup Sentry in Go\", or confi…"
-          },
-          {
-            "name": "sentry-nestjs-sdk",
-            "description": "Full Sentry SDK setup for NestJS. Use when asked to \"add Sentry to NestJS\", \"install @sentry/nestjs\", \"setup Sentry in…"
-          },
-          {
-            "name": "sentry-nextjs-sdk",
-            "description": "Full Sentry SDK setup for Next.js. Use when asked to \"add Sentry to Next.js\", \"install @sentry/nextjs\", or configure er…"
-          },
-          {
-            "name": "sentry-node-sdk",
-            "description": "Full Sentry SDK setup for Node.js, Bun, and Deno. Use when asked to \"add Sentry to Node.js\", \"add Sentry to Bun\", \"add…"
+            "name": "sentry-instrument",
+            "description": "Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any…"
           },
           {
             "name": "sentry-otel-exporter-setup",
             "description": "Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Us…"
           },
           {
-            "name": "sentry-php-sdk",
-            "description": "Full Sentry SDK setup for PHP. Use when asked to \"add Sentry to PHP\", \"install sentry/sentry\", \"setup Sentry in PHP\", o…"
+            "name": "sentry-setup-releases",
+            "description": "Set up Sentry releases and deploy tracking — tag events with a version and environment, create the release in CI with i…"
           },
           {
-            "name": "sentry-pr-code-review",
-            "description": "Review a project's PRs to check for issues detected in code review by Seer Bug Prediction. Use when asked to review or…"
+            "name": "sentry-snapshots-cocoa",
+            "description": "Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to \"setup SnapshotPreviews\", \"setup Apple snapshot…"
+          }
+        ]
+      }
+    },
+    "stripe": {
+      "sha": "453dacd48aac27d751aa3cb7e410256efb3fcfca",
+      "version": "0.5.4",
+      "components": {
+        "agents": [
+          {
+            "name": "company-researcher",
+            "description": "Research a company from its URL or description to infer Stripe Connect integration shape"
+          }
+        ],
+        "commands": [
+          {
+            "name": "explain-error",
+            "description": "Explain Stripe error codes and provide solutions with code examples"
           },
           {
-            "name": "sentry-python-sdk",
-            "description": "Full Sentry SDK setup for Python. Use when asked to \"add Sentry to Python\", \"install sentry-sdk\", \"setup Sentry in Pyth…"
+            "name": "test-cards",
+            "description": "Display Stripe test card numbers for various testing scenarios"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "stripe",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "connect-recommend",
+            "description": "Use this skill when the user asks about Stripe Connect configuration, charge patterns, Dashboard access, or how to get…"
           },
           {
-            "name": "sentry-react-native-sdk",
-            "description": "Full Sentry SDK setup for React Native and Expo. Use when asked to \"add Sentry to React Native\", \"install @sentry/react…"
+            "name": "connect-required-verification-information",
+            "description": "Use this skill when the user asks what information a Stripe Connect connected account must provide for verification, on…"
           },
           {
-            "name": "sentry-react-router-framework-sdk",
-            "description": "Full Sentry SDK setup for React Router Framework mode. Use when asked to \"add Sentry to React Router Framework\", \"insta…"
+            "name": "stripe-apps",
+            "description": "Use when building, modifying, or reviewing a Stripe App — or when the user describes something that implies one (e.g. \"…"
           },
           {
-            "name": "sentry-react-sdk",
-            "description": "Full Sentry SDK setup for React. Use when asked to \"add Sentry to React\", \"install @sentry/react\", or configure error m…"
+            "name": "stripe-best-practices",
+            "description": "Guides Stripe integration decisions across API selection (Checkout Sessions vs PaymentIntents), Connect platform setup…"
           },
           {
-            "name": "sentry-ruby-sdk",
-            "description": "Full Sentry SDK setup for Ruby. Use when asked to add Sentry to Ruby, install sentry-ruby, setup Sentry in Rails/Sinatr…"
+            "name": "stripe-directory",
+            "description": "Finds trusted external providers, merchants, nonprofits, platforms, APIs, and software services that can help complete…"
           },
           {
-            "name": "sentry-sdk-setup",
-            "description": "Set up Sentry in any language or framework. Detects the user's platform and loads the right SDK skill. Use when asked t…"
+            "name": "stripe-docs",
+            "description": "Use when the user or agent needs to read, search, or look up Stripe documentation or API reference. Prefer this over cu…"
           },
           {
-            "name": "sentry-sdk-skill-creator",
-            "description": "Create a complete Sentry SDK skill bundle for any platform. Use when asked to \"create an SDK skill\", \"add a new platfor…"
+            "name": "stripe-projects",
+            "description": "Use when the user wants to provision infrastructure or third-party services using Stripe Projects. Triggers: \"I need a…"
           },
           {
-            "name": "sentry-sdk-upgrade",
-            "description": "Upgrade the Sentry JavaScript SDK across major versions. Use when asked to upgrade Sentry, migrate to a newer version,…"
-          },
-          {
-            "name": "sentry-setup-ai-monitoring",
-            "description": "Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversati…"
-          },
-          {
-            "name": "sentry-svelte-sdk",
-            "description": "Full Sentry SDK setup for Svelte and SvelteKit. Use when asked to \"add Sentry to Svelte\", \"add Sentry to SvelteKit\", \"i…"
-          },
-          {
-            "name": "sentry-tanstack-start-sdk",
-            "description": "Full Sentry SDK setup for TanStack Start React. Use when asked to \"add Sentry to TanStack Start\", \"install @sentry/tans…"
-          },
-          {
-            "name": "sentry-workflow",
-            "description": "Fix production issues and review code with Sentry context. Use when asked to fix Sentry errors, debug issues, triage ex…"
+            "name": "upgrade-stripe",
+            "description": "Guide for upgrading Stripe API versions and SDKs"
           }
         ]
       }
     },
     "superpowers": {
-      "sha": "6fd4507659784c351abbd2bc264c7162cfd386dc",
+      "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
+      "version": "6.3.0",
       "components": {
         "hooks": [
           {
@@ -337,7 +872,7 @@
           },
           {
             "name": "finishing-a-development-branch",
-            "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completi…"
+            "description": "Use when implementation is complete, all tests pass, and you need to decide how to integrate the work"
           },
           {
             "name": "receiving-code-review",
@@ -365,7 +900,7 @@
           },
           {
             "name": "using-superpowers",
-            "description": "Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY…"
+            "description": "Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY resp…"
           },
           {
             "name": "verification-before-completion",
@@ -382,8 +917,89 @@
         ]
       }
     },
+    "tavily": {
+      "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "tavily",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "academic-scientific-research",
+            "description": "Find, screen, and synthesize academic papers, scientific literature, technical reports, preprints, clinical or biomedic…"
+          },
+          {
+            "name": "investment-research-briefs",
+            "description": "Create concise investment research briefs, company memos, sector snapshots, portfolio monitoring updates, earnings/news…"
+          },
+          {
+            "name": "product-competitor-intelligence",
+            "description": "Research competitor products, SKUs, pricing, packaging, positioning, feature comparisons, product catalogs, category pa…"
+          },
+          {
+            "name": "sales-account-intelligence",
+            "description": "Build sales-ready account intelligence for companies, prospects, customers, partners, and target buyers. Use when the u…"
+          },
+          {
+            "name": "tavily-best-practices",
+            "description": "Build production-ready Tavily integrations with best practices baked in. Reference documentation for developers using c…"
+          },
+          {
+            "name": "tavily-web",
+            "description": "Search and research the web with Tavily. Use for current information, source discovery, webpage extraction, site mappin…"
+          },
+          {
+            "name": "threat-intelligence-enrichment",
+            "description": "Enrich threat intelligence from CVEs, IOCs, malware names, threat actors, vendor advisories, security incidents, exploi…"
+          },
+          {
+            "name": "vendor-risk-kyc-screening",
+            "description": "Screen vendors, merchants, suppliers, counterparties, companies, executives, and related entities for vendor risk, KYC,…"
+          }
+        ]
+      }
+    },
+    "tinyfish": {
+      "sha": "89457fba3fa44c7b2227807948628011983ab668",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "tinyfish",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "tinyfish-authenticated",
+            "description": "Automate websites the user is logged into, using TinyFish Browser Context Profiles and Vault credentials. Use when a ta…"
+          },
+          {
+            "name": "tinyfish-automation",
+            "description": "Goal-driven browser automation with TinyFish. Use when a task needs a real browser to act on a site — clicking, filling…"
+          },
+          {
+            "name": "tinyfish-browser",
+            "description": "Create a remote stealth Chrome session with TinyFish and control it over CDP. Use when the task needs programmatic brow…"
+          },
+          {
+            "name": "tinyfish-research",
+            "description": "Web research powered by TinyFish search and fetch. Use for any question needing current web information, and for deep r…"
+          },
+          {
+            "name": "tinyfish-web",
+            "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
+          }
+        ]
+      }
+    },
     "vercel": {
-      "sha": "61f1903bed7b322c9745f6ba67095bc006de7e63",
+      "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6",
+      "version": "0.48.1",
       "components": {
         "agents": [
           {
@@ -417,10 +1033,6 @@
             "description": "Manage Vercel environment variables. Commands include list, pull, add, remove, and diff. Use to sync environment variab…"
           },
           {
-            "name": "marketplace",
-            "description": "Discover and install Vercel Marketplace integrations. Use to find databases, CMS, auth providers, and other services av…"
-          },
-          {
             "name": "status",
             "description": "Show the status of the current Vercel project — recent deployments, linked project info, and environment overview."
           }
@@ -442,6 +1054,10 @@
         ],
         "skills": [
           {
+            "name": "access-protected-vercel-deployment",
+            "description": "Access and test Vercel deployments protected by Vercel Authentication, SSO, or Deployment Protection. Use when curl, ag…"
+          },
+          {
             "name": "ai-gateway",
             "description": "Vercel AI Gateway expert guidance. Use when configuring model routing, provider failover, cost tracking, or managing mu…"
           },
@@ -458,8 +1074,20 @@
             "description": "Project bootstrapping orchestrator for repos that depend on Vercel-linked resources (databases, auth, and managed integ…"
           },
           {
+            "name": "build-agents",
+            "description": "Default guidance for building AI agents. Use for generic requests to build, create, scaffold, design, architect, or imp…"
+          },
+          {
+            "name": "cdn-caching",
+            "description": "Debug Vercel CDN caching — cache hit rate, stale content, revalidation behavior, ISR + PPR, per-request cache reasons (…"
+          },
+          {
             "name": "chat-sdk",
             "description": "Vercel Chat SDK expert guidance. Use when building multi-platform chat bots — Slack, Telegram, Microsoft Teams, Discord…"
+          },
+          {
+            "name": "create-a-backend",
+            "description": "Backend architecture guidance. Use when planning, building, or migrating an API or backend; choosing between Functions,…"
           },
           {
             "name": "deployments-cicd",
@@ -470,12 +1098,20 @@
             "description": "Vercel environment variable expert guidance. Use when working with .env files, vercel env commands, OIDC tokens, or man…"
           },
           {
+            "name": "eve",
+            "description": "eve framework guidance for durable AI agents and agent-powered applications. Use when creating, editing, or debugging a…"
+          },
+          {
             "name": "knowledge-update",
             "description": "Corrects outdated LLM knowledge about the Vercel platform and introduces new products. Injected at session start."
           },
           {
             "name": "marketplace",
-            "description": "Vercel Marketplace expert guidance — discovering, installing, and building integrations, auto-provisioned environment v…"
+            "description": "Vercel Marketplace expert guidance — discovering, installing, and managing third-party integrations via the `vercel int…"
+          },
+          {
+            "name": "microfrontends",
+            "description": "Guide for building, configuring, and deploying microfrontends on Vercel. Use this skill when the user mentions microfro…"
           },
           {
             "name": "next-cache-components",
@@ -522,6 +1158,10 @@
             "description": "Vercel CLI expert guidance. Use when deploying, managing environment variables, linking projects, viewing logs, queryin…"
           },
           {
+            "name": "vercel-connect",
+            "description": "Vercel Connect expert guidance — securely obtain scoped OAuth tokens for third-party services (Slack, GitHub, MCP serve…"
+          },
+          {
             "name": "vercel-firewall",
             "description": "Vercel Firewall expert guidance — automatic DDoS mitigation, the Vercel WAF (custom rules, IP blocking, managed ruleset…"
           },
@@ -534,6 +1174,10 @@
             "description": "Vercel Sandbox guidance — ephemeral Firecracker microVMs for running untrusted code safely. Supports AI agents, code ge…"
           },
           {
+            "name": "vercel-services",
+            "description": "Configure and troubleshoot Vercel Services for multiple frontends and backends in one project. Use when composing a pol…"
+          },
+          {
             "name": "vercel-storage",
             "description": "Vercel storage expert guidance — Blob, Edge Config, and Marketplace storage (Neon Postgres, Upstash Redis). Use when ch…"
           },
@@ -543,7 +1187,57 @@
           },
           {
             "name": "workflow",
-            "description": "Vercel Workflow DevKit (WDK) expert guidance. Use when building durable workflows, long-running tasks, API routes or ag…"
+            "description": "Vercel Workflow SDK expert guidance. Use when building durable workflows, long-running tasks, API routes or agents that…"
+          }
+        ]
+      }
+    },
+    "wix": {
+      "sha": "abff05613bf82101095a96b43b033150bfd8e145",
+      "version": "1.16.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wix-mcp",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "replatform",
+            "description": "Routes RePlatform source-to-Wix migrations to the next workflow step by inspecting migration project artifacts. Use whe…"
+          },
+          {
+            "name": "wix-app",
+            "description": "Build and review Wix CLI app extensions — dashboard pages, modals, plugins, menu plugins, custom element widgets, Edito…"
+          },
+          {
+            "name": "wix-auth",
+            "description": "Authenticate with Wix to obtain an access token for calling Wix APIs. Use when an agent needs a valid Wix access token…"
+          },
+          {
+            "name": "wix-base44-connector",
+            "description": "Build on Wix from the Base44 builder sandbox — this file is the complete guide (site context, doc discovery, API contra…"
+          },
+          {
+            "name": "wix-design-system",
+            "description": "Wix Design System component reference. Use when building UI with @wix/design-system, choosing components, checking prop…"
+          },
+          {
+            "name": "wix-docs",
+            "description": "Look up the Wix API/SDK documentation to confirm an exact endpoint, HTTP method, request/response shape, field, enum, o…"
+          },
+          {
+            "name": "wix-headless",
+            "description": "Connect Wix business services (Stores, Bookings, CMS, Blog, Events, Forms, and more) to a Wix Headless frontend — infer…"
+          },
+          {
+            "name": "wix-manage",
+            "description": "Wix business solution management recipes — REST API operations for configuring and managing Wix business solutions. Rou…"
+          },
+          {
+            "name": "wix-vibe-headless",
+            "description": "Client-only, dependency-free REST scaffolds for connecting an already-built front end (a vibe-coded app, an HTML/JSX/Vi…"
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing a plugin
+
+Thanks for submitting to the xAI plugin marketplace. This repo is an **index**: a PR doesn't ship a
+product, it adds one entry to `.grok-plugin/marketplace.json` that points Grok Build at your
+plugin's source. This guide covers how to submit, what we check, and the mistakes that most often
+send a PR back.
+
+For the catalog schema, source types, and SHA pinning mechanics, read the [README](README.md) first
+— this guide assumes it and focuses on the *process and tips*.
+
+## Before you start
+
+- **Only submit a plugin you own or have the right to distribute.** Each plugin is governed by its
+  own license. xAI does not author or verify third-party plugins (see the disclaimer in the
+  [README](README.md)).
+- **Plugins execute code on a user's machine.** That's exactly why review is strict — see
+  [Security expectations](#security-expectations).
+
+## Submit in 6 steps
+
+1. **Fork** this repo and branch from `main`.
+2. **Add your catalog entry** to `.grok-plugin/marketplace.json`:
+   - **Remote source (recommended for third-party):** point `source.url` at your public repo and
+     pin a full commit `sha`. Nothing else is vendored here.
+   - **Local source:** vendor your files under `external_plugins/<name>/` (third-party) and set
+     `source` to `{ "type": "local", "path": "./external_plugins/<name>" }`.
+3. **Pin the SHA** (remote only) — get it with:
+   ```bash
+   git ls-remote https://github.com/<your-org>/<your-repo>.git HEAD
+   ```
+4. **Regenerate the component index** (never hand-edit it):
+   ```bash
+   python3 scripts/generate-plugin-index.py
+   ```
+5. **Validate locally** — this is exactly what CI runs:
+   ```bash
+   python3 scripts/validate-catalog.py
+   python3 scripts/generate-plugin-index.py --check
+   ```
+6. **Open the PR.** Fill in the template, then wait for CI + code-owner review.
+
+## Requirements checklist
+
+- [ ] One entry added to `.grok-plugin/marketplace.json`, valid JSON, `name` in kebab-case and unique.
+- [ ] Remote sources pin a full 40-char lowercase commit `sha`; the commit is public and reachable.
+- [ ] `.grok-plugin/plugin-index.json` regenerated and committed (CI fails if stale).
+- [ ] A `homepage` and a clear `description`; brand-scoped `keywords`/`domains` (not generic terms — they power the plugin CTA) and a `category` where it helps discovery.
+- [ ] Local plugins include a `README.md` and a valid `.grok-plugin/plugin.json` manifest (`.claude-plugin/plugin.json` is also accepted for Claude-ecosystem plugins).
+- [ ] The plugin is licensed and the license is stated.
+- [ ] You've read [Security expectations](#security-expectations) and your plugin complies.
+
+## Tips for a clean submission
+
+- **Source from your official org, not a personal account.** A branded plugin (`acme`) sourced from
+  `some-personal-account/acme-thing` reads as a possible impersonation and *will* be questioned.
+  Publishing the source under your real org (`acme/...`) makes first-party ownership verifiable at a
+  glance and is the single biggest thing that speeds up review.
+- **Keep the pinned commit reachable.** Index generation and CI fetch your pinned `sha`; if the repo
+  is private, the commit is force-pushed away, or the repo is deleted, the build fails loudly.
+- **Pin a real commit, not a branch or tag.** `main`, `v1.2.3`, and abbreviated SHAs are rejected by
+  the validator. A moving ref would let a later force-push ship new code to everyone silently.
+- **Scope your plugin to least privilege.** Only request the MCP tools, hooks, and filesystem/network
+  access you actually need.
+- **Keep `keywords` and `domains` brand-scoped.** They power Grok Build's plugin **CTA** — the
+  prompt that proactively suggests your plugin — so generic terms like `postgres`, `database`,
+  `api`, `cli`, or `deploy` get pushed back: they'd mis-fire the CTA on unrelated requests. Use
+  specific, product-scoped terms (e.g. `neon`, `neon postgres`, `neon branch`) and only the
+  `domains` your product actually owns.
+- **To update a live plugin,** bump the `sha` (remote) or commit the changed files (local) and
+  regenerate the index — don't open a parallel duplicate entry.
+
+## Security expectations
+
+Submissions are statically reviewed for supply-chain and execution risk. Plugins that do any of the
+following will be rejected or sent back:
+
+- **Arbitrary code execution / RCE:** `curl | bash`, downloading and running binaries, `eval` of
+  remote content, or `postinstall` scripts that fetch and execute code.
+- **Secret or data exfiltration:** reading `~/.ssh`, `.env`, tokens, or env vars and sending them to
+  a network endpoint; undisclosed telemetry.
+- **Over-broad hooks / MCP scope:** lifecycle hooks that run shell on `Bash`/`Write` with no matcher,
+  or a shell-exec MCP server when a scoped tool would do.
+- **Obfuscation:** base64/hex payload blobs, minified bundles with no source, or typosquatted deps.
+- **Prompt injection** planted in `SKILL.md` or descriptions aimed at the installing agent.
+
+Declare any network endpoints your plugin calls and the credentials it needs, in your README — it
+makes review faster and builds trust.
+
+## What review checks
+
+Every PR gets a pass on these dimensions, so it helps to self-check them first:
+
+| Dimension | What we look for |
+|---|---|
+| Source legitimacy | Official org vs personal/throwaway account; repo exists; SHA pinned; brand matches source |
+| Security | Static audit of MCP configs, hooks, scripts, and skills (see above) |
+| Components | What the plugin actually ships (skills/commands/agents/hooks/MCP servers) |
+| Duplication | Not already in the catalog; not a parallel entry for an existing plugin |
+| Conventions & CI | `validate-catalog.py` + `generate-plugin-index.py --check` pass; valid JSON; naming; README/homepage |
+
+## Common reasons a PR gets sent back
+
+- **Unpinned or invalid `sha`** on a remote source (or a tag/branch instead of a commit).
+- **Source repo is private or the pinned commit isn't reachable** → CI can't fetch it.
+- **Stale `plugin-index.json`** — you edited the catalog but didn't rerun `generate-plugin-index.py`.
+- **Malformed `marketplace.json`** — a botched merge that leaves invalid JSON breaks the whole catalog;
+  always run `validate-catalog.py` after resolving conflicts.
+- **Personal-account source for a branded plugin** — move it under your official org.
+- **Missing `homepage`/`README`** or a vague one-line description.
+
+## Questions
+
+Open an issue, or leave a comment on your PR. We aim to do a first review pass quickly — a clean,
+self-checked submission (CI green, index regenerated, official source) is the fastest path to merge.

--- a/external_plugins/coderifts/.mcp.json
+++ b/external_plugins/coderifts/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "coderifts": {
+      "type": "http",
+      "url": "https://app.coderifts.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CODERIFTS_API_KEY}"
+      }
+    }
+  }
+}

--- a/external_plugins/coderifts/skills/api-governance/SKILL.md
+++ b/external_plugins/coderifts/skills/api-governance/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: api-governance
+description: Before merging or shipping any API or tool-contract change: preflight the change set, then branch on execution_action.
+---
+
+# CodeRifts API Governance
+
+<!-- GENERATED from CodeRifts agent-host-rule (single source). Do not edit rule sentences by hand; run: node scripts/generate-agent-host-files.js -->
+
+Call `preflight_change_set` before merge, deploy, publish, or tool registration when a contract artifact changed (OpenAPI/Swagger, GraphQL, gRPC/protobuf, AsyncAPI, MCP manifest, or agent tool schemas).
+
+Send the complete base-to-head change set: every changed contract artifact with full before and after content. Do not send a single-file subset when other contract files also change.
+
+Branch on `execution_action` only. Do not branch on `decision` and do not branch on `safe_for_agent` (not_for_control_flow_use_execution_action). Canonical `execution_action` values: CONTINUE, CONTINUE_WITH_MONITORING, REQUEST_APPROVAL, STOP.
+
+An unrecognised `execution_action` is not permission: fail closed (halt or re-preflight). Well-known code: `not_permission_fail_closed`.
+
+When `execution_action` is REQUEST_APPROVAL or STOP, surface the detected patterns and the blast radius, and propose the safer path — deprecate-then-remove, an additive change, or a new version — rather than shipping the break.
+
+`CONTINUE_WITH_MONITORING` requires a wired monitoring sink (`monitoringSinkWired`). It is not "proceed with caution" without monitoring.
+
+Do not call CodeRifts tools for a documentation-only change (README, guides, comments) with no contract artifact content change.
+
+If you already hold a chain receipt and only need authenticity/lifecycle: `verify_receipt`. If you need a past decision by id: `get_decision_details`. Neither replaces preflight for a new change set.
+
+The CodeRifts MCP server exposes exactly three tools — `preflight_change_set`, `verify_receipt`, `get_decision_details`. Do not invent or assume others.
+
+A receipt authorizes ONE operation: a merge receipt does not authorize a deploy. Before a different operation (deploy, publish), call `preflight_change_set` with `context.operation` set to that operation — reusing a differently-scoped receipt is not permitted and will fail at the gate.
+
+A stale or superseded receipt on a changed head requires a NEW preflight — `verify_receipt` cannot re-diff.
+
+For mutating tools, put only the guarded version in the agent's tool table; keep the raw handler host-only and unreachable from that table. How you name tools is yours — this is a reachability property, not a product rename of host tools. CodeRifts cannot see or stop a raw call the host makes outside the table it returns; adopt this as a host convention, not as a guarantee from the package.
+
+CodeRifts reports a governance decision and `execution_action`; it does not by itself block merges. Blocking requires separate repository configuration (required status checks, enforcement) that this rule file does not set.
+
+To act (mutate a contract, merge, deploy, or publish): call `preflight_change_set` with `preflight_mode` authorize. Analyze is informational (`may_execute` is always false) and is not permission. Read `execution_action` on the `decision_result` envelope.
+
+Before acting under a held receipt: call `verify_receipt` with the intended `context` (operation, environment, repository, branch, pull_request) for THIS attempt. Do not act on a receipt whose scope does not match.
+
+Act only when `currently_authorized` is true (`control_envelope.receipt_view.currently_authorized`). A valid-looking token is not permission if `currently_authorized` is false or omitted.
+
+Commit / CAS evidence is a separate measurement (`commit_observation` on GuardOutcome). It is not a substitute for authorize + `currently_authorized`. Production hosts that want the fail-closed conjunction lock it with `profile: ENFORCING_STRICT` on withCodeRifts.
+
+If the host requests an execution grant (opt-in `include_execution_grant`), the grant is bound to operation + target + after-payload (`scope_hash`) and is short-lived — never reuse it after the after-payload changes.
+
+An ATOMIC-profile grant carries `state_nonce` and is single-use at the executor — if the executor has consumed the nonce, re-preflight; do not retry the same grant.
+
+With a proven tenant↔repo binding you may request `derivation:"server"` instead of assembling `artifacts[]` yourself (`context.repository` + `context.base` + `context.head` required; caller-supplied artifacts are rejected on that path).
+
+A commit is only proven when an executor attestation verifies (customer-held executor key, `cas_evidence: executor_attested`); otherwise say "authorized, commit not proven".

--- a/scripts/bump-plugin-shas.py
+++ b/scripts/bump-plugin-shas.py
@@ -1,0 +1,839 @@
+#!/usr/bin/env python3
+"""Discover version-bumped url-source pins and open a stacked set of PRs.
+
+Pin advances when HEAD moved and the version gate passes
+(plugin_catalog extract, same path as generate-plugin-index):
+
+  - both have version, and they differ → bump to HEAD
+  - both lack version → bump to HEAD (SHA is the identity)
+  - same version → skip (commits moved, release did not)
+  - pin has version, HEAD does not → skip (do not un-version)
+  - pin lacks version, HEAD has one → bump (first version appears)
+
+Stack shape (one run / Pacific day):
+
+  main
+    └── bump/daily-YYYY-MM-DD            PR → main
+          ├── bump/YYYY-MM-DD/<plugin-a> PR → daily
+          ├── bump/YYYY-MM-DD/<plugin-b> PR → daily
+          └── ...
+
+Default: if remote `bump/daily-YYYY-MM-DD` already exists, the run is a
+no-op. Pass `--force` to rebuild that day's stack from current main.
+
+Designed for GitHub Actions with GITHUB_TOKEN (contents + pull-requests write).
+Local: `--dry-run` (no push/PR).
+
+Usage:
+  python3 scripts/bump-plugin-shas.py [--dry-run] [--force] [--only NAME]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+import plugin_catalog
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover
+    ZoneInfo = None  # type: ignore[misc, assignment]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CATALOG_PATH = Path(".grok-plugin/marketplace.json")
+INDEX_PATH = Path(".grok-plugin/plugin-index.json")
+INDEX_SCRIPT = Path("scripts/generate-plugin-index.py")
+SHA_RE = plugin_catalog.SHA_RE
+ALLOWED_HOSTS = {"github.com", "gitlab.com", "bitbucket.org"}
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    capture: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    result = subprocess.run(
+        cmd,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+        capture_output=capture,
+        text=True,
+        env=merged,
+    )
+    if check and result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        stdout = (result.stdout or "").strip()
+        detail = stderr or stdout or f"exit {result.returncode}"
+        raise RuntimeError(f"`{' '.join(cmd)}` failed: {detail}")
+    return result
+
+
+def pacific_date() -> str:
+    if ZoneInfo is not None:
+        return datetime.now(ZoneInfo("America/Los_Angeles")).strftime("%Y-%m-%d")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def load_catalog() -> dict:
+    return json.loads((REPO_ROOT / CATALOG_PATH).read_text(encoding="utf-8"))
+
+
+def url_entries(catalog: dict) -> list[dict]:
+    out = []
+    for entry in catalog.get("plugins", []):
+        if not isinstance(entry, dict):
+            continue
+        source = entry.get("source")
+        if not isinstance(source, dict):
+            continue
+        if source.get("source") != "url" and source.get("type") != "url":
+            continue
+        out.append(entry)
+    return out
+
+
+def host_allowed(url: str) -> bool:
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host in ALLOWED_HOSTS
+
+
+def ls_remote_head(url: str) -> str:
+    result = run(["git", "ls-remote", url, "HEAD"], check=True)
+    lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
+    if not lines:
+        raise RuntimeError(f"empty ls-remote for {url}")
+    sha = lines[0].split()[0].strip().lower()
+    if not SHA_RE.match(sha):
+        raise RuntimeError(f"unexpected ls-remote output for {url}: {lines[0]!r}")
+    return sha
+
+
+def remote_branch_exists(branch: str) -> bool:
+    """True if origin has refs/heads/<branch>. Fails hard on git errors."""
+    result = run(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"],
+        check=True,
+    )
+    return bool((result.stdout or "").strip())
+
+
+def open_pr_for_branch(branch: str) -> str | None:
+    """Return open PR URL for head branch, or None if none.
+
+    Raises on `gh` failure so we never treat API errors as "no PR".
+    """
+    result = run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "url",
+            "--jq",
+            ".[0].url // empty",
+        ],
+        check=True,
+    )
+    url = (result.stdout or "").strip()
+    return url or None
+
+
+def replace_sha_in_catalog(name: str, old_sha: str, new_sha: str) -> None:
+    path = REPO_ROOT / CATALOG_PATH
+    text = path.read_text(encoding="utf-8")
+    name_json = json.dumps(name)
+    pattern = re.compile(
+        rf'("name"\s*:\s*{re.escape(name_json)}[\s\S]*?"sha"\s*:\s*")'
+        rf"{re.escape(old_sha)}"
+        rf'(")',
+        re.MULTILINE,
+    )
+    new_text, n = pattern.subn(rf"\g<1>{new_sha}\2", text, count=1)
+    if n != 1:
+        needle = f'"sha": "{old_sha}"'
+        if text.count(needle) != 1:
+            raise RuntimeError(
+                f"could not uniquely locate sha for plugin {name!r} "
+                f"(old={old_sha})"
+            )
+        new_text = text.replace(needle, f'"sha": "{new_sha}"', 1)
+    path.write_text(new_text, encoding="utf-8")
+
+
+def regenerate_index() -> None:
+    env = {"PYTHONDONTWRITEBYTECODE": "1"}
+    run(
+        [sys.executable, "-B", str(REPO_ROOT / INDEX_SCRIPT)],
+        check=True,
+        capture=False,
+        env=env,
+    )
+
+
+def git_identity() -> None:
+    run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+    run(
+        [
+            "git",
+            "config",
+            "user.email",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        ],
+        check=True,
+    )
+
+
+def _is_ignorable_dirty_path(path: str) -> bool:
+    # Importing scripts/*.py can create bytecode; never treat that as dirty.
+    if path.endswith(".DS_Store"):
+        return True
+    parts = path.replace("\\", "/").split("/")
+    if "__pycache__" in parts:
+        return True
+    if parts and parts[-1].endswith((".pyc", ".pyo")):
+        return True
+    return False
+
+
+def ensure_clean_worktree() -> None:
+    result = run(["git", "status", "--porcelain"], check=True)
+    dirty = []
+    for line in (result.stdout or "").splitlines():
+        if not line.strip():
+            continue
+        # porcelain: XY PATH or XY ORIG -> PATH
+        path = line[3:].strip() if len(line) > 3 else line.strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if _is_ignorable_dirty_path(path):
+            continue
+        dirty.append(line)
+    if dirty:
+        raise RuntimeError(
+            "working tree is dirty; commit or stash before bumping:\n"
+            + "\n".join(dirty)
+        )
+
+
+def origin_base(base_branch: str) -> str:
+    run(["git", "fetch", "origin", base_branch], check=True)
+    result = run(["git", "rev-parse", f"origin/{base_branch}"], check=True)
+    return (result.stdout or "").strip()
+
+
+def reset_to_origin_base(base_branch: str) -> str:
+    """Fetch and hard-reset to origin/<base> so discovery matches the bump base."""
+    tip = origin_base(base_branch)
+    run(["git", "checkout", "--detach", tip], check=True)
+    run(["git", "reset", "--hard", tip], check=True)
+    run(["git", "clean", "-fd", "-e", ".DS_Store"], check=False)
+    print(f"reset to origin/{base_branch} ({tip[:12]})")
+    return tip
+
+
+def hard_reset_to(sha: str) -> None:
+    """Detach at sha with a clean tree (isolates failures across plugins)."""
+    run(["git", "checkout", "--detach", sha], check=True)
+    run(["git", "reset", "--hard", sha], check=True)
+    run(["git", "clean", "-fd"], check=True)
+
+
+def ensure_pr(
+    *,
+    head: str,
+    base: str,
+    title: str,
+    body: str,
+    dry_run: bool,
+) -> str | None:
+    if dry_run:
+        print(f"[dry-run] would open PR {head} -> {base}: {title}")
+        return None
+
+    existing = open_pr_for_branch(head)
+    if existing:
+        print(f"PR already open for {head}: {existing}")
+        return existing
+
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            base,
+            "--head",
+            head,
+            "--title",
+            title,
+            "--body",
+            body,
+        ],
+        check=True,
+    )
+    pr_url = (result.stdout or "").strip()
+    print(f"Opened {pr_url}")
+    return pr_url
+
+
+def push_branch(branch: str, *, force: bool) -> None:
+    cmd = ["git", "push"]
+    if force:
+        cmd.append("--force")
+    cmd.extend(["origin", f"HEAD:refs/heads/{branch}"])
+    run(cmd, check=True)
+
+
+def write_github_output(path: str, pr_urls: list[dict], bumped_count: int) -> None:
+    payload = json.dumps(pr_urls, separators=(",", ":"))
+    print(f"pr-urls={payload}")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(f"pr-urls={payload}\n")
+            fh.write(f"bumped_count={bumped_count}\n")
+
+
+def open_daily_base(
+    *,
+    daily_branch: str,
+    main_branch: str,
+    day: str,
+    run_url: str,
+    force: bool,
+    dry_run: bool,
+) -> tuple[str | None, str]:
+    """Create or rebuild daily branch from main; PR it into main.
+
+    Returns (pr_url, daily_tip_sha). dry-run returns (None, fake sha).
+    """
+    title = f"chore(plugins): daily pin bumps {day}"
+    body_lines = [
+        f"Daily base for plugin pin bumps on **{day}** (Pacific).",
+        "",
+        "Per-plugin PRs all target this branch (fan-out from daily). Review",
+        "and merge the ones you want into this branch, then land this PR into",
+        "`main` so history stays one landing per day.",
+        "",
+        "No auto-merge.",
+    ]
+    if force:
+        body_lines.extend(["", "Rebuilt with `--force` from current main."])
+    if run_url:
+        body_lines.extend(["", f"Triggered by: {run_url}"])
+    body = "\n".join(body_lines) + "\n"
+
+    if dry_run:
+        action = "rebuild (force)" if force else "create"
+        print(f"[dry-run] would {action} daily base {daily_branch} -> {main_branch}")
+        return None, "0" * 40
+
+    head = origin_base(main_branch)
+    git_identity()
+    hard_reset_to(head)
+    run(["git", "checkout", "-B", daily_branch], check=True)
+    # Marker commit so the daily -> main PR can open (GitHub rejects empty diffs).
+    run(
+        [
+            "git",
+            "commit",
+            "--allow-empty",
+            "-m",
+            f"chore(plugins): daily pin bumps {day}",
+        ],
+        check=True,
+    )
+    tip = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+    # First create: non-force push. Rebuild: force-push over the existing tip.
+    push_branch(daily_branch, force=force)
+    pr_url = ensure_pr(
+        head=daily_branch,
+        base=main_branch,
+        title=title,
+        body=body,
+        dry_run=False,
+    )
+    return pr_url, tip
+
+
+def apply_plugin_bump(
+    *,
+    name: str,
+    old_sha: str,
+    new_sha: str,
+    old_version: str,
+    new_version: str,
+    url: str,
+    branch: str,
+    daily_branch: str,
+    daily_sha: str,
+    run_url: str,
+    force: bool,
+    dry_run: bool,
+) -> str | None:
+    """Branch from daily tip, commit one plugin bump, open PR -> daily."""
+    short_old = old_sha[:7]
+    short_new = new_sha[:7]
+    ver_old = old_version or "(none)"
+    ver_new = new_version or "(none)"
+    if old_version or new_version:
+        title = (
+            f"chore(plugins): bump {name} {ver_old} -> {ver_new} "
+            f"({short_old} -> {short_new})"
+        )
+        version_line = f"- **version:** `{ver_old}` -> `{ver_new}`"
+        why = (
+            "Catalog SHA updated after an upstream version change (or first "
+            "version appearing). When a version is set, everyone on that "
+            "version shares the same pin."
+        )
+    else:
+        title = f"chore(plugins): bump {name} {short_old} -> {short_new}"
+        version_line = "- **version:** (none at pin or HEAD; pin tracks SHA)"
+        why = (
+            "Catalog SHA updated. Upstream has no plugin.json version on either "
+            "pin or HEAD, so the pin is the release identity."
+        )
+    body_lines = [
+        f"Automated pin bump for `{name}`.",
+        "",
+        f"- **source:** {url}",
+        version_line,
+        f"- **old sha:** `{old_sha}`",
+        f"- **new sha:** `{new_sha}` (HEAD when the bump was observed)",
+        f"- **base:** `{daily_branch}`",
+        "",
+        "Catalog SHA updated and `.grok-plugin/plugin-index.json` regenerated "
+        f"at the new pin. {why}",
+        "",
+        "Targets the daily base, not `main`. Merge into the daily branch "
+        "(or close to drop this bump), then land the daily PR.",
+        "",
+        "Human review still required (no auto-merge).",
+    ]
+    if run_url:
+        body_lines.extend(["", f"Triggered by: {run_url}"])
+    body = "\n".join(body_lines) + "\n"
+
+    if dry_run:
+        print(
+            f"[dry-run] would open PR {branch} -> {daily_branch}: {title} "
+            f"(from daily {daily_sha[:7]}, force={force})"
+        )
+        return None
+
+    git_identity()
+    # Clean cut from daily tip so a prior plugin failure cannot leak dirty files.
+    hard_reset_to(daily_sha)
+    run(["git", "checkout", "-B", branch], check=True)
+
+    try:
+        replace_sha_in_catalog(name, old_sha, new_sha)
+        regenerate_index()
+
+        run(["git", "add", "--", str(CATALOG_PATH), str(INDEX_PATH)], check=True)
+        status = run(["git", "status", "--porcelain"], check=True)
+        if not (status.stdout or "").strip():
+            raise RuntimeError(f"no file changes after bumping {name}")
+
+        run(["git", "commit", "-m", title], check=True)
+        # force=True when rebuilding the day; otherwise create-only push.
+        # If the plugin branch already exists without --force, push fails closed.
+        push_branch(branch, force=force)
+    except Exception:
+        # Leave a clean tree for the next candidate even if this one failed.
+        hard_reset_to(daily_sha)
+        raise
+
+    return ensure_pr(
+        head=branch,
+        base=daily_branch,
+        title=title,
+        body=body,
+        dry_run=False,
+    )
+
+
+def discover_candidates(
+    *,
+    only: str,
+    freeze: set[str],
+) -> tuple[list[dict], list[dict]]:
+    """Find url pins where HEAD moved and the version gate allows a bump.
+
+    Version extraction uses plugin_catalog.extract_plugin (same path as the
+    index generator).
+
+    Gate (after SHA moved):
+      - both versions set and equal → skip
+      - pin set, HEAD missing → skip (do not un-version)
+      - both missing → bump (SHA identity)
+      - pin missing, HEAD set → bump (first version)
+      - both set and differ → bump
+    """
+    catalog = load_catalog()
+    candidates: list[dict] = []
+    skipped: list[dict] = []
+
+    for entry in url_entries(catalog):
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            skipped.append({"name": "<unnamed>", "reason": "missing name"})
+            continue
+        if only and name != only:
+            continue
+        if name in freeze:
+            skipped.append({"name": name, "reason": "frozen"})
+            continue
+
+        source = entry["source"]
+        url = source.get("url")
+        old_sha = source.get("sha")
+        path = source.get("path")
+        subdir = path if isinstance(path, str) and path else None
+        if not isinstance(url, str) or not url.startswith("https://"):
+            skipped.append({"name": name, "reason": f"bad url {url!r}"})
+            continue
+        if not host_allowed(url):
+            skipped.append({"name": name, "reason": f"host not allowed: {url}"})
+            continue
+        if not isinstance(old_sha, str) or not SHA_RE.match(old_sha):
+            skipped.append({"name": name, "reason": f"bad pin {old_sha!r}"})
+            continue
+
+        try:
+            new_sha = ls_remote_head(url)
+        except Exception as e:  # noqa: BLE001
+            skipped.append({"name": name, "reason": f"ls-remote failed: {e}"})
+            continue
+
+        old_sha = old_sha.lower()
+        if new_sha == old_sha:
+            skipped.append({"name": name, "reason": "up to date"})
+            continue
+
+        try:
+            with tempfile.TemporaryDirectory(prefix=f"bump-{name}-") as tmp:
+                tmp_root = Path(tmp)
+                pin_rec = plugin_catalog.extract_at_sha(
+                    url,
+                    old_sha,
+                    tmp_root / "pin",
+                    subdir=subdir,
+                    name=name,
+                )
+                head_rec = plugin_catalog.extract_at_sha(
+                    url,
+                    new_sha,
+                    tmp_root / "head",
+                    subdir=subdir,
+                    name=name,
+                )
+        except Exception as e:  # noqa: BLE001
+            skipped.append({"name": name, "reason": f"extract failed: {e}"})
+            continue
+
+        old_version = pin_rec.get("version")
+        new_version = head_rec.get("version")
+
+        if old_version and not new_version:
+            skipped.append(
+                {
+                    "name": name,
+                    "reason": (
+                        f"sha moved ({old_sha[:7]}->{new_sha[:7]}) but HEAD "
+                        f"dropped version (pin has {old_version!r}; not "
+                        f"un-versioning)"
+                    ),
+                }
+            )
+            continue
+        if old_version and new_version and old_version == new_version:
+            skipped.append(
+                {
+                    "name": name,
+                    "reason": (
+                        f"sha moved ({old_sha[:7]}->{new_sha[:7]}) but "
+                        f"version still {old_version}"
+                    ),
+                }
+            )
+            continue
+        # bump: both missing | pin missing + HEAD set | both set and differ
+
+        candidates.append(
+            {
+                "name": name,
+                "url": url,
+                "old_sha": old_sha,
+                "new_sha": new_sha,
+                "old_version": old_version or "",
+                "new_version": new_version or "",
+                "path": subdir,
+            }
+        )
+
+    return candidates, skipped
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Rebuild today's stack even if bump/daily-YYYY-MM-DD already exists "
+            "on origin. Force-pushes daily and plugin branches. "
+            "Also set via FORCE_BUMP=true."
+        ),
+    )
+    parser.add_argument("--only", default="", help="Exact plugin name to bump")
+    parser.add_argument(
+        "--base-branch",
+        default=os.environ.get("BASE_BRANCH", "main"),
+        help="Default branch. Daily PR targets this.",
+    )
+    parser.add_argument(
+        "--day",
+        default=os.environ.get("BUMP_DAY", ""),
+        help="Pacific calendar day YYYY-MM-DD (default: today Pacific)",
+    )
+    parser.add_argument(
+        "--freeze",
+        default=os.environ.get("FREEZE_SHAS", ""),
+        help="Space-separated plugin names to never auto-bump",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+        help="Write pr-urls JSON for the Actions workflow",
+    )
+    args = parser.parse_args()
+
+    freeze = {n for n in args.freeze.split() if n}
+    only = args.only.strip()
+    run_url = os.environ.get("RUN_URL", "")
+    day = args.day.strip() or pacific_date()
+    daily_branch = f"bump/daily-{day}"
+    force = bool(args.force) or env_flag("FORCE_BUMP")
+    base_branch = args.base_branch
+
+    start_ref_proc = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=True)
+    start_ref = (start_ref_proc.stdout or "").strip()
+    if start_ref == "HEAD":
+        start_ref = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+
+    # Discover and bump from the same revision the stack will cut from.
+    # workflow_dispatch on a non-default ref would otherwise see a different
+    # catalog than origin/<base>.
+    if not args.dry_run:
+        reset_to_origin_base(base_branch)
+        ensure_clean_worktree()
+    else:
+        tip = origin_base(base_branch)
+        head = run(["git", "rev-parse", "HEAD"], check=True).stdout.strip()
+        if head != tip:
+            print(
+                f"[dry-run] worktree HEAD {head[:12]} != origin/{base_branch} "
+                f"{tip[:12]}; discovery uses the worktree catalog "
+                f"(non-dry-run resets to origin/{base_branch})",
+                file=sys.stderr,
+            )
+
+    if only:
+        catalog_names = {
+            e.get("name")
+            for e in load_catalog().get("plugins", [])
+            if isinstance(e, dict) and isinstance(e.get("name"), str)
+        }
+        if only not in catalog_names:
+            print(
+                f"ERROR: --only {only!r} matches no catalog plugin "
+                f"(known: {', '.join(sorted(catalog_names))})",
+                file=sys.stderr,
+            )
+            write_github_output(args.github_output, [], 0)
+            return 1
+
+    candidates, skipped = discover_candidates(only=only, freeze=freeze)
+
+    print(f"day={day} daily_branch={daily_branch} force={force}")
+    print(f"candidates={len(candidates)} skipped={len(skipped)}")
+    for s in skipped:
+        print(f"  skip {s['name']}: {s['reason']}")
+
+    pr_urls: list[dict] = []
+    errors: list[str] = []
+    daily_pr: str | None = None
+
+    if not candidates:
+        print("nothing to bump")
+        write_github_output(args.github_output, pr_urls, 0)
+        return 0
+
+    # Gate on remote branch existence (not open PR). Merged/closed daily still
+    # leaves the ref around unless deleted, so same-day re-runs stay no-ops.
+    daily_exists = remote_branch_exists(daily_branch)
+    if daily_exists and not force:
+        print(
+            f"remote branch {daily_branch} already exists; no-op "
+            "(pass --force to rebuild and force-push this day's stack)"
+        )
+        write_github_output(
+            args.github_output,
+            [
+                {
+                    "name": "_daily",
+                    "branch": daily_branch,
+                    "base": base_branch,
+                    "pr_url": "",
+                    "skipped": True,
+                }
+            ],
+            0,
+        )
+        return 0
+
+    if daily_exists and force:
+        print(f"remote branch {daily_branch} exists; --force rebuild from main")
+
+    try:
+        daily_pr, daily_sha = open_daily_base(
+            daily_branch=daily_branch,
+            main_branch=base_branch,
+            day=day,
+            run_url=run_url,
+            force=force or daily_exists,
+            dry_run=args.dry_run,
+        )
+        # First create: force=False for push. But if daily_exists we must force.
+        # open_daily_base already got force=force or daily_exists.
+        pr_urls.append(
+            {
+                "name": "_daily",
+                "branch": daily_branch,
+                "base": base_branch,
+                "pr_url": daily_pr or "",
+            }
+        )
+
+        # Plugin pushes: force when rebuilding the day so existing plugin
+        # branches are rewritten onto the new daily tip.
+        plugin_force = force or daily_exists
+
+        for c in candidates:
+            plugin_branch = f"bump/{day}/{c['name']}"
+            print(
+                f"bump {c['name']}: {c['old_version']} -> {c['new_version']} "
+                f"({c['old_sha'][:7]} -> {c['new_sha'][:7]}) "
+                f"on {plugin_branch} -> {daily_branch}"
+            )
+            try:
+                pr_url = apply_plugin_bump(
+                    name=c["name"],
+                    old_sha=c["old_sha"],
+                    new_sha=c["new_sha"],
+                    old_version=c["old_version"],
+                    new_version=c["new_version"],
+                    url=c["url"],
+                    branch=plugin_branch,
+                    daily_branch=daily_branch,
+                    daily_sha=daily_sha,
+                    run_url=run_url,
+                    force=plugin_force,
+                    dry_run=args.dry_run,
+                )
+                pr_urls.append(
+                    {
+                        "name": c["name"],
+                        "old_sha": c["old_sha"],
+                        "new_sha": c["new_sha"],
+                        "old_version": c["old_version"],
+                        "new_version": c["new_version"],
+                        "branch": plugin_branch,
+                        "base": daily_branch,
+                        "pr_url": pr_url or "",
+                    }
+                )
+            except Exception as e:  # noqa: BLE001
+                msg = f"{c['name']}: {e}"
+                errors.append(msg)
+                print(f"ERROR: {msg}", file=sys.stderr)
+    finally:
+        if not args.dry_run:
+            run(["git", "checkout", "-f", start_ref], check=False)
+
+    if not args.dry_run and daily_pr and len(pr_urls) > 1:
+        child_lines = [
+            f"- `{e['branch']}` ({e['name']}): {e['pr_url'] or 'opened'}"
+            for e in pr_urls
+            if e.get("name") != "_daily"
+        ]
+        run(
+            [
+                "gh",
+                "pr",
+                "edit",
+                daily_branch,
+                "--body",
+                "\n".join(
+                    [
+                        f"Daily base for plugin pin bumps on **{day}** (Pacific).",
+                        "",
+                        "Plugin PRs (all target this branch; merge or close independently):",
+                        *child_lines,
+                        "",
+                        "Land this PR into `main` after the desired plugins are merged here.",
+                        "",
+                        "No auto-merge.",
+                        *(["", f"Triggered by: {run_url}"] if run_url else []),
+                    ]
+                )
+                + "\n",
+            ],
+            check=False,
+        )
+
+    bumped = sum(1 for e in pr_urls if e.get("name") != "_daily")
+    write_github_output(args.github_output, pr_urls, bumped)
+
+    if errors:
+        print(f"{len(errors)} bump(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/generate-plugin-index.py
+++ b/scripts/generate-plugin-index.py
@@ -3,9 +3,11 @@
 
 For every entry in `.grok-plugin/marketplace.json`, this script resolves the
 plugin's source (local directories are scanned in place; url sources are
-shallow-fetched at their pinned commit sha) and records which components the
-plugin provides: skills, commands, agents, MCP servers, hooks, and LSP
+shallow-fetched at their pinned commit sha) and records version (when set)
+plus components: skills, commands, agents, MCP servers, hooks, and LSP
 servers. Clients use this to show what a plugin contains before installing it.
+
+Extraction is shared with bump-plugin-shas via plugin_catalog.extract_plugin.
 
 The output is deterministic — sorted keys, items sorted by name, no
 timestamps — so CI can regenerate it and fail on any diff.
@@ -17,322 +19,28 @@ Verify (CI):    python3 scripts/generate-plugin-index.py --check
 from __future__ import annotations
 
 import json
-import re
-import subprocess
 import sys
 import tempfile
-import time
 from pathlib import Path
+
+import plugin_catalog
 
 INDEX_PATH = Path(".grok-plugin/plugin-index.json")
 CATALOG_PATH = Path(".grok-plugin/marketplace.json")
 
-MAX_ITEMS_PER_CATEGORY = 50
-MAX_STRING_LEN = 120
-MAX_TEXT_READ_BYTES = 64 * 1024
-MAX_JSON_BYTES = 1 << 20
-FETCH_ATTEMPTS = 3
-
-SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-
-MANIFEST_PATHS = [
-    Path(".grok-plugin/plugin.json"),
-    Path(".claude-plugin/plugin.json"),
-]
-
-CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-
-
-def clean(text: str) -> str:
-    text = re.sub(r"\s+", " ", CONTROL_CHARS_RE.sub("", text)).strip()
-    if len(text) > MAX_STRING_LEN:
-        text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
-    return text
-
-
-def resolve_inside(root: Path, relative) -> Path | None:
-    """Resolve `relative` against `root`, returning None if the result
-    escapes `root` (via `..`, absolute paths, or symlinks). Plugin content
-    is untrusted; nothing outside the plugin tree may be read."""
-    try:
-        candidate = (root / relative).resolve()
-        if candidate.is_relative_to(root.resolve()):
-            return candidate
-    except (OSError, ValueError):
-        return None
-    return None
-
-
-def contained(path: Path, root: Path) -> bool:
-    try:
-        return path.resolve().is_relative_to(root.resolve())
-    except (OSError, ValueError):
-        return False
-
-
-def read_text_limited(path: Path) -> str:
-    with open(path, encoding="utf-8", errors="replace") as f:
-        return f.read(MAX_TEXT_READ_BYTES)
-
-
-def load_json_file(path: Path):
-    try:
-        if path.stat().st_size > MAX_JSON_BYTES:
-            return None
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-
-
-def parse_frontmatter(path: Path) -> dict[str, str]:
-    """Tolerant YAML-ish frontmatter parser: top-level `key: value` lines only."""
-    try:
-        text = read_text_limited(path)
-    except OSError:
-        return {}
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return {}
-    fields: dict[str, str] = {}
-    i = 1
-    while i < len(lines):
-        line = lines[i]
-        if line.strip() in ("---", "..."):
-            break
-        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
-        if not m:
-            i += 1
-            continue
-        key, value = m.group(1), m.group(2).strip()
-        if re.match(r"^[|>][+-]?$", value):
-            block: list[str] = []
-            j = i + 1
-            while j < len(lines) and (lines[j].startswith((" ", "\t")) or not lines[j].strip()):
-                if lines[j].strip():
-                    block.append(lines[j].strip())
-                j += 1
-            value = " ".join(block)
-            i = j
-        else:
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                value = value[1:-1]
-            i += 1
-        fields[key] = value
-    return fields
-
-
-def first_body_line(path: Path) -> str:
-    """First non-empty, non-heading line after any frontmatter block."""
-    try:
-        text = read_text_limited(path)
-    except OSError:
-        return ""
-    lines = text.splitlines()
-    i = 0
-    if lines and lines[0].strip() == "---":
-        for j in range(1, len(lines)):
-            if lines[j].strip() in ("---", "..."):
-                i = j + 1
-                break
-    for line in lines[i:]:
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            return stripped
-    return ""
-
-
-def make_item(name: str, description: str = "") -> dict:
-    item = {"name": clean(name)}
-    description = clean(description)
-    if description:
-        item["description"] = description
-    return item
-
-
-def load_manifest(root: Path) -> dict:
-    for rel in MANIFEST_PATHS:
-        path = resolve_inside(root, rel)
-        if path and path.is_file():
-            data = load_json_file(path)
-            if isinstance(data, dict):
-                return data
-    return {}
-
-
-def as_list(value) -> list:
-    if isinstance(value, list):
-        return value
-    if value is None:
-        return []
-    return [value]
-
-
-def scan_skills(root: Path, manifest: dict) -> list[dict]:
-    skill_dirs: dict[Path, str] = {}
-    for base in [root / "skills"]:
-        if base.is_dir():
-            for child in sorted(base.iterdir()):
-                skill_md = child / "SKILL.md"
-                if skill_md.is_file() and contained(skill_md, root):
-                    skill_dirs[child.resolve()] = child.name
-    for entry in as_list(manifest.get("skills")):
-        if isinstance(entry, str):
-            candidate = resolve_inside(root, entry)
-            if candidate and (candidate / "SKILL.md").is_file() and contained(candidate / "SKILL.md", root):
-                skill_dirs.setdefault(candidate, candidate.name)
-    items = []
-    for skill_dir, dirname in skill_dirs.items():
-        fm = parse_frontmatter(skill_dir / "SKILL.md")
-        items.append(make_item(fm.get("name") or dirname, fm.get("description", "")))
-    return items
-
-
-def scan_markdown_dir(root: Path, dirname: str, manifest_key: str, manifest: dict) -> list[dict]:
-    files: dict[Path, str] = {}
-    base = root / dirname
-    if base.is_dir():
-        for path in sorted(base.rglob("*.md")):
-            if path.is_file() and contained(path, root):
-                files[path.resolve()] = path.stem
-    for entry in as_list(manifest.get(manifest_key)):
-        if isinstance(entry, str):
-            candidate = resolve_inside(root, entry)
-            if candidate and candidate.is_file() and candidate.suffix == ".md":
-                files.setdefault(candidate, candidate.stem)
-    items = []
-    for path, stem in files.items():
-        fm = parse_frontmatter(path)
-        description = fm.get("description") or first_body_line(path)
-        items.append(make_item(fm.get("name") or stem, description))
-    return items
-
-
-def transport_hint(config: dict) -> str:
-    if not isinstance(config, dict):
-        return ""
-    transport = config.get("type") or config.get("transport")
-    if not transport:
-        if config.get("command"):
-            transport = "stdio"
-        elif config.get("url"):
-            transport = "http"
-    return str(transport) if transport else ""
-
-
-def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
-    servers: dict[str, dict] = {}
-    declared = manifest.get("mcpServers")
-    config_rel = declared if isinstance(declared, str) else ".mcp.json"
-    mcp_path = resolve_inside(root, config_rel)
-    if mcp_path and mcp_path.is_file():
-        data = load_json_file(mcp_path)
-        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
-            servers.update(data["mcpServers"])
-    if isinstance(declared, dict):
-        for name, config in declared.items():
-            servers.setdefault(name, config)
-    return [make_item(name, transport_hint(config)) for name, config in servers.items()]
-
-
-def scan_hooks(root: Path, manifest: dict) -> list[dict]:
-    data = None
-    hooks_path = resolve_inside(root, Path("hooks") / "hooks.json")
-    if hooks_path and hooks_path.is_file():
-        data = load_json_file(hooks_path)
-    if data is None:
-        declared = manifest.get("hooks")
-        if isinstance(declared, dict):
-            data = declared
-        elif isinstance(declared, str):
-            declared_path = resolve_inside(root, declared)
-            if declared_path and declared_path.is_file():
-                data = load_json_file(declared_path)
-    if not isinstance(data, dict):
-        return []
-    hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
-    items = []
-    for event, entries in hooks_obj.items():
-        if not isinstance(entries, list):
-            continue
-        matchers = [
-            e["matcher"]
-            for e in entries
-            if isinstance(e, dict) and isinstance(e.get("matcher"), str) and e["matcher"]
-        ]
-        items.append(make_item(event, ", ".join(matchers)))
-    return items
-
-
-def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
-    servers: dict[str, dict] = {}
-    lsp_path = resolve_inside(root, ".lsp.json")
-    if lsp_path and lsp_path.is_file():
-        data = load_json_file(lsp_path)
-        if isinstance(data, dict):
-            servers.update(data.get("lspServers") if isinstance(data.get("lspServers"), dict) else data)
-    declared = manifest.get("lspServers")
-    if isinstance(declared, dict):
-        for name, config in declared.items():
-            servers.setdefault(name, config)
-    return [make_item(name) for name, config in servers.items() if isinstance(config, dict)]
-
-
-def scan_plugin(root: Path) -> dict:
-    manifest = load_manifest(root)
-    categories = {
-        "skills": scan_skills(root, manifest),
-        "commands": scan_markdown_dir(root, "commands", "commands", manifest),
-        "agents": scan_markdown_dir(root, "agents", "agents", manifest),
-        "mcpServers": scan_mcp_servers(root, manifest),
-        "hooks": scan_hooks(root, manifest),
-        "lspServers": scan_lsp_servers(root, manifest),
-    }
-    components = {}
-    for key in sorted(categories):
-        items = sorted(categories[key], key=lambda i: i["name"])[:MAX_ITEMS_PER_CATEGORY]
-        if items:
-            components[key] = items
-    return components
-
-
-def run_git(cmd: list[str], url: str, sha: str) -> None:
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
-            f"{result.returncode}: {result.stderr.strip()}"
-        )
-
-
-def fetch_pinned(url: str, sha: str, dest: Path) -> None:
-    run_git(["git", "init", "--quiet", "--", str(dest)], url, sha)
-    fetch_cmd = [
-        "git", "-C", str(dest), "fetch", "--quiet", "--depth", "1",
-        "--end-of-options", url, sha,
-    ]
-    last_error: RuntimeError | None = None
-    for attempt in range(FETCH_ATTEMPTS):
-        try:
-            run_git(fetch_cmd, url, sha)
-            last_error = None
-            break
-        except RuntimeError as e:
-            last_error = e
-            if attempt < FETCH_ATTEMPTS - 1:
-                time.sleep(2 ** attempt)
-    if last_error is not None:
-        raise last_error
-    run_git(["git", "-C", str(dest), "checkout", "--quiet", "--detach", sha], url, sha)
-
 
 def resolve_local(repo_root: Path, path: str, name: str) -> Path:
-    resolved = resolve_inside(repo_root, path)
+    resolved = plugin_catalog.resolve_inside(repo_root, path)
     if resolved is None:
-        raise RuntimeError(f"plugin '{name}': local source path escapes the repo: {path!r}")
+        raise RuntimeError(
+            f"plugin '{name}': local source path escapes the repo: {path!r}"
+        )
     return resolved
 
 
-def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tuple[Path, str | None]:
+def resolve_source(
+    entry: dict, repo_root: Path, tmp_root: Path, idx: int
+) -> tuple[Path, str | None]:
     """Return (plugin root dir, pinned sha or None for local sources)."""
     name = entry.get("name", "<unnamed>")
     source = entry.get("source")
@@ -343,20 +51,25 @@ def resolve_source(entry: dict, repo_root: Path, tmp_root: Path, idx: int) -> tu
             url = source.get("url")
             sha = source.get("sha")
             if not isinstance(url, str) or not url.startswith("https://"):
-                raise RuntimeError(f"plugin '{name}': url source must be an https:// url, got {url!r}")
+                raise RuntimeError(
+                    f"plugin '{name}': url source must be an https:// url, got {url!r}"
+                )
             if not sha:
                 raise RuntimeError(
                     f"plugin '{name}': url source has no pinned sha. All url "
                     f"sources must pin a full commit sha (see README)."
                 )
-            if not isinstance(sha, str) or not SHA_RE.match(sha):
+            if not isinstance(sha, str) or not plugin_catalog.SHA_RE.match(sha):
                 raise RuntimeError(
                     f"plugin '{name}': sha {sha!r} is not a 40-character "
                     f"lowercase hex commit sha"
                 )
             dest = tmp_root / f"plugin-{idx}"
-            fetch_pinned(url, sha, dest)
-            return dest, sha
+            subdir = source.get("path")
+            subdir_s = subdir if isinstance(subdir, str) and subdir else None
+            plugin_catalog.fetch_at_sha(url, sha, dest)
+            root = plugin_catalog.plugin_root_for_fetch(dest, subdir_s, name)
+            return root, sha
         path = source.get("path")
         if isinstance(path, str):
             return resolve_local(repo_root, path, name), None
@@ -373,12 +86,13 @@ def generate(repo_root: Path) -> dict:
             if not name:
                 raise RuntimeError("catalog entry without a name")
             root, sha = resolve_source(entry, repo_root, tmp_root, idx)
-            if not root.is_dir():
-                raise RuntimeError(f"plugin '{name}': source dir not found: {root}")
+            extracted = plugin_catalog.extract_plugin(root)
             record: dict = {}
             if sha:
                 record["sha"] = sha
-            record["components"] = scan_plugin(root)
+            if "version" in extracted:
+                record["version"] = extracted["version"]
+            record["components"] = extracted["components"]
             plugins_out[name] = record
     return {
         "version": 1,

--- a/scripts/plugin_catalog.py
+++ b/scripts/plugin_catalog.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Shared plugin extraction for marketplace catalog tooling.
+
+One extract path given a plugin root on disk (already resolved at a known
+sha / local path):
+
+  - load manifest (.grok-plugin/plugin.json or .claude-plugin/plugin.json)
+  - read version if present
+  - scan components (skills, commands, agents, mcpServers, hooks, lspServers)
+
+Used by generate-plugin-index.py (full catalog) and bump-plugin-shas.py
+(version gate at HEAD vs pin).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+
+MAX_ITEMS_PER_CATEGORY = 50
+MAX_STRING_LEN = 120
+MAX_TEXT_READ_BYTES = 64 * 1024
+MAX_JSON_BYTES = 1 << 20
+FETCH_ATTEMPTS = 3
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+MANIFEST_PATHS = [
+    Path(".grok-plugin/plugin.json"),
+    Path(".claude-plugin/plugin.json"),
+]
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def clean(text: str) -> str:
+    text = re.sub(r"\s+", " ", CONTROL_CHARS_RE.sub("", text)).strip()
+    if len(text) > MAX_STRING_LEN:
+        text = text[: MAX_STRING_LEN - 1].rstrip() + "\u2026"
+    return text
+
+
+def resolve_inside(root: Path, relative) -> Path | None:
+    try:
+        candidate = (root / relative).resolve()
+        if candidate.is_relative_to(root.resolve()):
+            return candidate
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def contained(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def read_text_limited(path: Path) -> str:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.read(MAX_TEXT_READ_BYTES)
+
+
+def load_json_file(path: Path):
+    try:
+        if path.stat().st_size > MAX_JSON_BYTES:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def parse_frontmatter(path: Path) -> dict[str, str]:
+    try:
+        text = read_text_limited(path)
+    except OSError:
+        return {}
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    fields: dict[str, str] = {}
+    i = 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() in ("---", "..."):
+            break
+        m = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not m:
+            i += 1
+            continue
+        key, value = m.group(1), m.group(2).strip()
+        if re.match(r"^[|>][+-]?$", value):
+            block: list[str] = []
+            j = i + 1
+            while j < len(lines) and (lines[j].startswith((" ", "\t")) or not lines[j].strip()):
+                if lines[j].strip():
+                    block.append(lines[j].strip())
+                j += 1
+            value = " ".join(block)
+            i = j
+        else:
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            i += 1
+        fields[key] = value
+    return fields
+
+
+def first_body_line(path: Path) -> str:
+    try:
+        text = read_text_limited(path)
+    except OSError:
+        return ""
+    lines = text.splitlines()
+    i = 0
+    if lines and lines[0].strip() == "---":
+        for j in range(1, len(lines)):
+            if lines[j].strip() in ("---", "..."):
+                i = j + 1
+                break
+    for line in lines[i:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped
+    return ""
+
+
+def make_item(name: str, description: str = "") -> dict:
+    item = {"name": clean(name)}
+    description = clean(description)
+    if description:
+        item["description"] = description
+    return item
+
+
+def load_manifest(root: Path) -> dict:
+    for rel in MANIFEST_PATHS:
+        path = resolve_inside(root, rel)
+        if path and path.is_file():
+            data = load_json_file(path)
+            if isinstance(data, dict):
+                return data
+    return {}
+
+
+def manifest_version(manifest: dict) -> str | None:
+    """Return a non-empty version string from the manifest, or None."""
+    value = manifest.get("version")
+    if isinstance(value, str):
+        value = value.strip()
+        if value:
+            return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    return None
+
+
+def as_list(value) -> list:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def scan_skills(root: Path, manifest: dict) -> list[dict]:
+    skill_dirs: dict[Path, str] = {}
+    for base in [root / "skills"]:
+        if base.is_dir():
+            for child in sorted(base.iterdir()):
+                skill_md = child / "SKILL.md"
+                if skill_md.is_file() and contained(skill_md, root):
+                    skill_dirs[child.resolve()] = child.name
+    for entry in as_list(manifest.get("skills")):
+        if isinstance(entry, str):
+            candidate = resolve_inside(root, entry)
+            if (
+                candidate
+                and (candidate / "SKILL.md").is_file()
+                and contained(candidate / "SKILL.md", root)
+            ):
+                skill_dirs.setdefault(candidate, candidate.name)
+    items = []
+    for skill_dir, dirname in skill_dirs.items():
+        fm = parse_frontmatter(skill_dir / "SKILL.md")
+        items.append(make_item(fm.get("name") or dirname, fm.get("description", "")))
+    return items
+
+
+def scan_markdown_dir(
+    root: Path, dirname: str, manifest_key: str, manifest: dict
+) -> list[dict]:
+    files: dict[Path, str] = {}
+    base = root / dirname
+    if base.is_dir():
+        for path in sorted(base.rglob("*.md")):
+            if path.is_file() and contained(path, root):
+                files[path.resolve()] = path.stem
+    for entry in as_list(manifest.get(manifest_key)):
+        if isinstance(entry, str):
+            candidate = resolve_inside(root, entry)
+            if candidate and candidate.is_file() and candidate.suffix == ".md":
+                files.setdefault(candidate, candidate.stem)
+    items = []
+    for path, stem in files.items():
+        fm = parse_frontmatter(path)
+        description = fm.get("description") or first_body_line(path)
+        items.append(make_item(fm.get("name") or stem, description))
+    return items
+
+
+def transport_hint(config: dict) -> str:
+    if not isinstance(config, dict):
+        return ""
+    transport = config.get("type") or config.get("transport")
+    if not transport:
+        if config.get("command"):
+            transport = "stdio"
+        elif config.get("url"):
+            transport = "http"
+    return str(transport) if transport else ""
+
+
+def scan_mcp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    declared = manifest.get("mcpServers")
+    config_rel = declared if isinstance(declared, str) else ".mcp.json"
+    mcp_path = resolve_inside(root, config_rel)
+    if mcp_path and mcp_path.is_file():
+        data = load_json_file(mcp_path)
+        if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+            servers.update(data["mcpServers"])
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [make_item(name, transport_hint(config)) for name, config in servers.items()]
+
+
+def scan_hooks(root: Path, manifest: dict) -> list[dict]:
+    data = None
+    hooks_path = resolve_inside(root, Path("hooks") / "hooks.json")
+    if hooks_path and hooks_path.is_file():
+        data = load_json_file(hooks_path)
+    if data is None:
+        declared = manifest.get("hooks")
+        if isinstance(declared, dict):
+            data = declared
+        elif isinstance(declared, str):
+            declared_path = resolve_inside(root, declared)
+            if declared_path and declared_path.is_file():
+                data = load_json_file(declared_path)
+    if not isinstance(data, dict):
+        return []
+    hooks_obj = data.get("hooks") if isinstance(data.get("hooks"), dict) else data
+    items = []
+    for event, entries in hooks_obj.items():
+        if not isinstance(entries, list):
+            continue
+        matchers = [
+            e["matcher"]
+            for e in entries
+            if isinstance(e, dict) and isinstance(e.get("matcher"), str) and e["matcher"]
+        ]
+        items.append(make_item(event, ", ".join(matchers)))
+    return items
+
+
+def scan_lsp_servers(root: Path, manifest: dict) -> list[dict]:
+    servers: dict[str, dict] = {}
+    lsp_path = resolve_inside(root, ".lsp.json")
+    if lsp_path and lsp_path.is_file():
+        data = load_json_file(lsp_path)
+        if isinstance(data, dict):
+            servers.update(
+                data.get("lspServers")
+                if isinstance(data.get("lspServers"), dict)
+                else data
+            )
+    declared = manifest.get("lspServers")
+    if isinstance(declared, dict):
+        for name, config in declared.items():
+            servers.setdefault(name, config)
+    return [
+        make_item(name)
+        for name, config in servers.items()
+        if isinstance(config, dict)
+    ]
+
+
+def extract_plugin(root: Path) -> dict:
+    """Extract version + components from a plugin root on disk.
+
+    Returns:
+      {
+        "version": str | omitted when missing,
+        "components": { category: [items...] }
+      }
+    """
+    if not root.is_dir():
+        raise RuntimeError(f"plugin root is not a directory: {root}")
+
+    manifest = load_manifest(root)
+    categories = {
+        "skills": scan_skills(root, manifest),
+        "commands": scan_markdown_dir(root, "commands", "commands", manifest),
+        "agents": scan_markdown_dir(root, "agents", "agents", manifest),
+        "mcpServers": scan_mcp_servers(root, manifest),
+        "hooks": scan_hooks(root, manifest),
+        "lspServers": scan_lsp_servers(root, manifest),
+    }
+    components = {}
+    for key in sorted(categories):
+        items = sorted(categories[key], key=lambda i: i["name"])[
+            :MAX_ITEMS_PER_CATEGORY
+        ]
+        if items:
+            components[key] = items
+
+    record: dict = {"components": components}
+    version = manifest_version(manifest)
+    if version is not None:
+        record["version"] = version
+    return record
+
+
+def run_git(cmd: list[str], url: str, sha: str) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to fetch {url} at {sha}: `{' '.join(cmd)}` exited "
+            f"{result.returncode}: {result.stderr.strip()}"
+        )
+
+
+def fetch_at_sha(url: str, sha: str, dest: Path) -> None:
+    """Shallow-fetch url at sha into dest and detach checkout."""
+    if not SHA_RE.match(sha):
+        raise RuntimeError(f"sha {sha!r} is not a 40-character lowercase hex commit")
+    run_git(["git", "init", "--quiet", "--", str(dest)], url, sha)
+    fetch_cmd = [
+        "git",
+        "-C",
+        str(dest),
+        "fetch",
+        "--quiet",
+        "--depth",
+        "1",
+        "--end-of-options",
+        url,
+        sha,
+    ]
+    last_error: RuntimeError | None = None
+    for attempt in range(FETCH_ATTEMPTS):
+        try:
+            run_git(fetch_cmd, url, sha)
+            last_error = None
+            break
+        except RuntimeError as e:
+            last_error = e
+            if attempt < FETCH_ATTEMPTS - 1:
+                time.sleep(2 ** attempt)
+    if last_error is not None:
+        raise last_error
+    run_git(
+        ["git", "-C", str(dest), "checkout", "--quiet", "--detach", sha],
+        url,
+        sha,
+    )
+
+
+def plugin_root_for_fetch(dest: Path, subdir: str | None, name: str) -> Path:
+    if not subdir:
+        return dest
+    resolved = resolve_inside(dest, subdir)
+    if resolved is None:
+        raise RuntimeError(
+            f"plugin '{name}': url source path escapes the repo: {subdir!r}"
+        )
+    if not resolved.is_dir():
+        raise RuntimeError(f"plugin '{name}': url source path not found: {subdir!r}")
+    return resolved
+
+
+def extract_at_sha(
+    url: str,
+    sha: str,
+    dest: Path,
+    *,
+    subdir: str | None = None,
+    name: str = "<plugin>",
+) -> dict:
+    """Fetch url@sha into dest and extract_plugin from the resolved root."""
+    fetch_at_sha(url, sha, dest)
+    root = plugin_root_for_fetch(dest, subdir, name)
+    return extract_plugin(root)

--- a/scripts/validate-catalog.py
+++ b/scripts/validate-catalog.py
@@ -73,6 +73,22 @@ def validate_entry(entry: dict, idx: int) -> list[str]:
             f"abbreviated SHA."
         )
 
+    path = source.get("path")
+    if path is not None:
+        if not isinstance(path, str) or not path.strip():
+            errors.append(
+                f"plugin '{name}': url source `path` must be a non-empty string when present."
+            )
+        elif (
+            path.startswith("/")
+            or "\\" in path
+            or any(part in ("..", "") for part in path.split("/"))
+        ):
+            errors.append(
+                f"plugin '{name}': url source `path` {path!r} must be a relative "
+                f"subdirectory inside the repo (no leading '/', no '..', no backslashes)."
+            )
+
     return errors
 
 


### PR DESCRIPTION
Adds the CodeRifts plugin under external_plugins/: MCP server (https://app.coderifts.com/mcp) + the api-governance skill. The skill advertises exactly the 3 tools the live server exposes (preflight_change_set, verify_receipt, get_decision_details), verified against live tools/list. Detects breaking changes in OpenAPI specs and MCP manifests, scores blast radius and agent impact, and returns ALLOW/WARN/REQUIRE_APPROVAL/BLOCK with a signed, offline-verifiable receipt before a tool call or merge. Plugin index regenerated with scripts/generate-plugin-index.py; catalog validator green.