### PR TITLE
Add taskbullet-agent plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/GriffMurder/taskbullet-agent-plugin.git",
-        "sha": "a27e3e1cfc7952f6524ce82c773384e9b349c659"
+        "sha": "c62be95401d45a7ab6fb6de2e633720c8e6078f1"
       },
       "homepage": "https://taskbullet.com/docs/agent-api",
       "keywords": ["taskbullet", "taskbullet agent", "taskbullet va", "delegate_task"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/GriffMurder/taskbullet-agent-plugin.git",
-        "sha": "14677276ae328b5c14ac71bb96c16ebbeee7fad9"
+        "sha": "fd7dd1aa09b097b53c2d05b2d725b9e061955438"
       },
       "homepage": "https://taskbullet.com/docs/agent-api",
       "keywords": ["taskbullet", "taskbullet agent", "taskbullet va", "get_balance", "delegate_task"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -296,15 +296,15 @@
     },
     {
       "name": "taskbullet-agent",
-      "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant. Hosted MCP at https://taskbullet.com/api/agent-mcp with delegate_task, list_tasks, and get_task.",
+      "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant. Hosted MCP at https://taskbullet.com/api/agent-mcp with get_balance, delegate_task, list_tasks, and get_task.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/GriffMurder/taskbullet-agent-plugin.git",
-        "sha": "c62be95401d45a7ab6fb6de2e633720c8e6078f1"
+        "sha": "14677276ae328b5c14ac71bb96c16ebbeee7fad9"
       },
       "homepage": "https://taskbullet.com/docs/agent-api",
-      "keywords": ["taskbullet", "taskbullet agent", "taskbullet va", "delegate_task"],
+      "keywords": ["taskbullet", "taskbullet agent", "taskbullet va", "get_balance", "delegate_task"],
       "domains": ["taskbullet.com"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "taskbullet-agent",
+      "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant. Hosted MCP at https://taskbullet.com/api/agent-mcp with delegate_task, list_tasks, and get_task.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/GriffMurder/taskbullet-agent-plugin.git",
+        "sha": "a27e3e1cfc7952f6524ce82c773384e9b349c659"
+      },
+      "homepage": "https://taskbullet.com/docs/agent-api",
+      "keywords": ["taskbullet", "taskbullet agent", "taskbullet va", "delegate_task"],
+      "domains": ["taskbullet.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -948,7 +948,7 @@
       }
     },
     "taskbullet-agent": {
-      "sha": "14677276ae328b5c14ac71bb96c16ebbeee7fad9",
+      "sha": "fd7dd1aa09b097b53c2d05b2d725b9e061955438",
       "version": "1.0.1",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -948,8 +948,8 @@
       }
     },
     "taskbullet-agent": {
-      "sha": "c62be95401d45a7ab6fb6de2e633720c8e6078f1",
-      "version": "1.0.0",
+      "sha": "14677276ae328b5c14ac71bb96c16ebbeee7fad9",
+      "version": "1.0.1",
       "components": {
         "mcpServers": [
           {
@@ -960,7 +960,7 @@
         "skills": [
           {
             "name": "escalate-to-va",
-            "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant via delegate_task. Use when the ta…"
+            "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant. Call get_balance first, confirm s…"
           }
         ]
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -947,6 +947,24 @@
         ]
       }
     },
+    "taskbullet-agent": {
+      "sha": "a27e3e1cfc7952f6524ce82c773384e9b349c659",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "taskbullet-agent",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "escalate-to-va",
+            "description": "Escalate work a language model cannot finish to a TaskBullet human virtual assistant via delegate_task. Use when the ta…"
+          }
+        ]
+      }
+    },
     "tavily": {
       "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -948,7 +948,7 @@
       }
     },
     "taskbullet-agent": {
-      "sha": "a27e3e1cfc7952f6524ce82c773384e9b349c659",
+      "sha": "c62be95401d45a7ab6fb6de2e633720c8e6078f1",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## Plugin
- **Name:** taskbullet-agent
- **Source:** https://github.com/GriffMurder/taskbullet-agent-plugin.git
- **SHA:** fd7dd1aa09b097b53c2d05b2d725b9e061955438
- **Homepage:** https://taskbullet.com/docs/agent-api
- **License:** MIT

## What it does
Hosted streamable-HTTP MCP at `https://taskbullet.com/api/agent-mcp` plus skill `escalate-to-va`. Tools: `get_balance`, `delegate_task`, `list_tasks`, `get_task`. Cloud Grok Bots / Cursor escalate human-only work (phone, 2FA, captcha, physical world) to a TaskBullet VA. Never invents VA results.

## Security
- No scripts, hooks, or shell MCP. HTTP MCP only.
- Network: `taskbullet.com` (`/api/agent-mcp`).
- Credentials: user-supplied `tb_live_` key via plugin variable `TASKBULLET_API_KEY` / `x-api-key`. No secrets in the repo.
- I own TaskBullet and this plugin.

## Checklist
- [x] `python scripts/validate-catalog.py`
- [x] plugin-index regenerated for taskbullet-agent (extract_plugin at pinned SHA)
- [x] SHA pinned (full 40-char)
- [x] README + homepage
