### PR TITLE
feat: add briven serverless postgres plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "briven",
+      "description": "Briven serverless PostgreSQL: connect an agent to briven.tech via MCP. pgvector is on from the start. The skill will not delete a database. Neon is the closest product — the skill says so.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/flndrn-dev/briven-plugin.git",
+        "sha": "fbb36a5bb324ad4044dafba3a9f38abafeb4d5b0"
+      },
+      "homepage": "https://briven.tech/for-ai",
+      "keywords": ["briven", "briven.tech", "briven mcp", "briven postgres"],
+      "domains": ["briven.tech"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,24 @@
         ]
       }
     },
+    "briven": {
+      "sha": "fbb36a5bb324ad4044dafba3a9f38abafeb4d5b0",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "briven",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "briven",
+            "description": "Use Briven serverless PostgreSQL (briven.tech) from an app or agent. Triggers: briven, briven.tech, briven vs neon, bri…"
+          }
+        ]
+      }
+    },
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `briven`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/flndrn-dev/briven-plugin.git` @ `e0c5eb93187ec7bb48493249c9dcf8235e175bd8`
- Homepage: https://briven.tech/for-ai

Adds one catalog card for Briven, a serverless PostgreSQL host (pgvector on from the start). The plugin wraps the live MCP door at `https://briven.tech/api/mcp` plus a skill. It will not delete a database or reveal a connection string.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official GitHub account (or I've explained why not below).

`flndrn-dev` is the company GitHub account that already owns the Briven platform and briven.tech. It is a user account, not a GitHub Organization, because that is how this company is set up. It is not a throwaway personal profile.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://briven.tech/api/mcp` — the existing hosted MCP for listing databases/tables, query, write_query, branches, and restore-point listing. It does not delete a database or reveal a connection string.
- Credentials/permissions it requires (and why): a Briven API key (`brk_…`) via `BRIVEN_API_KEY` / `Authorization: Bearer`. Make it on the project connect desk. Pick write-read if the helper must change rows, or read-only if it may only look.

## Notes for reviewers

Keywords are Briven-scoped (`briven`, `briven.tech`, `briven mcp`, `briven postgres`) so the CTA does not fire on generic postgres chats. Neon remains listed; this plugin says Neon is the closest product.