### PR TITLE
Add cursor-supermemory plugin (persistent memory via Supermemory)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "cursor-supermemory",
+      "description": "Persistent AI memory for coding agents, powered by Supermemory. Recall project context across sessions, save durable facts, and search memories via MCP tools.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/supermemoryai/cursor-supermemory.git",
+        "sha": "0abb19f5f53a55486e5d36a4f90b2fcaa5c7a4ac"
+      },
+      "homepage": "https://supermemory.ai",
+      "keywords": ["cursor-supermemory", "supermemory"],
+      "domains": ["supermemory.ai", "app.supermemory.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,71 @@
         ]
       }
     },
+    "cursor-supermemory": {
+      "sha": "0abb19f5f53a55486e5d36a4f90b2fcaa5c7a4ac",
+      "components": {
+        "agents": [
+          {
+            "name": "supermemory-context-gatherer",
+            "description": "Gather deep background from Supermemory before substantial work, resuming old work, or investigating repository history."
+          }
+        ],
+        "commands": [
+          {
+            "name": "supermemory-config",
+            "description": "Configure Supermemory settings for this project"
+          },
+          {
+            "name": "supermemory-logout",
+            "description": "Disconnect Supermemory from Cursor"
+          },
+          {
+            "name": "supermemory-setup",
+            "description": "Connect Supermemory to Cursor for persistent AI memory"
+          },
+          {
+            "name": "supermemory-status",
+            "description": "Check Supermemory authentication and live connectivity"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "beforeSubmitPrompt",
+            "description": "UserPromptSubmit"
+          },
+          {
+            "name": "postToolUse"
+          },
+          {
+            "name": "preToolUse",
+            "description": "MCP:.*supermemory.*|supermemory_.*"
+          },
+          {
+            "name": "sessionEnd"
+          },
+          {
+            "name": "sessionStart"
+          },
+          {
+            "name": "stop"
+          }
+        ],
+        "skills": [
+          {
+            "name": "memory-init",
+            "description": "Deep codebase exploration to initialize project memory. Use when starting work on a new project or when user asks to \"i…"
+          },
+          {
+            "name": "memory-save",
+            "description": "Save important information to persistent memory. Use when user explicitly asks to remember something, or when you've so…"
+          },
+          {
+            "name": "memory-search",
+            "description": "Search persistent memory for relevant information from past coding sessions. Use when user asks about previous work, pa…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",


### PR DESCRIPTION
## What this PR does

Adds the official **cursor-supermemory** plugin to the xAI plugin marketplace as a remote-source catalog entry. No plugin code is vendored here.

- Plugin name: `cursor-supermemory`
- Type: remote source
- Source URL + pinned SHA: https://github.com/supermemoryai/cursor-supermemory.git at 0abb19f5f53a55486e5d36a4f90b2fcaa5c7a4ac
- Homepage: https://supermemory.ai

## Ownership

- [ ] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under the official org (supermemoryai).

This is a catalog index PR pointing at the vendor's official public repository. I am not affiliated with supermemoryai; the listing is sourced from that org's public plugin so Grok Build users can install it from the official marketplace.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`; the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally (generated from the full catalog, then this PR keeps only this plugin's index key).
- [x] `homepage` + clear `description` set; keywords/domains are brand-scoped.
- [x] License is stated: MIT

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the catalog entry.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars in the catalog entry.
- [x] MCP/hooks scope is whatever the upstream plugin ships — see notes.

**Network endpoints this plugin calls:** Supermemory API via the plugin's bundled Node CLI. MCP is stdio: node ${CURSOR_PLUGIN_ROOT}/dist/cli.js mcp.

**Credentials/permissions it requires:** `node dist/cli.js login` or SUPERMEMORY_API_KEY. Tokens live in user config, not in the plugin repo.

## Notes for reviewers

Official Supermemory Cursor plugin. Ships skills (memory-init/save/search), commands, an agent, and lifecycle hooks (sessionStart/sessionEnd/preToolUse/postToolUse/beforeSubmitPrompt/stop) that run the bundled dist/ with Node. No .grok-plugin/.claude-plugin manifest — only .cursor-plugin/plugin.json — so the generated index records directory-scanned components but not the MCP server in mcp.json. Reviewers should treat the hooks as code that runs on the user's machine.

Install after merge:

```
grok plugin install cursor-supermemory --trust
```