### PR TITLE
feat: add you.com search and research plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "you",
+      "description": "Web search, URL content extraction, cited research, and finance research via You.com's hosted MCP server and official skills. Keyless basic search works out of the box; connect a You.com API key for full search, contents, and research tools.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/youdotcom-oss/agent-skills.git",
+        "sha": "78e20fd40bfdccbf91a5aaa67c2e46ba4ed2bbaa"
+      },
+      "homepage": "https://you.com/docs",
+      "keywords": ["you.com", "you.com search", "you web search"],
+      "domains": ["you.com", "api.you.com", "docs.you.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1263,6 +1263,34 @@
           }
         ]
       }
+    },
+    "you": {
+      "sha": "78e20fd40bfdccbf91a5aaa67c2e46ba4ed2bbaa",
+      "version": "0.5.0",
+      "components": {
+        "skills": [
+          {
+            "name": "you-discover",
+            "description": "Route You.com integration planning through the you-discover MCP tool, Docs MCP, and direct API options."
+          },
+          {
+            "name": "you-finance",
+            "description": "Route finance questions to an existing local script, a new You.com Finance Research API call, or an MCP payment-aware f…"
+          },
+          {
+            "name": "you-free",
+            "description": "Use the free You.com MCP profile for unauthenticated basic web search with `you-search` only."
+          },
+          {
+            "name": "you-research",
+            "description": "Route research tasks between a cost-conscious agentic search workflow, You.com Research API scripts, and managed or pay…"
+          },
+          {
+            "name": "you-web",
+            "description": "Use You.com MCP tools for current web search, URL content extraction, cited web synthesis, and x402-aware web access."
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Adds You.com to the catalog as a remote-source entry pointing at the official org repo, [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) (MIT, `.grok-plugin/plugin.json` manifest, skills-based plugin — no vendored code here, pinned to commit `78e20fd`).

## What it provides

Five skills covering web search, URL content extraction, cited research, finance research, and integration discovery. The skills route through You.com's hosted MCP server:

- `https://api.you.com/mcp` — full tool set with a You.com API key (`Authorization: Bearer`)
- `https://api.you.com/mcp?profile=free` — keyless basic `you-search`, so the plugin is useful with zero setup
- `https://you.com/docs/_mcp/server` — You.com docs search, no auth

## Changes

- One entry appended to `.grok-plugin/marketplace.json` (`you`, category `development`, remote source with full 40-char SHA pin)
- `.grok-plugin/plugin-index.json` regenerated via `scripts/generate-plugin-index.py` (never hand-edited)

## Validation

- `python3 scripts/validate-catalog.py` → `Catalog OK`
- `python3 scripts/generate-plugin-index.py --check` → `Plugin index OK` (index generated from the pinned upstream commit; the five skills were extracted from it)
- Keywords/domains are brand-scoped (`you.com`, `you.com search`) rather than generic terms like `search` or `web search`, per the contributing guide's CTA guidance

The plugin is fully opt-in — users install it explicitly with `grok plugin install you`. For other agent platforms the same source repo installs via `npx skills add youdotcom-oss/agent-skills`.

Happy to adjust the description or category if you'd prefer different wording.