### PR TITLE
Add typefully plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "typefully",
+      "description": "Social media scheduler for great writing on X (Twitter), LinkedIn, Substack, Threads, Bluesky, and Mastodon. Write, review, schedule, publish, and analyze posts across every social media account in your collaborative Typefully workspace.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/typefully/typefully-plugin.git",
+        "sha": "c265cc23771ea290c860146913138aad92acf011"
+      },
+      "homepage": "https://github.com/typefully/typefully-plugin",
+      "keywords": ["typefully", "typefully draft", "typefully schedule", "typefully publish"],
+      "domains": ["typefully.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1007,6 +1007,18 @@
         ]
       }
     },
+    "typefully": {
+      "sha": "c265cc23771ea290c860146913138aad92acf011",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "typefully",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "c4a1c4e2e16feefb1d9f2ad2a4a451abd0ae91c6",
       "version": "0.48.1",


### PR DESCRIPTION
Official Typefully plugin, sourced from typefully/typefully-plugin at a pinned commit.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name: Typefully
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local):  https://github.com/typefully/typefully-plugin.git @ c265cc23771ea290c860146913138aad92acf011
- Homepage: https://typefully.com

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.typefully.com/mcp` — the hosted Typefully MCP server, the only endpoint the client connects to. The server itself calls Typefully's first-party API and OAuth authorization server on the user's behalf. No other endpoints; both are declared in the plugin README.
- Credentials/permissions it requires (and why): none stored in the plugin. Users sign in via OAuth 2.0. Access follows the user's own Typefully workspace permissions. The plugin ships no hooks, no scripts, and executes no local code — it is an MCP server configuration only.

