### PR TITLE
Add Mobbin plugin (hosted design-reference MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "mobbin",
+      "description": "Search real-world UI and UX design references for mobile apps, web apps, and websites with Mobbin. Hosted MCP server with OAuth; no local install or API key.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mobbin/mobbin-mcp-server.git",
+        "sha": "1b5abb4e0bac75e48229cbeb8000d1032e723310"
+      },
+      "homepage": "https://docs.mobbin.com/mcp",
+      "keywords": ["mobbin", "mobbin mcp"],
+      "domains": ["mobbin.com", "api.mobbin.com", "docs.mobbin.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "mobbin": {
+      "sha": "1b5abb4e0bac75e48229cbeb8000d1032e723310",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mobbin",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds the official **mobbin** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `mobbin`
- Type: remote source
- Source URL + pinned SHA: https://github.com/mobbin/mobbin-mcp-server.git at 1b5abb4e0bac75e48229cbeb8000d1032e723310
- Homepage: https://docs.mobbin.com/mcp

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (mobbin).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with mobbin; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: MIT

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** https://api.mobbin.com/mcp — Mobbin hosted Streamable HTTP MCP server.

**Credentials/permissions it requires:** OAuth in the browser on first use. No API key is stored in the plugin.

## Notes for reviewers

Official Mobbin repo already ships `.grok-plugin/plugin.json`. Generated index: HTTP MCP server `mobbin`, version 1.0.0. No hooks, no local binaries.

Install after merge:

```
grok plugin install mobbin --trust
```