### PR TITLE
Add brain-bank plugin (persistent local markdown memory)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,7 @@
       },
       "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
       "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
-    }
-         
+       }
+  ]
+}  
        

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -292,6 +292,6 @@
       },
       "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
       "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
-    },
+    }
   ]  
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -268,25 +268,6 @@
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
 
-    "brain-bank": {
-      "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7",
-      "version": "0.3.0",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "brain-bank",
-            "description": "stdio"
-          }
-        ],
-        "skills": [
-          {
-            "name": "brain-bank",
-            "description": "Memória persistente do usuário em markdown. Use ao salvar ou recuperar contexto de longo prazo — projetos, pessoas, pre…"
-          }
-        ]
-      }
-    },
-    
     {
       "name": "browser-use",
       "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
@@ -301,4 +282,17 @@
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
+    {
+      "name": "brain-bank",
+      "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/jorge13en-droid/Brain-Bank-MCP.git",
+        "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7"
+      },
+      "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
+      "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
+    }
+         
        

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -281,17 +281,17 @@
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     }
-     {
-  "name": "brain-bank",
-  "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",
-  "category": "productivity",
-  "source": {
-    "source": "url",
-    "url": "https://github.com/jorge13en-droid/Brain-Bank-MCP.git",
-    "sha": "57b9dce50829e96827da86af464a1c1f95623871"
-     },
-  "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
-  "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
-    }  
+         {
+      "name": "brain-bank",
+      "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/jorge13en-droid/Brain-Bank-MCP.git",
+        "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7"
+      },
+      "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
+      "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
+    }
   ]  
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -267,6 +267,26 @@
       "homepage": "https://github.com/cursor/plugins/tree/main/pstack",
       "keywords": ["pstack", "poteto-mode", "poteto"]
     },
+
+    "brain-bank": {
+      "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7",
+      "version": "0.3.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "brain-bank",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "brain-bank",
+            "description": "Memória persistente do usuário em markdown. Use ao salvar ou recuperar contexto de longo prazo — projetos, pessoas, pre…"
+          }
+        ]
+      }
+    },
+    
     {
       "name": "browser-use",
       "description": "Give Grok a real browser — the user's own Chrome, with their logins, or an isolated Browser Use Cloud browser. Use it whenever a task involves a website or web app: browsing, scraping and data extraction, filling forms, testing sites, taking screenshots, automating web workflows. Runs locally via uvx; no API key needed for local Chrome.",
@@ -281,17 +301,4 @@
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     },
-         {
-      "name": "brain-bank",
-      "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",
-      "category": "productivity",
-      "source": {
-        "source": "url",
-        "url": "https://github.com/jorge13en-droid/Brain-Bank-MCP.git",
-        "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7"
-      },
-      "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
-      "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
-    }
-  ]  
-}
+       

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -281,5 +281,17 @@
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     }
-  ]
+     {
+  "name": "brain-bank",
+  "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",
+  "category": "productivity",
+  "source": {
+    "source": "url",
+    "url": "https://github.com/jorge13en-droid/Brain-Bank-MCP.git",
+    "sha": "57b9dce50829e96827da86af464a1c1f95623871"
+     },
+  "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
+  "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
+    }  
+  ]  
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -292,6 +292,6 @@
       },
       "homepage": "https://github.com/jorge13en-droid/Brain-Bank-MCP",
       "keywords": ["brain-bank", "memoria-persistente", "memory", "mcp", "markdown"]
-    }
+    },
   ]  
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,7 +280,7 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
-    }
+    },
          {
       "name": "brain-bank",
       "description": "Memória persistente local em markdown para qualquer IA via MCP. Nunca mais comece uma conversa do zero.",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,27 @@
         ]
       }
     },
+    
+    "brain-bank": {
+      "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7",
+      "version": "0.3.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "brain-bank",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "brain-bank",
+            "description": "Memória persistente do usuário em markdown. Use ao salvar ou recuperar contexto de longo prazo — projetos, pessoas, pre…"
+          }
+        ]
+      }
+    },
+
+    
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,7 +71,6 @@
         ]
       }
     },
-    
     "brain-bank": {
       "sha": "670b4cfe38a4fa14d34e54cebd3494d7810da6f7",
       "version": "0.3.0",
@@ -90,8 +89,6 @@
         ]
       }
     },
-
-    
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",


### PR DESCRIPTION
## Summary

Adds **brain-bank**, a local-first persistent memory plugin for Grok Build.

Brain Bank stores long-term context as plain Markdown files organized in clear folders (projects, people, preferences, instructions, etc.). It exposes a simple MCP server + skill so the agent can read and write durable memory across sessions — without cloud, databases, or lock-in.

### Why this plugin

- Solves the “AI starts from zero every conversation” problem
- Fully local (Markdown files in `~/BrainBank`)
- Zero cloud / zero lock-in
- Clean skill that teaches the agent *when* and *how* to use the memory
- Works via MCP with clear, purpose-driven folders

### Plugin details

- **Name:** `brain-bank`
- **Source:** https://github.com/jorge13en-droid/Brain-Bank-MCP
- **License:** MIT
- **Components:** MCP server + Skill
- **Install method:** `uvx brain-bank-mcp` (no manual clone required)

### Checklist

- [x] Plugin is owned by me and licensed under MIT
- [x] Remote source with full 40-char commit SHA pinned
- [x] Homepage and clear description provided
- [x] Keywords are brand-scoped (`brain-bank`, `memoria-persistente`)
- [x] No arbitrary code execution, secret exfiltration, or over-broad hooks
- [x] Skill and MCP tools are least-privilege
- [x] README clearly explains what the plugin does and how memory is stored

### Security notes

- All memory stays local on the user’s machine (`~/BrainBank`)
- No network calls by default
- Path traversal is prevented via slugify + tests
- No postinstall scripts or remote code execution
