### PR TITLE
FirstTouch plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,10 +288,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/First-Touch-Inc/mcp.git",
-        "sha": "32f8a91b460b99914ae3258887436eee103adf8d"
+        "sha": "ff5e6a65a3407bd16d6cefd274326d93fe6db24e"
       },
       "homepage": "https://www.firsttouch.com",
-      "keywords": ["firsttouch", "firsttouch mcp", "firsttouch audiences", "firsttouch outreach flows", "firsttouch contact enrollment", "firsttouch tasks", "firsttouch hubspot import"],
+      "keywords": ["firsttouch", "firsttouch mcp", "firsttouch audiences", "firsttouch outreach flows", "firsttouch contact enrollment", "firsttouch hubspot import"],
       "domains": ["firsttouch.com", "www.firsttouch.com", "mcp.firsttouch.com"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -291,7 +291,7 @@
         "sha": "32f8a91b460b99914ae3258887436eee103adf8d"
       },
       "homepage": "https://www.firsttouch.com",
-      "keywords": ["firsttouch", "firsttouch mcp", "audience management", "outreach flow automation", "contact enrollment", "task management", "hubspot list import"],
+      "keywords": ["firsttouch", "firsttouch mcp", "firsttouch audiences", "firsttouch outreach flows", "firsttouch contact enrollment", "firsttouch tasks", "firsttouch hubspot import"],
       "domains": ["firsttouch.com", "www.firsttouch.com", "mcp.firsttouch.com"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "firsttouch",
+      "description": "FirstTouch CRM integration. Manage audiences, outreach flows, contact enrollments, tasks, and HubSpot list imports through the hosted FirstTouch MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/First-Touch-Inc/mcp.git",
+        "sha": "32f8a91b460b99914ae3258887436eee103adf8d"
+      },
+      "homepage": "https://www.firsttouch.com",
+      "keywords": ["firsttouch", "firsttouch mcp", "audience management", "outreach flow automation", "contact enrollment", "task management", "hubspot list import"],
+      "domains": ["firsttouch.com", "www.firsttouch.com", "mcp.firsttouch.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "firsttouch": {
+      "sha": "32f8a91b460b99914ae3258887436eee103adf8d",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "firsttouch",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "firsttouch": {
-      "sha": "32f8a91b460b99914ae3258887436eee103adf8d",
+      "sha": "ff5e6a65a3407bd16d6cefd274326d93fe6db24e",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the official FirstTouch hosted MCP integration as a remote plugin source. It enables audience management, outreach flow automation, contact enrollment, task review, and HubSpot list imports from a FirstTouch workspace.

- Plugin name: `firsttouch`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/First-Touch-Inc/mcp.git` at `32f8a91b460b99914ae3258887436eee103adf8d`
- Homepage: https://www.firsttouch.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA, and the commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` and a clear `description` are set; the remote repository includes a README and `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks or locally executed MCP code are included; access is limited to the hosted FirstTouch MCP server.
- Network endpoints this plugin calls (and why): `https://mcp.firsttouch.com` for the hosted MCP transport, browser-based authorization, and FirstTouch operations.
- Credentials/permissions it requires (and why): A FirstTouch account and browser-based OAuth authorization for a selected workspace. No API key, environment variable, or local credential is required. Connected HubSpot data is accessed only for explicitly requested workflows and according to the authorized user's permissions.

## Notes for reviewers

This is the official FirstTouch MCP integration, published under the `First-Touch-Inc` GitHub organization. The plugin repository contains static configuration, documentation, metadata, and a logo; it does not install or execute local code.