### PR TITLE
Add ballet plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "ballet",
+      "description": "Ballet agent operations platform integration. Author and operate a Ballet workspace from Grok: create and verify playbooks, define agents, skills, HTTP tools and connectors, manage secrets and persistent data tables, then publish and run playbooks and inspect run history.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/brainfish-ai/ballet-grok-plugin.git",
+        "sha": "35edf84f121ccb8d5d7eef19965365c7ad0edf36"
+      },
+      "homepage": "https://ballet.dev",
+      "keywords": ["ballet", "ballet playbook", "ballet agent", "brainfish ballet"],
+      "domains": ["ballet.dev", "app.ballet.dev", "api.ballet.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -43,6 +43,24 @@
         ]
       }
     },
+    "ballet": {
+      "sha": "35edf84f121ccb8d5d7eef19965365c7ad0edf36",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "ballet",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "ballet",
+            "description": "Author and operate Ballet workspaces — playbooks, agents, skills, HTTP tools, connectors, secrets, and persistent data…"
+          }
+        ]
+      }
+    },
     "base44": {
       "sha": "0d3b72a76e91d920f4a151b68dd224510ca5dc14",
       "version": "1.0.0-beta.1",


### PR DESCRIPTION
## What this PR does

Adds one new remote-source entry for the **Ballet** plugin. Ballet is an agent operations platform: you compose playbooks out of code and HTTP steps, give them agents, skills, connectors, secrets, and persistent data tables, then run them on a schedule, from a webhook, or on demand. This plugin lets Grok Build author and operate that workspace.

- Plugin name: `ballet`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/brainfish-ai/ballet-grok-plugin.git` @ `35edf84f121ccb8d5d7eef19965365c7ad0edf36`
- Homepage: https://ballet.dev

Ships one MCP server (Streamable HTTP) and one skill. No commands, agents, hooks, LSP servers, bundled binaries, or install scripts.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Ballet is built by Brainfish; the source repo is published under our official `brainfish-ai` org.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT, declared in `LICENSE` and in `.grok-plugin/plugin.json`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):** only `api.ballet.dev`.

| Endpoint | Purpose |
| --- | --- |
| `POST https://api.ballet.dev/mcp` | MCP JSON-RPC — all tool calls |
| `https://api.ballet.dev/.well-known/oauth-protected-resource` | Auth discovery (RFC 9728) |
| `https://api.ballet.dev/.well-known/oauth-authorization-server` | Auth discovery (RFC 8414) |
| `https://api.ballet.dev/oauth/*` | Dynamic client registration, consent, token, revoke |

No telemetry is collected by the plugin.

**Credentials/permissions it requires (and why):** a Ballet account. Authentication is browser-based OAuth 2.1 with PKCE — there is no API key to paste and no credential committed to the source repo. The MCP client performs dynamic client registration (RFC 7591) and opens a Ballet consent page on first use; approving issues a 1-hour access token plus a rotating refresh token, held by the MCP client. Tools operate only on the workspace of the approved account. Access is revocable from Ballet workspace settings or via `POST /oauth/revoke`.

Secret values are write-only across the tool surface: `list_secrets` returns names only, and no tool returns a secret value.

## Notes for reviewers

- The plugin declares no hooks and no filesystem or shell access. Its entire surface is the one hosted MCP server.
- Some tools change state: `run_playbook` executes real work against whatever systems a playbook is connected to, the `delete_*` tools are irreversible, and `create_secret` / `update_secret` write into the workspace secret store. The bundled skill instructs the agent to confirm with the user before calling any of them.
- `keywords` and `domains` are deliberately brand-scoped (`ballet`, `ballet playbook`, `ballet agent`, `brainfish ballet`) so the CTA doesn't mis-fire on generic playbook or automation requests. The three `domains` are all owned by us.
- Docs: https://docs.ballet.dev — connecting over MCP is covered at https://docs.ballet.dev/articles/how-do-i-connect-to-ballets-mcp-endpoint-1ydPKBzHZm