### PR TITLE
Add vibewatch plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,8 +15,14 @@
         "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
-      "domains": ["vercel.com"]
+      "keywords": [
+        "vercel",
+        "vercel deploy",
+        "deploy to vercel"
+      ],
+      "domains": [
+        "vercel.com"
+      ]
     },
     {
       "name": "sentry",
@@ -28,8 +34,12 @@
         "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": ["sentry"],
-      "domains": ["sentry.io"]
+      "keywords": [
+        "sentry"
+      ],
+      "domains": [
+        "sentry.io"
+      ]
     },
     {
       "name": "chrome-devtools",
@@ -41,7 +51,11 @@
         "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
+      "keywords": [
+        "chrome devtools",
+        "chrome-devtools",
+        "devtools mcp"
+      ]
     },
     {
       "name": "cloudflare",
@@ -53,8 +67,14 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
-      "domains": ["cloudflare.com"]
+      "keywords": [
+        "cloudflare",
+        "wrangler",
+        "cloudflare workers"
+      ],
+      "domains": [
+        "cloudflare.com"
+      ]
     },
     {
       "name": "superpowers",
@@ -66,7 +86,9 @@
         "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": ["superpowers"]
+      "keywords": [
+        "superpowers"
+      ]
     },
     {
       "name": "base44",
@@ -78,8 +100,17 @@
         "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
-      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
-      "domains": ["base44.com", "docs.base44.com"]
+      "keywords": [
+        "base44",
+        "base44 cli",
+        "base44 sdk",
+        "base44 app",
+        "base44 deploy"
+      ],
+      "domains": [
+        "base44.com",
+        "docs.base44.com"
+      ]
     },
     {
       "name": "mongodb",
@@ -92,8 +123,16 @@
         "path": "plugins/mongodb"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
-      "domains": ["mongodb.com"]
+      "keywords": [
+        "mongodb community",
+        "mongo",
+        "mongosh",
+        "mongodb local mcp",
+        "enterprise advanced"
+      ],
+      "domains": [
+        "mongodb.com"
+      ]
     },
     {
       "name": "mongodb-atlas",
@@ -106,8 +145,17 @@
         "path": "plugins/mongodb-atlas"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
-      "domains": ["mongodb.com", "cloud.mongodb.com"]
+      "keywords": [
+        "mongodb atlas",
+        "atlas",
+        "mongodb",
+        "atlas cluster",
+        "atlas mcp"
+      ],
+      "domains": [
+        "mongodb.com",
+        "cloud.mongodb.com"
+      ]
     },
     {
       "name": "axiom",
@@ -119,8 +167,13 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": ["axiom"],
-      "domains": ["axiom.co", "app.axiom.co"]
+      "keywords": [
+        "axiom"
+      ],
+      "domains": [
+        "axiom.co",
+        "app.axiom.co"
+      ]
     },
     {
       "name": "neon",
@@ -131,8 +184,17 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
-      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
+      "keywords": [
+        "neon",
+        "neon postgres",
+        "neon database",
+        "neon branch"
+      ],
+      "domains": [
+        "neon.tech",
+        "neon.com",
+        "console.neon.tech"
+      ]
     },
     {
       "name": "wix",
@@ -144,8 +206,18 @@
         "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
       },
       "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
-      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
+      "keywords": [
+        "wix",
+        "wix cli",
+        "wix mcp",
+        "wix apps",
+        "wix headless"
+      ],
+      "domains": [
+        "wix.com",
+        "dev.wix.com",
+        "manage.wix.com"
+      ]
     },
     {
       "name": "netlify",
@@ -157,12 +229,19 @@
         "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
       },
       "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
-      "domains": ["netlify.com", "app.netlify.com"]
+      "keywords": [
+        "netlify",
+        "netlify deploy",
+        "deploy to netlify"
+      ],
+      "domains": [
+        "netlify.com",
+        "app.netlify.com"
+      ]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -170,8 +249,14 @@
         "sha": "7100b62d09a40673fe1688175431b1baff7ed262"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": ["firecrawl", "fire crawl"],
-      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
+      "keywords": [
+        "firecrawl",
+        "fire crawl"
+      ],
+      "domains": [
+        "firecrawl.dev",
+        "docs.firecrawl.dev"
+      ]
     },
     {
       "name": "figma",
@@ -183,8 +268,14 @@
         "sha": "ae7e5e5f80da20f1dd7445e0c6ae5ac58a5b0bce"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": ["figma", "figma mcp"],
-      "domains": ["figma.com", "www.figma.com"]
+      "keywords": [
+        "figma",
+        "figma mcp"
+      ],
+      "domains": [
+        "figma.com",
+        "www.figma.com"
+      ]
     },
     {
       "name": "exa",
@@ -196,8 +287,16 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": ["exa", "exa search", "exa ai"],
-      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
+      "keywords": [
+        "exa",
+        "exa search",
+        "exa ai"
+      ],
+      "domains": [
+        "exa.ai",
+        "dashboard.exa.ai",
+        "docs.exa.ai"
+      ]
     },
     {
       "name": "tavily",
@@ -209,8 +308,17 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": ["tavily", "tavily search", "tavily ai"],
-      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
+      "keywords": [
+        "tavily",
+        "tavily search",
+        "tavily ai"
+      ],
+      "domains": [
+        "tavily.com",
+        "www.tavily.com",
+        "app.tavily.com",
+        "docs.tavily.com"
+      ]
     },
     {
       "name": "railway",
@@ -223,8 +331,15 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": ["railway", "railway deploy", "deploy to railway"],
-      "domains": ["railway.com", "railway.app"]
+      "keywords": [
+        "railway",
+        "railway deploy",
+        "deploy to railway"
+      ],
+      "domains": [
+        "railway.com",
+        "railway.app"
+      ]
     },
     {
       "name": "stripe",
@@ -237,12 +352,22 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
-      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
+      "keywords": [
+        "stripe",
+        "stripe payments",
+        "stripe connect",
+        "stripe mcp",
+        "stripe billing"
+      ],
+      "domains": [
+        "stripe.com",
+        "docs.stripe.com",
+        "dashboard.stripe.com"
+      ]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -251,8 +376,17 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
-      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
+      "keywords": [
+        "tinyfish",
+        "tinyfish agent",
+        "tinyfish web agent",
+        "agentql"
+      ],
+      "domains": [
+        "tinyfish.ai",
+        "agent.tinyfish.ai",
+        "docs.tinyfish.ai"
+      ]
     },
     {
       "name": "pstack",
@@ -265,11 +399,15 @@
         "path": "pstack"
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": ["pstack", "poteto-mode", "poteto"]
+      "keywords": [
+        "pstack",
+        "poteto-mode",
+        "poteto"
+      ]
     },
     {
       "name": "browser-use",
-      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",
       "source": {
         "source": "url",
@@ -278,8 +416,36 @@
         "path": "grok"
       },
       "homepage": "https://browser-use.com",
-      "keywords": ["browser use", "browser-use", "browser use cloud"],
-      "domains": ["browser-use.com", "cloud.browser-use.com"]
+      "keywords": [
+        "browser use",
+        "browser-use",
+        "browser use cloud"
+      ],
+      "domains": [
+        "browser-use.com",
+        "cloud.browser-use.com"
+      ]
+    },
+    {
+      "name": "vibewatch",
+      "description": "Give Grok access to your community's vibe. Vibewatch is community intelligence for web3 teams; this plugin connects Grok to your Vibewatch organization through the hosted Vibewatch MCP server \u2014 sentiment overview, daily trend, message search, daily insights, weekly reports, market context, and the public Stacks ecosystem index, all read-only. Sign in with your Vibewatch account.",
+      "category": "analytics",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Vibewatch-io/vibewatch-mcp.git",
+        "sha": "1d486d4d4e5614e276009bea310d517e4505282f",
+        "path": "plugins/vibewatch"
+      },
+      "homepage": "https://vibewatch.io",
+      "keywords": [
+        "vibewatch",
+        "vibewatch mcp",
+        "vibe watch"
+      ],
+      "domains": [
+        "vibewatch.io",
+        "app.vibewatch.io"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -15,14 +15,8 @@
         "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2"
       },
       "homepage": "https://github.com/vercel/vercel-plugin",
-      "keywords": [
-        "vercel",
-        "vercel deploy",
-        "deploy to vercel"
-      ],
-      "domains": [
-        "vercel.com"
-      ]
+      "keywords": ["vercel", "vercel deploy", "deploy to vercel"],
+      "domains": ["vercel.com"]
     },
     {
       "name": "sentry",
@@ -34,12 +28,8 @@
         "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5"
       },
       "homepage": "https://github.com/getsentry/sentry-for-ai",
-      "keywords": [
-        "sentry"
-      ],
-      "domains": [
-        "sentry.io"
-      ]
+      "keywords": ["sentry"],
+      "domains": ["sentry.io"]
     },
     {
       "name": "chrome-devtools",
@@ -51,11 +41,7 @@
         "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3"
       },
       "homepage": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-      "keywords": [
-        "chrome devtools",
-        "chrome-devtools",
-        "devtools mcp"
-      ]
+      "keywords": ["chrome devtools", "chrome-devtools", "devtools mcp"]
     },
     {
       "name": "cloudflare",
@@ -67,14 +53,8 @@
         "sha": "60147cbb773649eadca89cee92b4e0caf02234b4"
       },
       "homepage": "https://github.com/cloudflare/skills",
-      "keywords": [
-        "cloudflare",
-        "wrangler",
-        "cloudflare workers"
-      ],
-      "domains": [
-        "cloudflare.com"
-      ]
+      "keywords": ["cloudflare", "wrangler", "cloudflare workers"],
+      "domains": ["cloudflare.com"]
     },
     {
       "name": "superpowers",
@@ -86,9 +66,7 @@
         "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797"
       },
       "homepage": "https://github.com/obra/superpowers",
-      "keywords": [
-        "superpowers"
-      ]
+      "keywords": ["superpowers"]
     },
     {
       "name": "base44",
@@ -100,17 +78,8 @@
         "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14"
       },
       "homepage": "https://docs.base44.com",
-      "keywords": [
-        "base44",
-        "base44 cli",
-        "base44 sdk",
-        "base44 app",
-        "base44 deploy"
-      ],
-      "domains": [
-        "base44.com",
-        "docs.base44.com"
-      ]
+      "keywords": ["base44", "base44 cli", "base44 sdk", "base44 app", "base44 deploy"],
+      "domains": ["base44.com", "docs.base44.com"]
     },
     {
       "name": "mongodb",
@@ -123,16 +92,8 @@
         "path": "plugins/mongodb"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": [
-        "mongodb community",
-        "mongo",
-        "mongosh",
-        "mongodb local mcp",
-        "enterprise advanced"
-      ],
-      "domains": [
-        "mongodb.com"
-      ]
+      "keywords": ["mongodb community", "mongo", "mongosh", "mongodb local mcp", "enterprise advanced"],
+      "domains": ["mongodb.com"]
     },
     {
       "name": "mongodb-atlas",
@@ -145,17 +106,8 @@
         "path": "plugins/mongodb-atlas"
       },
       "homepage": "https://www.mongodb.com/docs/mcp-server/get-started/",
-      "keywords": [
-        "mongodb atlas",
-        "atlas",
-        "mongodb",
-        "atlas cluster",
-        "atlas mcp"
-      ],
-      "domains": [
-        "mongodb.com",
-        "cloud.mongodb.com"
-      ]
+      "keywords": ["mongodb atlas", "atlas", "mongodb", "atlas cluster", "atlas mcp"],
+      "domains": ["mongodb.com", "cloud.mongodb.com"]
     },
     {
       "name": "axiom",
@@ -167,13 +119,8 @@
         "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d"
       },
       "homepage": "https://github.com/axiomhq/skills",
-      "keywords": [
-        "axiom"
-      ],
-      "domains": [
-        "axiom.co",
-        "app.axiom.co"
-      ]
+      "keywords": ["axiom"],
+      "domains": ["axiom.co", "app.axiom.co"]
     },
     {
       "name": "neon",
@@ -184,17 +131,8 @@
         "path": "./external_plugins/neon"
       },
       "homepage": "https://neon.com",
-      "keywords": [
-        "neon",
-        "neon postgres",
-        "neon database",
-        "neon branch"
-      ],
-      "domains": [
-        "neon.tech",
-        "neon.com",
-        "console.neon.tech"
-      ]
+      "keywords": ["neon", "neon postgres", "neon database", "neon branch"],
+      "domains": ["neon.tech", "neon.com", "console.neon.tech"]
     },
     {
       "name": "wix",
@@ -206,18 +144,8 @@
         "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e"
       },
       "homepage": "https://dev.wix.com/docs/api-reference/articles/ai-tools/about-wix-skills",
-      "keywords": [
-        "wix",
-        "wix cli",
-        "wix mcp",
-        "wix apps",
-        "wix headless"
-      ],
-      "domains": [
-        "wix.com",
-        "dev.wix.com",
-        "manage.wix.com"
-      ]
+      "keywords": ["wix", "wix cli", "wix mcp", "wix apps", "wix headless"],
+      "domains": ["wix.com", "dev.wix.com", "manage.wix.com"]
     },
     {
       "name": "netlify",
@@ -229,19 +157,12 @@
         "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c"
       },
       "homepage": "https://github.com/netlify/context-and-tools",
-      "keywords": [
-        "netlify",
-        "netlify deploy",
-        "deploy to netlify"
-      ],
-      "domains": [
-        "netlify.com",
-        "app.netlify.com"
-      ]
+      "keywords": ["netlify", "netlify deploy", "deploy to netlify"],
+      "domains": ["netlify.com", "app.netlify.com"]
     },
     {
       "name": "firecrawl",
-      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server \u2014 keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
+      "description": "Turn any website into clean, LLM-ready markdown or structured data. Search, scrape, map, crawl, and extract live web data via the bundled hosted Firecrawl MCP server — keyless on eligible networks (1,000 free credits/month, no signup), with an optional free API key for more usage. Automatic JS rendering, anti-bot handling, and proxy rotation; CLI skills available as a fallback.",
       "category": "development",
       "source": {
         "source": "url",
@@ -249,14 +170,8 @@
         "sha": "7100b62d09a40673fe1688175431b1baff7ed262"
       },
       "homepage": "https://github.com/firecrawl/firecrawl-grok-plugin",
-      "keywords": [
-        "firecrawl",
-        "fire crawl"
-      ],
-      "domains": [
-        "firecrawl.dev",
-        "docs.firecrawl.dev"
-      ]
+      "keywords": ["firecrawl", "fire crawl"],
+      "domains": ["firecrawl.dev", "docs.firecrawl.dev"]
     },
     {
       "name": "figma",
@@ -268,14 +183,8 @@
         "sha": "ae7e5e5f80da20f1dd7445e0c6ae5ac58a5b0bce"
       },
       "homepage": "https://github.com/figma/mcp-server-guide",
-      "keywords": [
-        "figma",
-        "figma mcp"
-      ],
-      "domains": [
-        "figma.com",
-        "www.figma.com"
-      ]
+      "keywords": ["figma", "figma mcp"],
+      "domains": ["figma.com", "www.figma.com"]
     },
     {
       "name": "exa",
@@ -287,16 +196,8 @@
         "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8"
       },
       "homepage": "https://exa.ai",
-      "keywords": [
-        "exa",
-        "exa search",
-        "exa ai"
-      ],
-      "domains": [
-        "exa.ai",
-        "dashboard.exa.ai",
-        "docs.exa.ai"
-      ]
+      "keywords": ["exa", "exa search", "exa ai"],
+      "domains": ["exa.ai", "dashboard.exa.ai", "docs.exa.ai"]
     },
     {
       "name": "tavily",
@@ -308,17 +209,8 @@
         "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d"
       },
       "homepage": "https://www.tavily.com",
-      "keywords": [
-        "tavily",
-        "tavily search",
-        "tavily ai"
-      ],
-      "domains": [
-        "tavily.com",
-        "www.tavily.com",
-        "app.tavily.com",
-        "docs.tavily.com"
-      ]
+      "keywords": ["tavily", "tavily search", "tavily ai"],
+      "domains": ["tavily.com", "www.tavily.com", "app.tavily.com", "docs.tavily.com"]
     },
     {
       "name": "railway",
@@ -331,15 +223,8 @@
         "path": "plugins/railway"
       },
       "homepage": "https://github.com/railwayapp/railway-skills",
-      "keywords": [
-        "railway",
-        "railway deploy",
-        "deploy to railway"
-      ],
-      "domains": [
-        "railway.com",
-        "railway.app"
-      ]
+      "keywords": ["railway", "railway deploy", "deploy to railway"],
+      "domains": ["railway.com", "railway.app"]
     },
     {
       "name": "stripe",
@@ -352,22 +237,12 @@
         "path": "providers/grok/plugin"
       },
       "homepage": "https://github.com/stripe/ai",
-      "keywords": [
-        "stripe",
-        "stripe payments",
-        "stripe connect",
-        "stripe mcp",
-        "stripe billing"
-      ],
-      "domains": [
-        "stripe.com",
-        "docs.stripe.com",
-        "dashboard.stripe.com"
-      ]
+      "keywords": ["stripe", "stripe payments", "stripe connect", "stripe mcp", "stripe billing"],
+      "domains": ["stripe.com", "docs.stripe.com", "dashboard.stripe.com"]
     },
     {
       "name": "tinyfish",
-      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites \u2014 including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
+      "description": "Web search, content extraction, and goal-driven browser automation via TinyFish's hosted MCP server. Search and fetch pages for free, then drive real multi-step workflows on live sites — including authenticated ones, using saved Browser Context Profiles and password-manager credentials. Sign in with your TinyFish account on first connection; no API key needed.",
       "category": "development",
       "source": {
         "source": "url",
@@ -376,17 +251,8 @@
         "path": "grok"
       },
       "homepage": "https://www.tinyfish.ai",
-      "keywords": [
-        "tinyfish",
-        "tinyfish agent",
-        "tinyfish web agent",
-        "agentql"
-      ],
-      "domains": [
-        "tinyfish.ai",
-        "agent.tinyfish.ai",
-        "docs.tinyfish.ai"
-      ]
+      "keywords": ["tinyfish", "tinyfish agent", "tinyfish web agent", "agentql"],
+      "domains": ["tinyfish.ai", "agent.tinyfish.ai", "docs.tinyfish.ai"]
     },
     {
       "name": "pstack",
@@ -399,15 +265,11 @@
         "path": "pstack"
       },
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
-      "keywords": [
-        "pstack",
-        "poteto-mode",
-        "poteto"
-      ]
+      "keywords": ["pstack", "poteto-mode", "poteto"]
     },
     {
       "name": "browser-use",
-      "description": "Give Grok a real browser \u2014 the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
+      "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
       "category": "development",
       "source": {
         "source": "url",
@@ -416,19 +278,12 @@
         "path": "grok"
       },
       "homepage": "https://browser-use.com",
-      "keywords": [
-        "browser use",
-        "browser-use",
-        "browser use cloud"
-      ],
-      "domains": [
-        "browser-use.com",
-        "cloud.browser-use.com"
-      ]
+      "keywords": ["browser use", "browser-use", "browser use cloud"],
+      "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
     {
       "name": "vibewatch",
-      "description": "Give Grok access to your community's vibe. Vibewatch is community intelligence for web3 teams; this plugin connects Grok to your Vibewatch organization through the hosted Vibewatch MCP server \u2014 sentiment overview, daily trend, message search, daily insights, weekly reports, market context, and the public Stacks ecosystem index, all read-only. Sign in with your Vibewatch account.",
+      "description": "Give Grok access to your community's vibe. Vibewatch is community intelligence for web3 teams; this plugin connects Grok to your Vibewatch organization through the hosted Vibewatch MCP server — sentiment overview, daily trend, message search, daily insights, weekly reports, market context, and the public Stacks ecosystem index, all read-only. Sign in with your Vibewatch account.",
       "category": "analytics",
       "source": {
         "source": "url",
@@ -437,15 +292,8 @@
         "path": "plugins/vibewatch"
       },
       "homepage": "https://vibewatch.io",
-      "keywords": [
-        "vibewatch",
-        "vibewatch mcp",
-        "vibe watch"
-      ],
-      "domains": [
-        "vibewatch.io",
-        "app.vibewatch.io"
-      ]
+      "keywords": ["vibewatch", "vibewatch mcp", "vibe watch"],
+      "domains": ["vibewatch.io", "app.vibewatch.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1214,6 +1214,24 @@
         ]
       }
     },
+    "vibewatch": {
+      "sha": "1d486d4d4e5614e276009bea310d517e4505282f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "vibewatch",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "use-vibewatch",
+            "description": "Read a community's vibe from Vibewatch: current sentiment, the trend over time, the messages behind a score, daily insi…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e",
       "version": "1.17.0",


### PR DESCRIPTION
## What this PR does

Adds the Vibewatch plugin (new plugin, remote source).

- Plugin name: vibewatch
- Type: remote source
- Source URL + pinned SHA: https://github.com/Vibewatch-io/vibewatch-mcp.git @ `1d486d4d4e5614e276009bea310d517e4505282f`, path `plugins/vibewatch`
- Homepage: https://vibewatch.io

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (Vibewatch-io).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (Apache-2.0).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://api.vibewatch.io/mcp/` only — the hosted Vibewatch MCP server the plugin exists to connect. Eight read-only tools (all annotated `readOnlyHint`), no write surface. Also declared in the repo README.
- Credentials/permissions it requires (and why): standard MCP OAuth sign-in against the server (browser consent, org-scoped, read-only). The plugin ships no credentials, no hooks, and no scripts — manifests, one skill, and a logo.

## Notes for reviewers

Vibewatch (vibewatch.io) is a community-sentiment product for web3 teams; this plugin is our official packaging, sourced from our org. The connection path was verified against Grok Bot before this submission: custom-connector add of the same server URL completed OAuth dynamic client registration, browser consent, token exchange, tool discovery, and live tool calls. The plugin repo layout follows railwayapp/railway-skills.
