### PR TITLE
Add Fibery plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "fibery",
+      "description": "Fibery MCP server packaged as a Cursor plugin. Connect to Fibery via OAuth remote MCP for workspace schema, queries, entities, and docs.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Fibery-inc/fibery-cursor-plugin.git",
+        "sha": "91a38503f007dd1268c67b40dd99ed246d94a0f9"
+      },
+      "homepage": "https://github.com/Fibery-inc/fibery-cursor-plugin",
+      "keywords": ["fibery", "fibery mcp", "fibery workspace"],
+      "domains": ["fibery.com", "fibery.io", "mcp.fibery.io"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -223,6 +223,24 @@
         ]
       }
     },
+    "fibery": {
+      "sha": "91a38503f007dd1268c67b40dd99ed246d94a0f9",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "fibery",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "use-fibery-mcp",
+            "description": "Use when working with a Fibery workspace — schema, databases, entities, queries, documents, or user guide. Prefer Fiber…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "ae7e5e5f80da20f1dd7445e0c6ae5ac58a5b0bce",
       "version": "2.2.107",


### PR DESCRIPTION
## Summary
Adds **Fibery** as a third-party remote plugin pointing at the official org repo.

- Source: https://github.com/Fibery-inc/fibery-cursor-plugin (official Fibery-inc)
- Pinned SHA: `91a38503f007dd1268c67b40dd99ed246d94a0f9`
- Layout: `.mcp.json` (HTTP MCP → `https://mcp.fibery.io/mcp`), `.grok-plugin/plugin.json`, optional thin skill; skills primarily provided by the remote MCP after OAuth
- No secrets in repo, no hooks, no shell MCP — OAuth remote HTTP only
- homepage: https://fibery.com

## Validation
Locally ran:
- `python3 scripts/generate-plugin-index.py`
- `python3 scripts/validate-catalog.py`
- `python3 scripts/generate-plugin-index.py --check`

## Checklist
- [x] One kebab-case unique entry in `.grok-plugin/marketplace.json`
- [x] Remote source pins full 40-char lowercase commit SHA
- [x] `.grok-plugin/plugin-index.json` regenerated
- [x] Official org source (not personal account)
- [x] Homepage + description + brand-scoped keywords/domains
