### PR TITLE
Add flightclaw plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "flightclaw",
+      "description": "Flight search, price tracking and booking. Search Google Flights, watch a route and get an alert when the fare drops, then book and pay through Duffel. Remembers travellers, companions, loyalty programmes, cards and cabin preferences, so options come back ranked for the person asking.",
+      "category": "travel",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/jackculpan/flightclaw.git",
+        "sha": "8866fc070549eb137bcc43911ca7d2b422a84b68"
+      },
+      "homepage": "https://flightclaw.com",
+      "keywords": ["flightclaw", "flight claw", "flightclaw track"],
+      "domains": ["flightclaw.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/jackculpan/flightclaw.git",
-        "sha": "8866fc070549eb137bcc43911ca7d2b422a84b68"
+        "sha": "bc90b58dd385302d6cdc5c1426d041c1b16ae9ab"
       },
       "homepage": "https://flightclaw.com",
       "keywords": ["flightclaw", "flight claw", "flightclaw track"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "flightclaw": {
+      "sha": "8866fc070549eb137bcc43911ca7d2b422a84b68",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "flightclaw",
+            "description": "stdio"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "flightclaw": {
-      "sha": "8866fc070549eb137bcc43911ca7d2b422a84b68",
+      "sha": "bc90b58dd385302d6cdc5c1426d041c1b16ae9ab",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds one new entry: **flightclaw** — flight search, price tracking and booking over MCP. Search Google Flights, watch a route and get an alert when the fare drops, then book and pay through Duffel. It remembers travellers, companions, loyalty programmes, cards and cabin preferences, so options come back ranked for the person asking.

- Plugin name: `flightclaw`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/jackculpan/flightclaw.git` @ `8866fc070549eb137bcc43911ca7d2b422a84b68`
- Homepage: https://flightclaw.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (see notes below).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable on `master`.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated: MIT (`LICENSE` in the source repo, and `license` in `.grok-plugin/plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. Nothing runs at install time. The connector launches `server.py` through `uv run`, which resolves pinned dependencies at start-up.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or env vars. The server reads only its own `FLIGHTCLAW_*` and `KIWI_*` variables.
- [x] Hooks and MCP scope are least-privilege. The plugin ships one stdio MCP server and no hooks, no commands, no agents.

**Network endpoints this plugin calls (and why):**

| Endpoint | Purpose |
|---|---|
| `google.com/travel/flights` (via the `fli` library) | Flight search and price tracking |
| The private flightclaw-api Worker at `FLIGHTCLAW_API_URL` | Traveller profiles, preferences, cards, groups, trip history, Duffel booking and Link virtual-card payment |
| `api.tequila.kiwi.com`, with hand-off links to `kiwi.com` and `skyscanner.net` | Optional bookability check |

**Credentials/permissions it requires (and why):**

Search and price tracking need **no credentials at all**. Everything else stays inactive until the user sets the variable:

| Variable | Effect when unset |
|---|---|
| `FLIGHTCLAW_API_URL`, `FLIGHTCLAW_API_KEY` | Profile, booking and payment tools report "not configured" |
| `KIWI_API_KEY`, `KIWI_AFFILID` | Kiwi coverage is skipped |

The full table is in the source repo's [README](https://github.com/jackculpan/flightclaw#what-the-connector-reaches-and-what-it-needs). Price history is written only to the plugin's own `data/` directory.

## Notes for reviewers

**On the personal-account source:** flightclaw is a solo open-source project, not a company product. `jackculpan/flightclaw` *is* the first-party home of the brand — the same account owns https://flightclaw.com, which the manifest and the catalog entry both point at. There is no org to move it under.

**Category:** I used `travel`, which is new to the catalog. Happy to fold it into an existing category if you would rather not add one.

**Verified before submitting:** the server starts over stdio through the exact `.mcp.json` command and lists 32 tools (`search_flights`, `search_dates`, `track_flight`, `check_prices`, `recommend_flights`, `book_flight`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)