### PR TITLE
Add Superdesign plugin (UI / canvas skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "superdesign",
+      "description": "Design or redesign frontend UI, presentations, and marketing graphics on the Superdesign infinite canvas. Reads your codebase for design context, then generates branchable drafts you refine.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/superdesigndev/superdesign-skill.git",
+        "sha": "f9f05cd988c247dce6c072eaf9ac6b162f2ffc4b"
+      },
+      "homepage": "https://superdesign.dev",
+      "keywords": ["superdesign", "superdesign.dev"],
+      "domains": ["superdesign.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -865,6 +865,18 @@
         ]
       }
     },
+    "superdesign": {
+      "sha": "f9f05cd988c247dce6c072eaf9ac6b162f2ffc4b",
+      "version": "0.6.0",
+      "components": {
+        "skills": [
+          {
+            "name": "superdesign",
+            "description": "Design or redesign frontend UI, presentations, and graphics on the Superdesign canvas with a choice of leading AI model…"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
       "version": "6.3.0",


### PR DESCRIPTION
## What this PR does

Adds the official **superdesign** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `superdesign`
- Type: remote source
- Source URL + pinned SHA: https://github.com/superdesigndev/superdesign-skill.git at f9f05cd988c247dce6c072eaf9ac6b162f2ffc4b
- Homepage: https://superdesign.dev

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (superdesigndev).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with superdesigndev; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: MIT

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** The skill drives the Superdesign CLI (@superdesign/cli) against superdesign.dev. No MCP server is bundled.

**Credentials/permissions it requires:** User runs `superdesign login` after installing the CLI. No secrets in the plugin repo.

## Notes for reviewers

Official Superdesign skill pack. Generated index: skill `superdesign`, version 0.6.0. No hooks, no MCP.

Install after merge:

```
grok plugin install superdesign --trust
```