### PR TITLE
Add Wonder plugin (design canvas MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "wonder",
+      "description": "Create and edit designs with Grok on a Wonder canvas where every design is real HTML and CSS. Inspect artboards, generate screens, and push designs back into code via the hosted Wonder MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/aquila-lab/wonder-plugins.git",
+        "sha": "e60f8bd908e13ec49b3738f54e1e42d659915286",
+        "path": "plugins/wonder"
+      },
+      "homepage": "https://wonder.design",
+      "keywords": ["wonder", "wonder design", "wonder canvas"],
+      "domains": ["wonder.design", "wonder.so", "mcp.wonder.so"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1263,6 +1263,18 @@
           }
         ]
       }
+    },
+    "wonder": {
+      "sha": "e60f8bd908e13ec49b3738f54e1e42d659915286",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "wonder",
+            "description": "http"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds the official **wonder** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `wonder`
- Type: remote source
- Source URL + pinned SHA: https://github.com/aquila-lab/wonder-plugins.git at e60f8bd908e13ec49b3738f54e1e42d659915286, path plugins/wonder
- Homepage: https://wonder.design

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (aquila-lab / Wonder).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with aquila-lab / Wonder; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: MIT

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** https://mcp.wonder.so/mcp — Wonder hosted MCP for reading and writing the user's canvas.

**Credentials/permissions it requires:** OAuth in the browser on first use. No API key is stored in the plugin.

## Notes for reviewers

The source repo is a multi-agent marketplace; the plugin lives at `plugins/wonder` (same shape as browser-use / railway). Manifest is `.claude-plugin/plugin.json`, which CONTRIBUTING accepts. Generated index: HTTP MCP server `wonder`. No hooks, no local binaries.

Install after merge:

```
grok plugin install wonder --trust
```