### PR TITLE
Add Norman Finance plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "norman-finance",
+      "description": "Official Norman Finance plugin for European bookkeeping, accounting, invoicing, documents, tax filing, and German company workflows through a hosted OAuth MCP server and bundled skills.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/norman-finance/norman-mcp-server.git",
+        "sha": "e12a79152b496001e364d50129f190362c17724a"
+      },
+      "homepage": "https://norman.finance",
+      "keywords": ["norman finance", "norman bookkeeping", "norman mcp"],
+      "domains": ["norman.finance", "app.norman.finance", "mcp.norman.finance"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/norman-finance/norman-mcp-server.git",
-        "sha": "79c670abc939e38068ddb5e0984dde7ec657fc81"
+        "sha": "f9578ee8d5de8ed6d6c3a89ffc01f252a478a3a4"
       },
       "homepage": "https://norman.finance",
       "keywords": ["norman finance", "norman bookkeeping", "norman mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/norman-finance/norman-mcp-server.git",
-        "sha": "e12a79152b496001e364d50129f190362c17724a"
+        "sha": "a1148f328525b08d357dd70d7fb2c13fd7d80893"
       },
       "homepage": "https://norman.finance",
       "keywords": ["norman finance", "norman bookkeeping", "norman mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/norman-finance/norman-mcp-server.git",
-        "sha": "8c51318b92fc91ec308e4bf3ac51c606df8941ea"
+        "sha": "79c670abc939e38068ddb5e0984dde7ec657fc81"
       },
       "homepage": "https://norman.finance",
       "keywords": ["norman finance", "norman bookkeeping", "norman mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/norman-finance/norman-mcp-server.git",
-        "sha": "a1148f328525b08d357dd70d7fb2c13fd7d80893"
+        "sha": "8c51318b92fc91ec308e4bf3ac51c606df8941ea"
       },
       "homepage": "https://norman.finance",
       "keywords": ["norman finance", "norman bookkeeping", "norman mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,7 +537,7 @@
       }
     },
     "norman-finance": {
-      "sha": "79c670abc939e38068ddb5e0984dde7ec657fc81",
+      "sha": "f9578ee8d5de8ed6d6c3a89ffc01f252a478a3a4",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,7 +537,7 @@
       }
     },
     "norman-finance": {
-      "sha": "8c51318b92fc91ec308e4bf3ac51c606df8941ea",
+      "sha": "79c670abc939e38068ddb5e0984dde7ec657fc81",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,96 @@
         ]
       }
     },
+    "norman-finance": {
+      "sha": "e12a79152b496001e364d50129f190362c17724a",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "norman-finance",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "accounting-cutover",
+            "description": "Analyze and migrate opening balances or prior DATEV books into Norman's SME Ledger. Use when a GmbH or UG is starting i…"
+          },
+          {
+            "name": "categorize-transactions",
+            "description": "Review and categorize uncategorized bank transactions, match them with invoices, and verify bookkeeping entries. Use wh…"
+          },
+          {
+            "name": "company-incorporation",
+            "description": "Found a German GmbH or UG (haftungsbeschränkt) through a guided chat. Use when the user wants to open, found or incorpo…"
+          },
+          {
+            "name": "corporate-tax-registration",
+            "description": "Prepare the corporate tax registration (Fragebogen zur steuerlichen Erfassung for a GmbH/UG) through a guided chat. Use…"
+          },
+          {
+            "name": "create-invoice",
+            "description": "Create and optionally send a new invoice to a client. Use when the user wants to invoice someone, bill a client, or cre…"
+          },
+          {
+            "name": "expense-report",
+            "description": "Generate a detailed expense breakdown by category for a given period. Use when the user asks for an expense report, spe…"
+          },
+          {
+            "name": "financial-overview",
+            "description": "Get a complete financial overview of the business including balance, recent transactions, outstanding invoices, and upc…"
+          },
+          {
+            "name": "find-receipts",
+            "description": "Find and attach missing receipts for business transactions. Search Gmail, email, or other sources for invoices and rece…"
+          },
+          {
+            "name": "gewerbe-registration",
+            "description": "Prepare a German trade-office registration (Gewerbeanmeldung, form GewA 1) through a guided chat. Use when the user wan…"
+          },
+          {
+            "name": "manage-clients",
+            "description": "Manage business clients - list, search, create, or update client information. Use when the user mentions clients, conta…"
+          },
+          {
+            "name": "monthly-reconciliation",
+            "description": "Perform a complete monthly financial reconciliation - review all transactions, match invoices, check outstanding paymen…"
+          },
+          {
+            "name": "overdue-reminders",
+            "description": "Find overdue invoices and send payment reminders (Zahlungserinnerungen / Mahnungen) to clients. Use when the user asks…"
+          },
+          {
+            "name": "suggest-category",
+            "description": "Find the right SKR account code for a bookkeeping category (SME only). Search the full SKR03/SKR04 chart of accounts by…"
+          },
+          {
+            "name": "ta-company-review",
+            "description": "Full company review for tax advisors. Generates a structured health report covering financials, document completeness,…"
+          },
+          {
+            "name": "ta-datev-preparation",
+            "description": "Prepare a DATEV export for a client company. Verifies all transactions are categorized, receipts attached, DATEV settin…"
+          },
+          {
+            "name": "ta-missing-receipts",
+            "description": "Find and collect missing receipts for a client company. Identify high-priority items, suggest a ping strategy, and bulk…"
+          },
+          {
+            "name": "ta-tax-compliance",
+            "description": "Tax compliance check for a client company. Checks all tax periods, identifies unfiled or overdue reports, verifies tax…"
+          },
+          {
+            "name": "tax-deduction-finder",
+            "description": "Scan transactions for potentially missed tax deductions and suggest proper categorization. Use when the user asks about…"
+          },
+          {
+            "name": "tax-report",
+            "description": "Review and manage German tax reports including VAT (Umsatzsteuer), income tax prepayments, and Finanzamt submissions. U…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "efa2a531985e0a8084d36ff3cf87233be8a9f34b",
       "components": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,7 +537,7 @@
       }
     },
     "norman-finance": {
-      "sha": "e12a79152b496001e364d50129f190362c17724a",
+      "sha": "a1148f328525b08d357dd70d7fb2c13fd7d80893",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -537,7 +537,7 @@
       }
     },
     "norman-finance": {
-      "sha": "a1148f328525b08d357dd70d7fb2c13fd7d80893",
+      "sha": "8c51318b92fc91ec308e4bf3ac51c606df8941ea",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the official Norman Finance hosted MCP server and its bundled finance/accounting skills to the Grok Build marketplace.

- Plugin name: `norman-finance`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/norman-finance/norman-mcp-server.git` @ `f9578ee8d5de8ed6d6c3a89ffc01f252a478a3a4`
- Homepage: https://norman.finance

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The source is maintained by Norman Finance in the `norman-finance` GitHub organization.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a full 40-character lowercase SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set.
- [x] The source is licensed under MIT.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` behavior.
- [x] No reading or exfiltration of local secrets, tokens, `.env`, or arbitrary environment variables.
- [x] No lifecycle hooks or shell-execution MCP tools.

Network endpoints:
- `https://mcp.norman.finance/mcp` — hosted Streamable HTTP MCP endpoint.
- `https://mcp.norman.finance/authorize` and related OAuth metadata/token routes — MCP OAuth 2.1 flow.
- `https://api.norman.finance/api/v1/oauth/` — Norman account authorization reached through the hosted MCP OAuth redirect.

Credentials/permissions:
- A Norman account is required. Authentication is completed in the browser through OAuth with PKCE; the plugin does not ask for, read, or store the user password or an API key.
- Norman MCP tool calls operate only on companies available to the authenticated Norman user. Mutating tools carry MCP safety annotations and remain subject to Grok approvals.

## Notes for reviewers

The generated index discovers one remote MCP server and 19 bundled skills from the pinned source. The same public MCP is already distributed through Claude Connectors and the ChatGPT Plugins Directory. Source compatibility work is tracked in norman-finance/norman-mcp-server#116.


