### PR TITLE
Add nocodb plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "nocodb",
+      "description": "NocoDB integration (MCP Server + Skills). Read, create, update, and delete records in your NocoDB bases through the hosted NocoDB MCP server, and manage workspaces, bases, tables, fields, and views with the NocoDB v3 API skill.",
+      "category": "database",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/nocodb/agent-skills.git",
+        "sha": "a22f820597ce3dcee7db8ba71e90cd308d18d0ca",
+        "path": "plugins/nocodb"
+      },
+      "homepage": "https://nocodb.com/docs/product-docs/mcp",
+      "keywords": ["nocodb", "nocodb mcp", "nocodb base"],
+      "domains": ["nocodb.com", "app.nocodb.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,24 @@
         ]
       }
     },
+    "nocodb": {
+      "sha": "a22f820597ce3dcee7db8ba71e90cd308d18d0ca",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "nocodb",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "nocodb",
+            "description": "Access and manage NocoDB databases via REST APIs. Free plans support bases, tables, fields, records, links, filters, so…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "7314f723a487ec406b6369fe5865ba034cfed166",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the NocoDB plugin as a remote-source entry.

- Plugin name: `nocodb`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/nocodb/agent-skills.git` @ `a22f820597ce3dcee7db8ba71e90cd308d18d0ca`, path `plugins/nocodb`
- Homepage: https://nocodb.com/docs/product-docs/mcp

Components: one MCP server (`nocodb`, streamable HTTP at `https://app.nocodb.com/mcp`, OAuth) and one skill (`nocodb`, a CLI over the NocoDB v3 REST API for workspaces, bases, tables, fields, views, records, links, attachments, and team management).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`nocodb`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, `LICENSE` in the plugin directory and repo root).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://app.nocodb.com/mcp` (or a user's self-hosted NocoDB host): the MCP server, OAuth 2.1 with PKCE, scoped to the single workspace and base the user selects at authorization.
  - `https://app.nocodb.com/api/v3/*` (or `NOCODB_URL`): called by the skill's `nocodb.sh` / `nocodb.ps1` scripts with the user's API token in the `xc-token` header.
- Credentials/permissions it requires (and why):
  - OAuth grant to one NocoDB base for the MCP server; per-tool "ask before write" is configurable in NocoDB.
  - `NOCODB_TOKEN` env var (user-created NocoDB API token) for the skill scripts. No hooks, nothing runs at install time.

## Notes for reviewers

Same plugin directory also serves the Claude Code and Cursor marketplaces, so the `.grok-plugin/plugin.json` sits next to `.claude-plugin/` and `.cursor-plugin/` manifests. Plugin README with the endpoint list: https://github.com/nocodb/agent-skills/blob/main/plugins/nocodb/README.md