### PR TITLE
Add Convoy plugin — orchestrate harnesses on a GitHub repo from Grok Bot

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -288,7 +288,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Deploy-Forward/convoy.git",
-        "sha": "b4b186d925bdb24e414cedd8abfa208d342d98b9",
+        "sha": "9743e2dea061ee2dcdff074c7ff87599be9c00d3",
         "path": "plugin/convoy"
       },
       "homepage": "https://convoy.bot",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,6 +280,20 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
+    },
+    {
+      "name": "convoy",
+      "description": "Orchestrate BYO AI harnesses as neurons on one Convoy thread with a live, fail-closed MCP wizard.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Deploy-Forward/convoy.git",
+        "sha": "b4b186d925bdb24e414cedd8abfa208d342d98b9",
+        "path": "plugin/convoy"
+      },
+      "homepage": "https://convoy.bot",
+      "keywords": ["convoy", "convoy wizard", "convoy bot"],
+      "domains": ["convoy.bot"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -283,12 +283,12 @@
     },
     {
       "name": "convoy",
-      "description": "Orchestrate BYO AI harnesses as neurons on one Convoy thread with a live, fail-closed MCP wizard.",
+      "description": "Convoy lets Grok Bot orchestrate BYO harnesses (Claude, Codex, Grok, and more) as neurons against a GitHub repo or local checkout on one thread, with a fail-closed live MCP wizard.",
       "category": "development",
       "source": {
         "source": "url",
         "url": "https://github.com/Deploy-Forward/convoy.git",
-        "sha": "9743e2dea061ee2dcdff074c7ff87599be9c00d3",
+        "sha": "46067263bde3d13e5d1dc2421ea2934a0a4bc9c3",
         "path": "plugin/convoy"
       },
       "homepage": "https://convoy.bot",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,7 +200,7 @@
       }
     },
     "convoy": {
-      "sha": "b4b186d925bdb24e414cedd8abfa208d342d98b9",
+      "sha": "9743e2dea061ee2dcdff074c7ff87599be9c00d3",
       "version": "0.1.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -199,6 +199,28 @@
         ]
       }
     },
+    "convoy": {
+      "sha": "b4b186d925bdb24e414cedd8abfa208d342d98b9",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "convoy",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "convoy",
+            "description": "/convoy orchestrates Convoy using live tools/list, never a frozen catalog."
+          },
+          {
+            "name": "convoy-wizard",
+            "description": "Optional @convoy wizard: fail-closed live-tool preflight, then ONE card (harness -> model -> effort | attach, usage rem…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -200,7 +200,7 @@
       }
     },
     "convoy": {
-      "sha": "9743e2dea061ee2dcdff074c7ff87599be9c00d3",
+      "sha": "46067263bde3d13e5d1dc2421ea2934a0a4bc9c3",
       "version": "0.1.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds the official Convoy plugin to the marketplace.

- **Plugin name:** `convoy`
- **Type:** remote source
- **Source URL + pinned SHA:** `https://github.com/Deploy-Forward/convoy.git` @ `46067263bde3d13e5d1dc2421ea2934a0a4bc9c3` (`path`: `plugin/convoy`)
- **Homepage:** https://convoy.bot
- **Logo:** Deploy Forward mark at `plugin/convoy/assets/logo.svg` (referenced from `.grok-plugin/plugin.json`)

### What Convoy is

Convoy turns **Grok Bot into a conductor** for multi-harness coding work. You attach Convoy once, then orchestrate BYO CLI harnesses — Claude, Codex, Grok, Cursor Agent, and others you already have — as **neurons** against a **GitHub repository or local checkout**, all on **one shared thread**.

Instead of juggling separate sessions, `@convoy` runs a fail-closed live MCP wizard: one card for GitHub (optional) → harness / model / effort → N neurons → one thread window. Skills orchestrate; the live MCP endpoint owns every verb (no frozen tool menu).

### Plugin contents

Hosted MCP + 2 skills (Exa-shaped layout):

| Component | What it does |
|---|---|
| MCP `convoy` (`https://convoy.bot/mcp`) | Live roster, thread/context, send, feed, bring-up, wizard verbs (`card`, `repos`, `crew`, …) |
| Skill `convoy` | Orchestrate using live `tools/list` only — never a hardcoded menu |
| Skill `convoy-wizard` | Optional `@convoy` one-card walk: Gate 0 preflight → GitHub → N neurons → observed connects |

### Why this belongs in the catalog

- Published under the official **Deploy-Forward** org ([Deploy-Forward/convoy](https://github.com/Deploy-Forward/convoy), MIT).
- Pack matches [exa-labs/exa-grok-plugin](https://github.com/exa-labs/exa-grok-plugin): `.mcp.json` (`type: http`), `skills/`, `.grok-plugin/plugin.json` + logo.
- **No credentials** on the public MCP path: no API key, env scrape, OAuth, or GitHub token in `.mcp.json`. Public write verbs stay hidden until a gated deploy sets `CONVOY_MCP_WRITE_TOOLS=1`.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (Deploy-Forward/convoy).

I'm with Deploy Forward; Convoy is our open-source Grok Bot / multi-harness orchestration product.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; pack includes `README.md` + `.grok-plugin/plugin.json` + logo.
- [x] License is stated (MIT).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- **Network endpoints:** `https://convoy.bot/mcp` only (Deploy Forward hosted MCP).
- **Credentials:** none required to install or list tools. Public deploy is read-oriented; mutating wizard verbs are write-gated by design. No IDE/OAuth login is required for the plugin itself.

## Notes for reviewers

**Install (honest):** Once this catalog entry merges, Convoy is meant to be discoverable from the **xAI plugin marketplace index** this repo powers. Client chrome differs by product and build:

- **Grok Bot** — look for Plugins / marketplace surfaces that read `.grok-plugin/marketplace.json` (labels like Marketplace / Yours / Connectors may vary by build; do not treat any one click-path as universal).
- **Grok Build** — `/marketplace` → `convoy` → `i` when that slash command is enabled on the build.

Until this PR merges, Convoy will not appear in any live marketplace UI. This submission does not claim a verified end-to-end install screenshot on every client.

Keywords are brand-scoped (`convoy`, `convoy wizard`, `convoy bot`). Domain: `convoy.bot`.

**Known limitation:** Public `https://convoy.bot/mcp` may still briefly serve an older tools/list until the Python origin is restarted onto this tip; the wizard **fail-closes** (Gate 0 RED) rather than inventing tools. The pack itself is complete. After origin restart, public reads expand; write verbs remain hidden unless `CONVOY_MCP_WRITE_TOOLS=1` on a gated endpoint.

Pin includes wizard pack ([Deploy-Forward/convoy#52](https://github.com/Deploy-Forward/convoy/pull/52)) + Deploy Forward logo ([#54](https://github.com/Deploy-Forward/convoy/pull/54)).