### PR TITLE
feat(plugins): add pingroom-mcp and pingroom-cli

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
+        "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
         "path": "mcp"
       },
       "homepage": "https://pingroom.io/connect-mcp.md",
@@ -302,7 +302,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
+        "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
         "path": "cli"
       },
       "homepage": "https://www.npmjs.com/package/@pingroom/cli",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,33 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "pingroom",
+      "description": "Reach a human through PingRoom (hosted MCP server + skill). Send someone a ping with files, a map location, a tappable link, or structured data; ask a question and block until they answer; gate an action on an approve/deny decision; hand a decision off to your authorizing human; drive a live-progress card on their lock screen while long work runs.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/pingroom/skills.git",
+        "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+        "path": "mcp"
+      },
+      "homepage": "https://pingroom.io/connect-mcp.md",
+      "keywords": ["pingroom", "ping room", "pingroom mcp"],
+      "domains": ["pingroom.io", "api.pingroom.io"]
+    },
+    {
+      "name": "pingroom-cli",
+      "description": "Reach a human from a shell, a CI pipeline, or an agent hook with the @pingroom/cli. Pings carry attachments up to 5 MiB, human answers come back as exit codes a script can branch on, deploys can wait on an approve/deny, and rooms, webhooks and quick actions are managed from the terminal.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/pingroom/skills.git",
+        "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+        "path": "cli"
+      },
+      "homepage": "https://www.npmjs.com/package/@pingroom/cli",
+      "keywords": ["pingroom cli", "@pingroom/cli", "pingroom ask", "pingroom pair"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
+        "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
         "path": "mcp"
       },
       "homepage": "https://pingroom.io/connect-mcp.md",
@@ -315,7 +315,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
+        "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
         "path": "cli"
       },
       "homepage": "https://www.npmjs.com/package/@pingroom/cli",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+        "sha": "621874f9f5daca354f93d507080010bfec5578ad",
         "path": "mcp"
       },
       "homepage": "https://pingroom.io/connect-mcp.md",
@@ -315,7 +315,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+        "sha": "621874f9f5daca354f93d507080010bfec5578ad",
         "path": "cli"
       },
       "homepage": "https://www.npmjs.com/package/@pingroom/cli",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -282,13 +282,13 @@
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
     {
-      "name": "pingroom",
+      "name": "pingroom-mcp",
       "description": "Reach a human through PingRoom (hosted MCP server + skill). Send someone a ping with files, a map location, a tappable link, or structured data; ask a question and block until they answer; gate an action on an approve/deny decision; hand a decision off to your authorizing human; drive a live-progress card on their lock screen while long work runs.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+        "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
         "path": "mcp"
       },
       "homepage": "https://pingroom.io/connect-mcp.md",
@@ -302,7 +302,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/pingroom/skills.git",
-        "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+        "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
         "path": "cli"
       },
       "homepage": "https://www.npmjs.com/package/@pingroom/cli",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,7 +537,7 @@
       }
     },
     "pingroom-cli": {
-      "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+      "sha": "621874f9f5daca354f93d507080010bfec5578ad",
       "version": "1.1.1",
       "components": {
         "skills": [
@@ -549,7 +549,7 @@
       }
     },
     "pingroom-mcp": {
-      "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+      "sha": "621874f9f5daca354f93d507080010bfec5578ad",
       "version": "1.1.1",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,8 +537,8 @@
       }
     },
     "pingroom-cli": {
-      "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
-      "version": "1.0.0",
+      "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
+      "version": "1.1.0",
       "components": {
         "skills": [
           {
@@ -549,8 +549,8 @@
       }
     },
     "pingroom-mcp": {
-      "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
-      "version": "1.0.0",
+      "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
+      "version": "1.1.0",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,8 +537,8 @@
       }
     },
     "pingroom-cli": {
-      "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
-      "version": "1.1.0",
+      "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+      "version": "1.1.1",
       "components": {
         "skills": [
           {
@@ -549,8 +549,8 @@
       }
     },
     "pingroom-mcp": {
-      "sha": "79e17efd5ed69cbb2a9c214f3c7fc4e4838d63a2",
-      "version": "1.1.0",
+      "sha": "b9366fa22742f4b6f7e886aaca472e5195c972d2",
+      "version": "1.1.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,8 +536,20 @@
         ]
       }
     },
-    "pingroom": {
-      "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+    "pingroom-cli": {
+      "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "pingroom-cli",
+            "description": "Use the `pingroom` CLI to reach humans from terminals, scripts, CI, and Claude Code hooks — send pings with file attach…"
+          }
+        ]
+      }
+    },
+    "pingroom-mcp": {
+      "sha": "45d0902dd964cc42fddf19a186fe6022b4e1a31f",
       "version": "1.0.0",
       "components": {
         "mcpServers": [
@@ -550,18 +562,6 @@
           {
             "name": "pingroom-mcp",
             "description": "Reach a human through PingRoom — the event platform whose MCP connector this session has. Use this skill whenever the t…"
-          }
-        ]
-      }
-    },
-    "pingroom-cli": {
-      "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
-      "version": "1.0.0",
-      "components": {
-        "skills": [
-          {
-            "name": "pingroom-cli",
-            "description": "Use the `pingroom` CLI to reach humans from terminals, scripts, CI, and Claude Code hooks — send pings with file attach…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,36 @@
         ]
       }
     },
+    "pingroom": {
+      "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "pingroom",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "pingroom-mcp",
+            "description": "Reach a human through PingRoom — the event platform whose MCP connector this session has. Use this skill whenever the t…"
+          }
+        ]
+      }
+    },
+    "pingroom-cli": {
+      "sha": "e08b3cf11722f66c9394842e83b0ab88d6daee51",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "pingroom-cli",
+            "description": "Use the `pingroom` CLI to reach humans from terminals, scripts, CI, and Claude Code hooks — send pings with file attach…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "efa2a531985e0a8084d36ff3cf87233be8a9f34b",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds PingRoom — an event platform for reaching a human from an agent session. Two sibling plugins from the same repo: the hosted MCP connector, and a skill for the `@pingroom/cli` for shells, CI, and hooks.

- Plugin name: `pingroom-mcp` and `pingroom-cli`
- Type: remote source (both)
- Source URL + pinned SHA: `https://github.com/pingroom/skills.git` @ `45d0902dd964cc42fddf19a186fe6022b4e1a31f` — `path: mcp` and `path: cli`
- Homepage: https://pingroom.io/connect-mcp.md and https://www.npmjs.com/package/@pingroom/cli

What each ships (per the regenerated index):

| Plugin | Components |
|---|---|
| `pingroom-mcp` | 1 skill (`pingroom-mcp`, with a generated tool reference) + 1 HTTP MCP server |
| `pingroom-cli` | 1 skill (`pingroom-cli`) |

No commands, agents, hooks, LSP servers, or executable code in either plugin directory.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`github.com/pingroom/skills` is the PingRoom org's public skills repo, MIT licensed. The fork this PR comes from is a personal account; the plugin source is not.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`). — two entries, see note below
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`. — remote source; repo has a README, and each plugin dir has a `.claude-plugin/plugin.json`
- [x] License is stated. — MIT, in each `plugin.json` and at the repo root.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

Neither plugin directory contains any executable code — `mcp/` is a `plugin.json`, an `.mcp.json`, and a `SKILL.md` plus one reference file; `cli/` is a `plugin.json` and a `SKILL.md`. No hooks, no scripts, no install step.

- Network endpoints this plugin calls (and why): `https://api.pingroom.io/api/agent/mcp` — the hosted PingRoom MCP server, the only endpoint the `pingroom-mcp` plugin contacts. It is the product's own API. `pingroom-cli` contacts nothing on its own; it documents a CLI the user installs separately with `npm i -g @pingroom/cli`, which talks to the same host.
- Credentials/permissions it requires (and why): the MCP server authenticates over OAuth at connect time (`/mcp`) so pings are attributed to the user's own PingRoom account and can only reach rooms that account is a member of. Nothing is read from the environment or the filesystem. The CLI holds its own token from `pingroom activate` / `pingroom pair`, stored by the CLI itself, outside the plugin.

## Notes for reviewers

**On "exactly one entry":** this adds two, for the same reason `mongodb`/`mongodb-atlas` are two — they are different surfaces with different install stories (a hosted MCP connection vs. a locally installed CLI for shells and CI), and the skills cross-reference each other rather than duplicating. Their `keywords` are deliberately disjoint so the CTA fires for one or the other, never both: `pingroom-mcp` owns `pingroom` / `ping room` / `pingroom mcp`, and `pingroom-cli` owns the shell-scoped terms. Happy to split into two PRs or drop the CLI entry if you'd rather.

Both entries are named for their manifests. Verified end to end against `grok 1.0.13`: `grok plugin validate` passes on each directory, and installing from a marketplace source registers them as `pingroom-mcp` and `pingroom-cli` with the MCP server resolved — an entry named `pingroom` installed as `pingroom-mcp`, which would have made `grok plugin list` and `uninstall` disagree with the catalog.

The two plugins are also published as Claude Code plugins from the same repo, which is why the manifests live at `.claude-plugin/plugin.json` — accepted per CONTRIBUTING. `mcp/.mcp.json` was added alongside the inline `mcpServers` declaration so the server resolves the same way under Grok Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQtwQ9Mf8BZErMAzp764LE
