### PR TITLE
Add Hormi plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "hormi",
+      "description": "Hormi shared household expense tracker (MCP server + skills). Record expenses and incomes, review spending by category and member, read the monthly report, and manage the household's shared categories through Hormi's hosted OAuth MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/hormiapp/hormi-plugins.git",
+        "sha": "527bdd0ac162eee1eb725308365bb12adbbda88a"
+      },
+      "homepage": "https://hormi.app/mcp",
+      "keywords": ["hormi", "hormi app", "hormi gastos", "hormi plus"],
+      "domains": ["hormi.app", "api.hormi.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,32 @@
         ]
       }
     },
+    "hormi": {
+      "sha": "527bdd0ac162eee1eb725308365bb12adbbda88a",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "hormi",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "categorias",
+            "description": "Keep a Hormi household's expense categories tidy - list, create, rename and delete categories through the Hormi MCP ser…"
+          },
+          {
+            "name": "registrar-gastos",
+            "description": "Record, correct and delete household expenses and incomes in Hormi through its MCP server, the way a careful assistant…"
+          },
+          {
+            "name": "resumen-de-gastos",
+            "description": "Answer questions about a household's spending in Hormi - totals, category and member breakdowns, balances and the month…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds **Hormi**, a shared household expense tracker used across Latin America and Spain, as a remote-source plugin. It ships a hosted OAuth MCP server plus three skills that teach the agent the product's rules before it calls a tool.

- Plugin name: `hormi`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/hormiapp/hormi-plugins.git` @ `527bdd0ac162eee1eb725308365bb12adbbda88a`
- Homepage: https://hormi.app/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`hormiapp`, the org behind hormi.app).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; the source repo has a `README.md` and a `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, in the manifest and a `LICENSE` file).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):** exactly one, `https://api.hormi.app/mcp` — the product's own MCP server, over HTTPS streamable HTTP. There are no other network calls, and no local code execution of any kind: the plugin is one `.mcp.json`, three `SKILL.md` files and a PNG. No hooks, commands, agents, binaries, install scripts or dependencies.

**Credentials/permissions it requires (and why):** OAuth 2.1 (authorization code + PKCE S256, dynamic client registration per RFC 7591, resource binding per RFC 8707). The user signs in to Hormi once and approves scopes on a consent screen; no credentials ship in the repo. Scopes requested: `profile:read`, `expenses:read`, `expenses:write`, `incomes:read`, `incomes:write`, `categories:read`, `categories:write`, `households:read`, `reports:read`. No scope exists for the account, the subscription or household membership, and a user can only edit or delete their own records.

## Notes for reviewers

- All three commands were run locally before opening this: `validate-catalog.py`, `generate-plugin-index.py`, and `generate-plugin-index.py --check`. The regenerated index resolves the pinned commit and lists 1 MCP server and 3 skills.
- Write tools carry MCP tool annotations; the delete tools set `destructiveHint`, and the bundled skills require showing the record and getting an explicit confirmation before any deletion.
- Access is a paid feature: without an active Hormi plan the tools return `subscription_required` rather than failing opaquely. The 14-day trial counts.
- The source repo also carries `.claude-plugin/`, `.cursor-plugin/` and `.plugin/` manifests. Same plugin, one shared `.mcp.json` and `skills/` — per-client manifests as peers, no client-specific content.