### PR TITLE
feat(plugins): add kyma-api

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/kyma-api/kyma-mcp-plugin.git",
-        "sha": "4e9c565004f70f1c13f7d97b1a4832560dabe483"
+        "sha": "3b8bff3efc5f8d526b67efe046b1404e3563be3e"
       },
       "homepage": "https://kymaapi.com",
       "keywords": ["kyma", "kyma api", "llm gateway", "open models", "model pricing", "model uptime", "chat completions"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "kyma-api",
+      "description": "Kyma API for your agent: live model catalog with prices and measured uptime, rankings, your credits and spend, and spend-capped chat over one MCP URL with OAuth sign-in (dedicated key per connection, $10 per 30 days by default, adjustable $1 to $500).",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/kyma-api/kyma-mcp-plugin.git",
+        "sha": "4e9c565004f70f1c13f7d97b1a4832560dabe483"
+      },
+      "homepage": "https://kymaapi.com",
+      "keywords": ["kyma", "kyma api", "llm gateway", "open models", "model pricing", "model uptime", "chat completions"],
+      "domains": ["kymaapi.com", "mcp.kymaapi.com", "docs.kymaapi.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/kyma-api/kyma-mcp-plugin.git",
-        "sha": "3b8bff3efc5f8d526b67efe046b1404e3563be3e"
+        "sha": "16143b8afd8390d2e35befcdcc5488952c08be94"
       },
       "homepage": "https://kymaapi.com",
       "keywords": ["kyma", "kyma api", "llm gateway", "open models", "model pricing", "model uptime", "chat completions"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/kyma-api/kyma-mcp-plugin.git",
-        "sha": "16143b8afd8390d2e35befcdcc5488952c08be94"
+        "sha": "2db3e1eb02b125bc897271fee22d54f57d4ed0cd"
       },
       "homepage": "https://kymaapi.com",
       "keywords": ["kyma", "kyma api", "llm gateway", "open models", "model pricing", "model uptime", "chat completions"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "kyma-api": {
-      "sha": "3b8bff3efc5f8d526b67efe046b1404e3563be3e",
+      "sha": "16143b8afd8390d2e35befcdcc5488952c08be94",
       "version": "1.0.2",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,8 +358,8 @@
       }
     },
     "kyma-api": {
-      "sha": "16143b8afd8390d2e35befcdcc5488952c08be94",
-      "version": "1.0.2",
+      "sha": "2db3e1eb02b125bc897271fee22d54f57d4ed0cd",
+      "version": "1.0.3",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "kyma-api": {
-      "sha": "4e9c565004f70f1c13f7d97b1a4832560dabe483",
+      "sha": "3b8bff3efc5f8d526b67efe046b1404e3563be3e",
       "version": "1.0.2",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "kyma-api": {
+      "sha": "4e9c565004f70f1c13f7d97b1a4832560dabe483",
+      "version": "1.0.2",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "kyma",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

New third-party plugin, remote source.

- Plugin name: `kyma-api`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/kyma-api/kyma-mcp-plugin.git` @ `5f482cf382608e0e4b8dd625bbfd1a144020ffef`
- Homepage: https://kymaapi.com

Kyma API is an LLM API gateway for open models. The plugin gives Grok Build one MCP server (`https://mcp.kymaapi.com/mcp`) with read tools for the live model catalog (real prices, measured 30-day uptime, usage rankings, a model recommendation for coding agents), the user's own credits, spend and transactions, and one spend tool (`send_message`) that runs a chat completion against the user's account.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`kyma-api`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; the source repo includes `README.md`, `.claude-plugin/plugin.json` and `.mcp.json`.
- [x] License is stated (MIT, `LICENSE` in the source repo).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin ships no scripts, hooks, skills or agents: only an MCP server declaration.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.kymaapi.com/mcp` only (Streamable HTTP MCP; OAuth 2.1 + PKCE with dynamic client registration on the same host, discovery via RFC 9728 / RFC 8414 well-known documents).
- Credentials/permissions it requires (and why): the user signs in to their own Kyma account in the browser during OAuth; the server issues a per-connection key scoped to read tools plus one chat tool, capped at $10 of the user's credits per 30 days and revocable at https://kymaapi.com/integrations. No API key is stored in the plugin or in config files. Tools carry MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`); the chat tool requires an explicit `allow=true` after the user approves it.

## Notes for reviewers

The source repo is a two-format bundle: Agent Plugins spec (`plugin.json`) and Claude Code format (`.claude-plugin/plugin.json` + `.mcp.json`), which is the one Grok Build reads. Docs for the server: https://docs.kymaapi.com/guides/mcp-server. Privacy policy: https://kymaapi.com/privacy. Contact: hello@kymaapi.com.