### PR TITLE
Add Todoist plugin (hosted MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "todoist",
+      "description": "Manage Todoist tasks, projects, labels, and workflows from Grok via Doist's hosted MCP server. OAuth on first use; no API key required.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Doist/todoist-mcp.git",
+        "sha": "4e173822d738327503cae6da1e6b269e9e810646"
+      },
+      "homepage": "https://github.com/Doist/todoist-mcp",
+      "keywords": ["todoist"],
+      "domains": ["todoist.com", "ai.todoist.net", "doist.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1015,6 +1015,18 @@
         ]
       }
     },
+    "todoist": {
+      "sha": "4e173822d738327503cae6da1e6b269e9e810646",
+      "version": "13.1.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "todoist",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2",
       "version": "0.48.2",


### PR DESCRIPTION
## What this PR does

Adds the official **todoist** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `todoist`
- Type: remote source
- Source URL + pinned SHA: https://github.com/Doist/todoist-mcp.git at 4e173822d738327503cae6da1e6b269e9e810646
- Homepage: https://github.com/Doist/todoist-mcp

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (Doist).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with Doist; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: MIT

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** https://ai.todoist.net/mcp — Doist hosted Streamable HTTP MCP server.

**Credentials/permissions it requires:** OAuth in the browser on first use. No API key is stored in the plugin.

## Notes for reviewers

Official Doist plugin. Manifest is `.claude-plugin/plugin.json`. Generated index: HTTP MCP server `todoist`, version 13.1.3. No hooks.

Install after merge:

```
grok plugin install todoist --trust
```