### PR TITLE
Add volunteerreminder plugin to the official catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -287,7 +287,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/talltimbersgroup/VolunteerReminder.git",
-        "sha": "40e7c1d75dea3d8d58ca9b3abc2fd7f2805ea4f1"
+        "sha": "9e2be257803f48e051db7af526223c6eddb0ee6c"
       },
       "homepage": "https://volunteerreminder.com/docs/agents",
       "keywords": ["volunteerreminder", "volunteer reminder"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,18 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "volunteerreminder",
+      "description": "Connect Grok to VolunteerReminder's remote MCP. Import a volunteer roster in test mode, preview first. Nothing texts a real volunteer until a human turns live sends on.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/talltimbersgroup/VolunteerReminder.git",
+        "sha": "40e7c1d75dea3d8d58ca9b3abc2fd7f2805ea4f1"
+      },
+      "homepage": "https://volunteerreminder.com/docs/agents",
+      "keywords": ["volunteerreminder", "volunteer reminder"],
+      "domains": ["volunteerreminder.com", "mcp.volunteerreminder.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1215,8 +1215,14 @@
       }
     },
     "volunteerreminder": {
-      "sha": "40e7c1d75dea3d8d58ca9b3abc2fd7f2805ea4f1",
+      "sha": "9e2be257803f48e051db7af526223c6eddb0ee6c",
       "components": {
+        "mcpServers": [
+          {
+            "name": "volunteerreminder",
+            "description": "http"
+          }
+        ],
         "skills": [
           {
             "name": "volunteer-schedule-import",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1214,6 +1214,17 @@
         ]
       }
     },
+    "volunteerreminder": {
+      "sha": "40e7c1d75dea3d8d58ca9b3abc2fd7f2805ea4f1",
+      "components": {
+        "skills": [
+          {
+            "name": "volunteer-schedule-import",
+            "description": "Start a VolunteerReminder trial and import a pasted volunteer roster"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "6277ddff7bc62102d06d969d76e41f81eb86d48e",
       "version": "1.17.0",


### PR DESCRIPTION
## What this PR does

Adds VolunteerReminder as a remote-source plugin in the official Grok marketplace catalog.

- Plugin name: `volunteerreminder`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/talltimbersgroup/VolunteerReminder.git` @ `9e2be257803f48e051db7af526223c6eddb0ee6c`
- Homepage: https://volunteerreminder.com/docs/agents

Pin `9e2be257803f48e051db7af526223c6eddb0ee6c` is the squash-merge of VolunteerReminder PR 111 onto `master` (adds repo-root `.mcp.json` so xAI's `generate-plugin-index.py` indexes the hosted MCP). Previous pin was `40e7c1d75dea3d8d58ca9b3abc2fd7f2805ea4f1`.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`talltimbersgroup/VolunteerReminder`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [ ] License is stated. (Upstream has no root LICENSE file at this pin; happy to add one and bump the SHA.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. (Remote HTTP MCP only; no stdio/shell MCP, no hooks.)
- Network endpoints this plugin calls (and why):
  - `https://mcp.volunteerreminder.com/mcp` — hosted Streamable HTTP MCP (roster import / preview in test mode)
  - `https://volunteerreminder.com` — product app, docs, and import REST API used by that MCP
- Credentials/permissions it requires (and why):
  - User OAuth Allow, or a user-minted API key. This plugin does not ship secrets or headers.

## Notes for reviewers

- Official org source: `talltimbersgroup/VolunteerReminder`.
- Keywords/domains are brand-scoped (`volunteerreminder`, `volunteer reminder`; `volunteerreminder.com`, `mcp.volunteerreminder.com`). Generic terms were omitted.
- Category omitted: none of the existing catalog categories (`development`, `deployment`, `monitoring`, `database`, `observability`) is a close fit, so we did not invent a new one.
- **MCP:** This pin includes repo-root `.mcp.json` (`mcpServers.volunteerreminder.url` = `https://mcp.volunteerreminder.com/mcp`, no headers/secrets). Regenerated `plugin-index.json` lists the `volunteerreminder` HTTP MCP server plus the existing `volunteer-schedule-import` skill.
- Import is test-mode / preview-first. Nothing texts a real volunteer until a human turns live sends on.
