### PR TITLE
Add Nowledge Mem plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "nowledge-mem",
+      "description": "Persistent memory and knowledge graph for Grok Build. Load working context, search past decisions and conversations, and capture sessions through lifecycle hooks.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/nowledge-co/community.git",
+        "sha": "6b7bb0312db6e439f6fa557512e862126f2505d9",
+        "path": "nowledge-mem-claude-code-plugin"
+      },
+      "homepage": "https://mem.nowledge.co",
+      "keywords": ["nowledge mem", "nowledge memory", "nowledge knowledge graph"],
+      "domains": ["mem.nowledge.co", "nowledge.co", "nowledge-labs.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,73 @@
         ]
       }
     },
+    "nowledge-mem": {
+      "sha": "6b7bb0312db6e439f6fa557512e862126f2505d9",
+      "version": "0.7.24",
+      "components": {
+        "commands": [
+          {
+            "name": "save",
+            "description": "Save current session to Nowledge Mem"
+          },
+          {
+            "name": "search",
+            "description": "Search Nowledge Mem for relevant memories"
+          },
+          {
+            "name": "status",
+            "description": "Check Nowledge Mem connection and server status"
+          },
+          {
+            "name": "sum",
+            "description": "Distill insights from this conversation into memories"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PreCompact"
+          },
+          {
+            "name": "SessionEnd"
+          },
+          {
+            "name": "SessionStart",
+            "description": "startup|resume|clear, compact"
+          },
+          {
+            "name": "Stop"
+          },
+          {
+            "name": "SubagentStart",
+            "description": ".*"
+          },
+          {
+            "name": "SubagentStop"
+          },
+          {
+            "name": "UserPromptSubmit"
+          }
+        ],
+        "skills": [
+          {
+            "name": "distill-memory",
+            "description": "Recognize breakthrough moments, blocking resolutions, and design decisions worth preserving. Detect high-value insights…"
+          },
+          {
+            "name": "read-working-memory",
+            "description": "Read your daily Working Memory briefing to understand current context. Contains active focus areas, priorities, unresol…"
+          },
+          {
+            "name": "save-thread",
+            "description": "Save the real Claude Code or Grok Build session messages only when the user explicitly requests it. Use nmem t save to…"
+          },
+          {
+            "name": "search-memory",
+            "description": "Search memory store when past insights would improve response. Recognize when user's stored breakthroughs, decisions, o…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "7314f723a487ec406b6369fe5865ba034cfed166",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: `nowledge-mem`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/nowledge-co/community.git` at `6b7bb0312db6e439f6fa557512e862126f2505d9`, path `nowledge-mem-claude-code-plugin`
- Homepage: https://mem.nowledge.co

This adds Nowledge Mem's official Grok Build plugin to the catalog. The plugin loads working context, searches prior memories and conversations, and captures Grok Build sessions through lifecycle hooks.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Nowledge Labs maintains the plugin in the official `nowledge-co/community` repository. Its manifest declares the MIT license.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

Additional source validation:

- `grok plugin validate <plugin-dir>` — manifest valid; v0.7.24; skills, commands, and hooks detected.
- `uv run --with pytest pytest -q` — 56 passed.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): the installed `nmem` CLI talks only to the user's configured Nowledge Mem endpoint—local App by default, or a user-configured remote HTTPS endpoint—to read context and save/search memories and sessions.
- Credentials/permissions it requires (and why): remote endpoints require the user's Nowledge Mem API key in the standard `nmem` client configuration (or a temporary `NMEM_API_KEY` override). The plugin itself does not inspect or transmit the key; it invokes the installed `nmem` CLI. Lifecycle hooks need permission to run the bundled shell/Python scripts and read the current Grok session through `nmem` for thread capture.

The bundled scripts read only documented host metadata and routing variables (for example, plugin root, session ID, workspace root, Space, and agent ID). They do not enumerate the environment, read `.env`/SSH files, or send arbitrary environment values anywhere.

## Notes for reviewers

The remote source is pinned to the public official-org commit. The plugin uses the Claude-compatible manifest Grok Build supports and contains no MCP server or shell-exec MCP configuration; its lifecycle hooks invoke only bundled scripts and the separately installed `nmem` CLI. The broader connector rollout is tracked in https://github.com/nowledge-co/mem/issues/2784.
