### PR TITLE
Add Ranla plugin for Grok Build

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "ranla",
+      "description": "Official Ranla plugin for Grok Build. Connect your Ranla workspace to instrument lifecycle events, inspect audience and campaigns, talk to Ranla, and approve growth work via hosted MCP with browser OAuth.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Super-Send/ranla-grok-plugin.git",
+        "sha": "93c2bbba3bd6d46a96ce6a18b2133e78fd1fd8ff"
+      },
+      "homepage": "https://ranla.ai",
+      "keywords": ["ranla", "ranla mcp", "ranla email", "ranla campaigns"],
+      "domains": ["ranla.ai", "app.ranla.ai", "docs.ranla.ai", "mcp.ranla.ai"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,15 +283,15 @@
     },
     {
       "name": "ranla",
-      "description": "Official Ranla plugin for Grok Build. Transactional email — send, domains, templates, webhooks, and deliverability — plus a growth agent for lifecycle events, audience, and campaigns. Hosted MCP with browser OAuth.",
+      "description": "Official Ranla plugin for Grok Build. An AI growth agent for the signups you already have — instrument lifecycle events, inspect audience and campaigns, talk to Ranla, and approve growth work. The same workspace also sends transactional email. Hosted MCP with browser OAuth.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Super-Send/ranla-grok-plugin.git",
-        "sha": "a5d3dc020e94cdbc6a59339dbf3aac3d562f41ac"
+        "sha": "274a5f3cad4e09cf41d8a69884f3ad31e500efe3"
       },
       "homepage": "https://ranla.ai",
-      "keywords": ["ranla", "ranla mcp", "ranla email", "ranla transactional email", "ranla send", "ranla campaigns"],
+      "keywords": ["ranla", "ranla mcp", "ranla campaigns", "ranla email"],
       "domains": ["ranla.ai", "app.ranla.ai", "docs.ranla.ai", "mcp.ranla.ai"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,15 +283,15 @@
     },
     {
       "name": "ranla",
-      "description": "Official Ranla plugin for Grok Build. Connect your Ranla workspace to instrument lifecycle events, inspect audience and campaigns, talk to Ranla, and approve growth work via hosted MCP with browser OAuth.",
+      "description": "Official Ranla plugin for Grok Build. Transactional email — send, domains, templates, webhooks, and deliverability — plus a growth agent for lifecycle events, audience, and campaigns. Hosted MCP with browser OAuth.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Super-Send/ranla-grok-plugin.git",
-        "sha": "93c2bbba3bd6d46a96ce6a18b2133e78fd1fd8ff"
+        "sha": "a5d3dc020e94cdbc6a59339dbf3aac3d562f41ac"
       },
       "homepage": "https://ranla.ai",
-      "keywords": ["ranla", "ranla mcp", "ranla email", "ranla campaigns"],
+      "keywords": ["ranla", "ranla mcp", "ranla email", "ranla transactional email", "ranla send", "ranla campaigns"],
       "domains": ["ranla.ai", "app.ranla.ai", "docs.ranla.ai", "mcp.ranla.ai"]
     }
   ]

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -757,6 +757,28 @@
         ]
       }
     },
+    "ranla": {
+      "sha": "93c2bbba3bd6d46a96ce6a18b2133e78fd1fd8ff",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "ranla",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ranla",
+            "description": "Connect Ranla to a product for lifecycle email — Audience contacts, lifecycle events, activation, conversion, and campa…"
+          },
+          {
+            "name": "ranla-mcp",
+            "description": "Use Ranla MCP from Grok Build. Prefer the bundled hosted server at mcp.ranla.ai (OAuth, no API key). Use Arc for growth…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -758,8 +758,8 @@
       }
     },
     "ranla": {
-      "sha": "a5d3dc020e94cdbc6a59339dbf3aac3d562f41ac",
-      "version": "1.0.1",
+      "sha": "274a5f3cad4e09cf41d8a69884f3ad31e500efe3",
+      "version": "1.0.2",
       "components": {
         "mcpServers": [
           {
@@ -770,11 +770,11 @@
         "skills": [
           {
             "name": "ranla",
-            "description": "Connect Ranla to a product for transactional email and lifecycle growth — send receipts, auth codes, and alerts; verify…"
+            "description": "Connect Ranla to a product for lifecycle email — Audience contacts, lifecycle events, activation, conversion, and campa…"
           },
           {
             "name": "ranla-mcp",
-            "description": "Use Ranla MCP from Grok Build. Prefer the bundled hosted server at mcp.ranla.ai (OAuth, no API key). Transactional emai…"
+            "description": "Use Ranla MCP from Grok Build. Prefer the bundled hosted server at mcp.ranla.ai (OAuth, no API key). Use Arc for growth…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -758,8 +758,8 @@
       }
     },
     "ranla": {
-      "sha": "93c2bbba3bd6d46a96ce6a18b2133e78fd1fd8ff",
-      "version": "1.0.0",
+      "sha": "a5d3dc020e94cdbc6a59339dbf3aac3d562f41ac",
+      "version": "1.0.1",
       "components": {
         "mcpServers": [
           {
@@ -770,11 +770,11 @@
         "skills": [
           {
             "name": "ranla",
-            "description": "Connect Ranla to a product for lifecycle email — Audience contacts, lifecycle events, activation, conversion, and campa…"
+            "description": "Connect Ranla to a product for transactional email and lifecycle growth — send receipts, auth codes, and alerts; verify…"
           },
           {
             "name": "ranla-mcp",
-            "description": "Use Ranla MCP from Grok Build. Prefer the bundled hosted server at mcp.ranla.ai (OAuth, no API key). Use Arc for growth…"
+            "description": "Use Ranla MCP from Grok Build. Prefer the bundled hosted server at mcp.ranla.ai (OAuth, no API key). Transactional emai…"
           }
         ]
       }


### PR DESCRIPTION
## What this PR does

Adds the official Ranla plugin to the Grok plugin marketplace.

- **Plugin name:** `ranla`
- **Type:** remote source
- **Source URL + pinned SHA:** `https://github.com/Super-Send/ranla-grok-plugin.git@274a5f3cad4e09cf41d8a69884f3ad31e500efe3`
- **Homepage:** https://ranla.ai

### What Ranla provides

Ranla is an AI growth agent for the signups a product already has. This plugin connects Grok Build to a Ranla workspace through the hosted MCP server. The same workspace also sends transactional email, so application mail does not need a second product.

| Surface | What it does |
|---|---|
| Hosted MCP | `https://mcp.ranla.ai/mcp` — OAuth in the browser, no API key to paste |
| `arc_message` / threads / approvals | Talk to Ranla for growth strategy and gated campaign mutations |
| `arc_*` read tools | Audience, campaigns, events, templates, setup status, product context |
| Skills | `ranla` (instrument lifecycle in app code) and `ranla-mcp` (Arc-first MCP usage) |
| Transactional email (same workspace) | `send_email`, domains, templates, webhooks, deliverability |

Growth campaign mutations stay on Ranla (`arc_message` + approvals). Transactional send is available on the same MCP when the user needs receipts, auth, or alerts.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

Plugin source: [Super-Send/ranla-grok-plugin](https://github.com/Super-Send/ranla-grok-plugin) under the official [`Super-Send`](https://github.com/Super-Send) organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] License is stated as MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://mcp.ranla.ai/mcp` — hosted MCP tools
  - `https://app.ranla.ai` — OAuth authorization / dashboard
  - `https://api.ranla.ai` — mail and Audience API calls made by the MCP server
- Credentials/permissions it requires (and why):
  - Browser OAuth to a Ranla account on first connect. No embedded secrets. Bearer `rnl_…` / `stx_…` is optional for advanced/CI setups only.

The plugin contains no lifecycle hooks or installation scripts. MCP is HTTP-only (no local shell server).

## Notes for reviewers

Keywords and domains are brand-scoped (`ranla`, `ranla campaigns`, `ranla.ai` and our app/docs/MCP hosts). Index generation fetched the pinned commit successfully.
