### PR TITLE
Add airwallex-dev plugin (Airwallex integration codegen skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "airwallex-dev",
+      "description": "Airwallex developer skills that generate production-ready integration code: Hosted Payment Page, Drop-in and Split Card Elements, billing checkout, and connected-account KYC.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/airwallex/airwallex-marketplace.git",
+        "sha": "5cb3dd8b63e5ac873add34191e1994a1475ce145",
+        "path": "plugins/airwallex-dev"
+      },
+      "homepage": "https://www.airwallex.com/docs/developer-tools/ai/developer-connector",
+      "keywords": ["airwallex-dev", "airwallex"],
+      "domains": ["airwallex.com", "www.airwallex.com", "mcp.sandbox.airwallex.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,44 @@
 {
   "version": 1,
   "plugins": {
+    "airwallex-dev": {
+      "sha": "5cb3dd8b63e5ac873add34191e1994a1475ce145",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "airwallex-dev",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "airwallex-ai-provider-card-mit",
+            "description": "Use this skill to guide an end-to-end implementation plan document for card-only Airwallex Payments flows used by AI pr…"
+          },
+          {
+            "name": "airwallex-billing-checkout",
+            "description": "Guide integration of Airwallex Billing Hosted Checkout for subscription, one-off payment (PAYMENT), and card-saving (SE…"
+          },
+          {
+            "name": "airwallex-dropin",
+            "description": "Generate Airwallex Drop-in Element integration code. Use when user mentions Drop-in, dropIn element, embedded payment U…"
+          },
+          {
+            "name": "airwallex-hpp",
+            "description": "Generate Airwallex Hosted Payment Page (HPP) integration code. Use when user mentions HPP, hosted payment page, redirec…"
+          },
+          {
+            "name": "airwallex-kyc",
+            "description": "Generate Airwallex Connected Account KYC onboarding integration code. Use when user mentions KYC, embedded KYC element,…"
+          },
+          {
+            "name": "airwallex-split-card",
+            "description": "Generate Airwallex Split Card Element integration code. Use when user mentions Split Card, cardNumber element, expiry/c…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the official **airwallex-dev** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `airwallex-dev`
- Type: remote source
- Source URL + pinned SHA: https://github.com/airwallex/airwallex-marketplace.git at 5cb3dd8b63e5ac873add34191e1994a1475ce145, path plugins/airwallex-dev
- Homepage: https://www.airwallex.com/docs/developer-tools/ai/developer-connector

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (airwallex).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with airwallex; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: Apache-2.0

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** https://mcp.sandbox.airwallex.com/developer — Airwallex Developer MCP (docs + sandbox).

**Credentials/permissions it requires:** OAuth / sandbox credentials. No secrets in the plugin repo.

## Notes for reviewers

Official Airwallex developer plugin. Skills generate Hosted Payment Page, Drop-in, Split Card, billing checkout, KYC, and an MIT card-on-file plan. Manifest is `.claude-plugin/plugin.json`. No hooks.

Install after merge:

```
grok plugin install airwallex-dev --trust
```