### PR TITLE
Add HTML/CSS to Image plugin (MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -291,7 +291,7 @@
         "sha": "0c0481e6e0444bece910a2270f6b8e602c0a5401"
       },
       "homepage": "https://htmlcsstoimage.com",
-      "keywords": ["html/css to image", "html css to image", "html-to-image", "html to image api", "hcti", "hcti mcp", "screenshot"],
+      "keywords": ["html/css to image", "html css to image", "html-to-image", "html to image api", "hcti", "screenshot", "url screenshot"],
       "domains": ["htmlcsstoimage.com", "docs.htmlcsstoimage.com", "hcti.io", "mcp.hcti.io"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/htmlcsstoimage/agent-plugins.git",
-        "sha": "0c0481e6e0444bece910a2270f6b8e602c0a5401"
+        "sha": "49511d284a0253e66984ca715cd6892f1fa163ae"
       },
       "homepage": "https://htmlcsstoimage.com",
       "keywords": ["html/css to image", "html css to image", "html-to-image", "html to image api", "hcti", "screenshot", "url screenshot"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "html-css-to-image",
+      "description": "HTML/CSS to Image API integration (hosted OAuth MCP server + skill). Let AI agents capture live website screenshots, render HTML/CSS, and populate reusable templates as images or PDFs—without managing a browser.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/htmlcsstoimage/agent-plugins.git",
+        "sha": "0c0481e6e0444bece910a2270f6b8e602c0a5401"
+      },
+      "homepage": "https://htmlcsstoimage.com",
+      "keywords": ["html/css to image", "html css to image", "html-to-image", "html to image api", "hcti", "hcti mcp", "screenshot"],
+      "domains": ["htmlcsstoimage.com", "docs.htmlcsstoimage.com", "hcti.io", "mcp.hcti.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -349,6 +349,24 @@
         ]
       }
     },
+    "html-css-to-image": {
+      "sha": "0c0481e6e0444bece910a2270f6b8e602c0a5401",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "hcti",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "hcti-image-generation",
+            "description": "Let AI agents capture live website screenshots, render HTML/CSS, and populate reusable templates as images or PDFs—with…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "html-css-to-image": {
-      "sha": "0c0481e6e0444bece910a2270f6b8e602c0a5401",
+      "sha": "49511d284a0253e66984ca715cd6892f1fa163ae",
       "version": "0.1.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the official HTML/CSS to Image API integration for Grok Build. The plugin connects to HCTI's hosted OAuth MCP server and includes focused skills for:

- Rendering HTML/CSS as images or PDFs
- Capturing public webpages
- Generating batches and working with reusable templates
- Creating and implementing dynamic Open Graph image configurations
- Managing supporting resources such as proxies and storage destinations

- Plugin name: `html-css-to-image`
- Type: Remote source
- Source URL + pinned SHA: `https://github.com/htmlcsstoimage/agent-plugins.git` at `330e552ee4f9ab763ea50bfd370d4e22c8697ffb`
- Homepage: https://htmlcsstoimage.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] The source repository includes a README, `.grok-plugin/plugin.json`, and MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No lifecycle hooks; MCP access is limited to HCTI's hosted server.
- Network endpoint used by the plugin: `https://mcp.hcti.io`.
- For URL screenshots and dynamic Open Graph images, the hosted HCTI service fetches webpages supplied or configured by the user.
- HCTI may also use proxy or storage destinations that the user explicitly configures in their organization.
- Authentication requires an HTML/CSS to Image account authorized through browser-based OAuth. Available tools depend on the organization permissions granted during authorization.
- No API key or access token is stored in the plugin repository.

## Notes for reviewers

The source is maintained under the official `htmlcsstoimage` GitHub organization.

The generated component index identifies:

- MCP server: `hcti` using HTTP
- Skill: `hcti-image-generation`
- Skill: `hcti-open-graph-images`
- Plugin version: `0.2.0`

The Open Graph skill covers the complete integration workflow: creating a configuration, adding page-level metadata such as `hcti:selector` or `html:tv:*`, constructing the stable `og:image` URL from the returned `domain_id`, and verifying the rendered result.

Reviewers can create a free HTML/CSS to Image account to test the integration. If the review requires additional credits or access to higher-tier functionality, contact us at support@htmlcsstoimage.com and we'll provide complimentary review access.