### PR TITLE
Add Omneky hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "omneky",
+      "description": "Omneky ads, analytics, product catalogue, and creative generation. Sign in with an Omneky account to launch and manage campaigns from Grok.",
+      "category": "development",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/omneky"
+      },
+      "homepage": "https://www.omneky.com",
+      "keywords": ["omneky", "omneky ads", "omneky mcp"],
+      "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,17 @@
         ]
       }
     },
+    "omneky": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "omneky",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "efa2a531985e0a8084d36ff3cf87233be8a9f34b",
       "components": {

--- a/external_plugins/omneky/.grok-plugin/plugin.json
+++ b/external_plugins/omneky/.grok-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "omneky",
+  "version": "1.0.0",
+  "description": "Omneky ads, analytics, product catalogue, and creative generation via the hosted MCP at mcp.omneky.com. Sign in with an Omneky account on first connect.",
+  "author": {
+    "name": "Omneky",
+    "url": "https://github.com/omneky-org"
+  },
+  "homepage": "https://www.omneky.com",
+  "license": "Proprietary",
+  "keywords": [
+    "omneky",
+    "omneky ads",
+    "omneky mcp"
+  ]
+}

--- a/external_plugins/omneky/.mcp.json
+++ b/external_plugins/omneky/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "omneky": {
+      "type": "http",
+      "url": "https://mcp.omneky.com/mcp"
+    }
+  }
+}

--- a/external_plugins/omneky/README.md
+++ b/external_plugins/omneky/README.md
@@ -1,0 +1,30 @@
+# Omneky plugin for Grok Build
+
+Connect Grok Build to [Omneky](https://www.omneky.com) — ads analytics, product
+catalogue, multi-channel launch, and creative generation.
+
+## Installation
+
+In Grok Build, open `/plugin`, search for **Omneky**, and install.
+
+On first connection, Grok opens Omneky sign-in in the browser. Use an Omneky
+account (email/password or Google). Do not paste an API key or JWT into chat.
+
+## Authentication
+
+The plugin connects only to `https://mcp.omneky.com/mcp`. Authentication is
+OAuth 2.1 against that host.
+
+Network endpoints:
+
+- `https://mcp.omneky.com/mcp` — hosted MCP (streamable HTTP)
+- `https://mcp.omneky.com/authorize`, `/token`, `/register` — OAuth 2.1 + DCR
+- `https://cgp.omneky.com/login` — human sign-in (password / Google)
+
+Credentials: an Omneky account. The access token is an Omneky Nexus JWT used as
+`Authorization: Bearer` on `/mcp`. No API key is stored in the plugin. Tools
+are scoped to brands the signed-in user can access.
+
+## License
+
+Proprietary. Use of the hosted MCP is governed by Omneky's terms.


### PR DESCRIPTION
<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

Adds the Omneky plugin so Grok Build can connect to Omneky's hosted MCP.

- Plugin name: `omneky`
- Type: local (`external_plugins`)
- Source URL + pinned SHA (remote), or vendored path (local): `./external_plugins/omneky`
- Homepage: https://www.omneky.com

The plugin is an HTTP MCP pointer at `https://mcp.omneky.com/mcp`. On install, Grok runs Omneky's OAuth 2.1 flow (dynamic client registration + browser sign-in). No API key, no local process, no server source.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Vendored under `external_plugins/omneky/` from Omneky (`omneky-org`). We do not remote-source our MCP server repo — that repo is private and is not what Grok should clone.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [ ] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable. *(n/a — local source)*
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.omneky.com/mcp` — hosted MCP (streamable HTTP)
  - `https://mcp.omneky.com/authorize`, `/token`, `/register` — OAuth 2.1 + DCR (discovered via `/.well-known/oauth-authorization-server`)
  - `https://cgp.omneky.com/login` — human sign-in (password / Google), then resume on mcp.omneky.com
- Credentials/permissions it requires (and why):
  - Omneky account via browser OAuth. The access token is an Omneky Nexus JWT used as `Authorization: Bearer` on `/mcp`. No API key in the plugin. Tools are scoped to brands the signed-in user can access.

## Notes for reviewers

Omneky is an ads platform (analytics, product catalogue, multi-channel launch, creative generation). Official org: https://github.com/omneky-org. Product: https://www.omneky.com.

This listing is the same hosted MCP already used by Claude / ChatGPT, at the full `/mcp` surface. We are not submitting `/mcp-claude` (that path exists only for Anthropic's Connector Directory review).

Keywords are brand-scoped (`omneky`, `omneky ads`, `omneky mcp`) so the plugin CTA does not fire on generic “ads” / “mcp” prompts.