### PR TITLE
Add YouTube Comments Downloader MCP

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,23 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "youtube-comments-downloader-mcp",
+      "description": "Export and research public YouTube comments through the YouTube Comments Downloader MCP server.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/youtube-comments-downloader/youtube-comments-downloader-mcp.git",
+        "sha": "cbca0a052ce061f99c2afc426859118a4331a344"
+      },
+      "homepage": "https://youtubecommentsdownloader.com/tools/mcp",
+      "keywords": [
+        "youtube comments downloader",
+        "youtube comment export",
+        "youtube audience research"
+      ],
+      "domains": ["youtubecommentsdownloader.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/youtube-comments-downloader/youtube-comments-downloader-mcp.git",
-        "sha": "cbca0a052ce061f99c2afc426859118a4331a344"
+        "sha": "5ab0c82047baa795cd0c087516cbd2ef9165655c"
       },
       "homepage": "https://youtubecommentsdownloader.com/tools/mcp",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1263,6 +1263,23 @@
           }
         ]
       }
+    },
+    "youtube-comments-downloader-mcp": {
+      "sha": "cbca0a052ce061f99c2afc426859118a4331a344",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "youtube-comments-downloader",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "youtube-audience-research",
+            "description": "Turn YouTube comment exports into structured audience research questions, summaries, and follow-up analyses."
+          }
+        ]
+      }
     }
   }
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1265,7 +1265,7 @@
       }
     },
     "youtube-comments-downloader-mcp": {
-      "sha": "cbca0a052ce061f99c2afc426859118a4331a344",
+      "sha": "5ab0c82047baa795cd0c087516cbd2ef9165655c",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## Summary

- add the official YouTube Comments Downloader MCP plugin to the external catalog
- pin the public source to commit cbca0a052ce061f99c2afc426859118a4331a344
- regenerate the component index

## Security and ownership

The plugin is maintained by the YouTube Comments Downloader organization, licensed MIT, and uses a hosted MCP endpoint over HTTPS. It forwards the existing API key or OAuth authorization to the existing API; it does not ship shell hooks, local scripts, or undisclosed telemetry. The README documents the endpoint and credentials required.

## Validation

- python3 scripts/validate-catalog.py
- python3 scripts/generate-plugin-index.py --check

Source repository: https://github.com/youtube-comments-downloader/youtube-comments-downloader-mcp
Homepage: https://youtubecommentsdownloader.com/tools/mcp