### PR TITLE
Add airwallex-agentos plugin (finance workflow skills + MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "airwallex-agentos",
+      "description": "Airwallex AgentOS workflow skills for Billing, Payouts, Issuing, and Treasury. Orchestrate invoices, beneficiaries, cards, and cashflow through the airwallex CLI or Airwallex MCP servers.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/airwallex/airwallex-marketplace.git",
+        "sha": "5cb3dd8b63e5ac873add34191e1994a1475ce145",
+        "path": "plugins/airwallex-agentos"
+      },
+      "homepage": "https://www.airwallex.com/docs/developer-tools/ai/agentos",
+      "keywords": ["airwallex-agentos", "airwallex agentos", "airwallex"],
+      "domains": ["airwallex.com", "www.airwallex.com", "mcp.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,44 @@
 {
   "version": 1,
   "plugins": {
+    "airwallex-agentos": {
+      "sha": "5cb3dd8b63e5ac873add34191e1994a1475ce145",
+      "version": "0.2.4",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airwallex-agentos",
+            "description": "http"
+          },
+          {
+            "name": "airwallex-dev",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "awx-best-practices",
+            "description": "Fallback Airwallex skill — works with the Airwallex CLI or the Airwallex MCP server. Use ONLY when no dedicated workflo…"
+          },
+          {
+            "name": "beneficiary-creation",
+            "description": "Extract bank details from supplier invoices or documents, validate per-country requirements, and create beneficiaries i…"
+          },
+          {
+            "name": "card-provisioning",
+            "description": "Provision virtual or physical corporate cards in Airwallex Issuing — create cardholders, issue cards with spend limits,…"
+          },
+          {
+            "name": "contract-to-billing",
+            "description": "Extract billing details from purchase orders, contracts, or quotes, then set up Airwallex Billing by creating invoices…"
+          },
+          {
+            "name": "manage-cashflow",
+            "description": "Multi-currency cash management — balances, receivables, obligations, FX exposure, runway, rebalancing, and indicative F…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the official **airwallex-agentos** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `airwallex-agentos`
- Type: remote source
- Source URL + pinned SHA: https://github.com/airwallex/airwallex-marketplace.git at 5cb3dd8b63e5ac873add34191e1994a1475ce145, path plugins/airwallex-agentos
- Homepage: https://www.airwallex.com/docs/developer-tools/ai/agentos

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (airwallex).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with airwallex; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: Apache-2.0

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** https://mcp.airwallex.com/mcp (AgentOS) and https://mcp.sandbox.airwallex.com/developer (developer/sandbox, also declared on this plugin).

**Credentials/permissions it requires:** OAuth for MCP, or `airwallex auth login` for the CLI. No secrets in the plugin repo.

## Notes for reviewers

Official Airwallex marketplace already documents Grok install. Skills: contract-to-billing, beneficiary-creation, card-provisioning, manage-cashflow, awx-best-practices. The skills explicitly do not initiate money-out actions. Manifest is `.claude-plugin/plugin.json`.

Install after merge:

```
grok plugin install airwallex-agentos --trust
```