### PR TITLE
Add Unitpost plugin (remote source)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -289,7 +289,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/unitpostcom/unitpost-grok-plugin.git",
-        "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba"
+        "sha": "5b524c4d4334777fdf29f52ee593fb669d9c3273"
       },
       "homepage": "https://www.unitpost.com/ai/mcp",
       "keywords": ["unitpost"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,7 +283,7 @@
     }
     ,
     {
-      "name": "unitpost",
+      "name": "Unitpost",
       "description": "Let agents send email, with approval. Official Unitpost plugin: hosted MCP server for transactional email, campaigns, contacts, domains, and webhooks (OAuth 2.1).",
       "category": "development",
       "source": {

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -281,5 +281,19 @@
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
     }
+    ,
+    {
+      "name": "unitpost",
+      "description": "Let agents send email, with approval. Official Unitpost plugin: hosted MCP server for transactional email, campaigns, contacts, domains, and webhooks (OAuth 2.1).",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/unitpostcom/unitpost-grok-plugin.git",
+        "sha": "b2b1297f462f866447a6bf291189810d2ce8701a"
+      },
+      "homepage": "https://www.unitpost.com/ai/mcp",
+      "keywords": ["unitpost"],
+      "domains": ["unitpost.com", "mcp.unitpost.com"]
+    }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -289,7 +289,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/unitpostcom/unitpost-grok-plugin.git",
-        "sha": "ab5ff9954dce2406808ccc5429e10fb794102776"
+        "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba"
       },
       "homepage": "https://www.unitpost.com/ai/mcp",
       "keywords": ["unitpost"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -289,7 +289,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/unitpostcom/unitpost-grok-plugin.git",
-        "sha": "b2b1297f462f866447a6bf291189810d2ce8701a"
+        "sha": "ab5ff9954dce2406808ccc5429e10fb794102776"
       },
       "homepage": "https://www.unitpost.com/ai/mcp",
       "keywords": ["unitpost"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,7 +283,7 @@
     }
     ,
     {
-      "name": "Unitpost",
+      "name": "unitpost",
       "description": "Let agents send email, with approval. Official Unitpost plugin: hosted MCP server for transactional email, campaigns, contacts, domains, and webhooks (OAuth 2.1).",
       "category": "development",
       "source": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1016,7 +1016,7 @@
       }
     },
     "unitpost": {
-      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
+      "sha": "5b524c4d4334777fdf29f52ee593fb669d9c3273",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,23 @@
 {
   "version": 1,
   "plugins": {
+    "Unitpost": {
+      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "unitpost",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "unitpost",
+            "description": "Use when sending transactional or marketing email; managing contacts, segments, topics, templates, Brand Kit (on-brand…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",
@@ -1011,23 +1028,6 @@
           {
             "name": "tinyfish-web",
             "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
-          }
-        ]
-      }
-    },
-    "unitpost": {
-      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "unitpost",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "unitpost",
-            "description": "Use when sending transactional or marketing email; managing contacts, segments, topics, templates, Brand Kit (on-brand…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1015,6 +1015,23 @@
         ]
       }
     },
+    "unitpost": {
+      "sha": "b2b1297f462f866447a6bf291189810d2ce8701a",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "unitpost",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "unitpost",
+            "description": "Use when sending transactional or marketing email; managing contacts, segments, topics, templates, Brand Kit (on-brand…"
+          }
+        ]
+      }
+    },
     "vercel": {
       "sha": "7b0a6f61b254b0149bb644cadfb588a5c46df0c2",
       "version": "0.48.2",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1016,7 +1016,7 @@
       }
     },
     "unitpost": {
-      "sha": "b2b1297f462f866447a6bf291189810d2ce8701a",
+      "sha": "ab5ff9954dce2406808ccc5429e10fb794102776",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1016,7 +1016,7 @@
       }
     },
     "unitpost": {
-      "sha": "ab5ff9954dce2406808ccc5429e10fb794102776",
+      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,23 +1,6 @@
 {
   "version": 1,
   "plugins": {
-    "Unitpost": {
-      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
-      "components": {
-        "mcpServers": [
-          {
-            "name": "unitpost",
-            "description": "http"
-          }
-        ],
-        "skills": [
-          {
-            "name": "unitpost",
-            "description": "Use when sending transactional or marketing email; managing contacts, segments, topics, templates, Brand Kit (on-brand…"
-          }
-        ]
-      }
-    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",
@@ -1028,6 +1011,23 @@
           {
             "name": "tinyfish-web",
             "description": "Pick the right TinyFish tool for a web task. Use when a request involves the live web — searching, reading pages, extra…"
+          }
+        ]
+      }
+    },
+    "unitpost": {
+      "sha": "13d46cf62515a5e983d54d00ab8b60c5b821daba",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "unitpost",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "unitpost",
+            "description": "Use when sending transactional or marketing email; managing contacts, segments, topics, templates, Brand Kit (on-brand…"
           }
         ]
       }


### PR DESCRIPTION
## What this PR does

New plugin: **Unitpost**. It lets Grok agents send email (with approval), run campaigns, and manage contacts, domains, and webhooks through the user's Unitpost workspace. Ships one remote MCP server + one skill.

- Plugin name: `unitpost`
- Type: remote source (nothing vendored in this repo)
- Source URL + pinned SHA (remote): `https://github.com/unitpostcom/unitpost-grok-plugin.git` @ `5b524c4d4334777fdf29f52ee593fb669d9c3273`
- Homepage: https://www.unitpost.com/ai/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (unitpostcom).

Unitpost is an email platform (Work Reactor Inc.). `unitpostcom/unitpost-grok-plugin` is our official plugin repo (MIT), mirrored by CI from our monorepo's `connectors/grok/` source of truth.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The pinned commit is on `main` in a public repo. The plugin directory includes a `README.md` and `.plugin/plugin.json` (`version: 0.1.0`, MIT), plus `skills/unitpost/SKILL.md` and brand assets.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.unitpost.com/mcp` (the hosted MCP server itself); `https://www.unitpost.com/oauth/*` + `/.well-known/oauth-*` (OAuth 2.1 browser approval — the only auth; no credentials are baked into the plugin).
- Credentials/permissions it requires (and why): per-user OAuth consent with workspace scopes; send tools additionally require a verified sending domain and in-app approval.

## Notes for reviewers

The plugin is a thin wrapper: no hooks, scripts, commands, or agents — one remote MCP server entry plus the skill markdown. Happy to adjust anything to fit review.