### PR TITLE
Add Helena by Enrich Labs

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,10 +301,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
-        "sha": "39e662fe75d497b68fdea2d203d610a398c80254"
+        "sha": "42717a0fc19ae2ea3ba0ee68c7387cfcbc913d1a"
       },
       "homepage": "https://enrichlabs.ai",
-      "keywords": ["helena", "enrich labs", "helena ai marketer", "helena autonomous marketer", "helena marketing"],
+      "keywords": ["helena", "enrich labs", "helena ai marketer", "helena marketing ai agent", "helena autonomous marketer", "helena marketing"],
       "domains": ["enrichlabs.ai", "agent.enrichlabs.ai"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -296,15 +296,15 @@
     },
     {
       "name": "helena",
-      "description": "Helena by Enrich Labs connects Grok to a brand-aware AI marketing coordinator for campaign planning, research, copy, and image, video, and audio creation.",
+      "description": "Helena by Enrich Labs gives Grok an AI marketer for Shopify brands. It uses live brand and commerce context to research opportunities, shape strategy, build campaigns, create on-brand copy and media, and execute across connected marketing channels.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
-        "sha": "4d5e8aba3a40baba26e8cafc91abdebf30c8bf50"
+        "sha": "207d3ce083666fe06ea090bff60bdcaeaf3343e3"
       },
       "homepage": "https://enrichlabs.ai",
-      "keywords": ["helena", "enrich labs", "helena ai marketing coordinator", "helena mcp"],
+      "keywords": ["helena", "enrich labs", "helena ai marketer", "helena mcp"],
       "domains": ["enrichlabs.ai", "agent.enrichlabs.ai"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -296,12 +296,12 @@
     },
     {
       "name": "helena",
-      "description": "Helena is an AI marketer that learns your business and executes campaigns across SEO, ads, social, and email.",
+      "description": "Helena is an AI marketer that learns your business and plans, launches, and optimizes campaigns across SEO, ads, social, and email.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
-        "sha": "42717a0fc19ae2ea3ba0ee68c7387cfcbc913d1a"
+        "sha": "29dd06b5cb25a8a7426326f901cb8687af70ce99"
       },
       "homepage": "https://enrichlabs.ai",
       "keywords": ["helena", "enrich labs", "helena ai marketer", "helena marketing ai agent", "helena autonomous marketer", "helena marketing"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -296,15 +296,15 @@
     },
     {
       "name": "helena",
-      "description": "Helena by Enrich Labs brings the first autonomous AI marketer to Grok. She learns your brand, builds a personalized strategy, and executes it 24/7—writing, publishing, optimizing, and reporting across SEO, social, ads, and email.",
+      "description": "Helena is an AI marketer that learns your business and executes campaigns across SEO, ads, social, and email.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
-        "sha": "41a1ed56d7d7f969bcd06df1bf52a4ceafab725c"
+        "sha": "39e662fe75d497b68fdea2d203d610a398c80254"
       },
       "homepage": "https://enrichlabs.ai",
-      "keywords": ["helena", "enrich labs", "helena ai marketer", "helena mcp"],
+      "keywords": ["helena", "enrich labs", "helena ai marketer", "helena autonomous marketer", "helena marketing"],
       "domains": ["enrichlabs.ai", "agent.enrichlabs.ai"]
     }
   ]

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -296,12 +296,12 @@
     },
     {
       "name": "helena",
-      "description": "Helena by Enrich Labs gives Grok an AI marketer for Shopify brands. It uses live brand and commerce context to research opportunities, shape strategy, build campaigns, create on-brand copy and media, and execute across connected marketing channels.",
+      "description": "Helena by Enrich Labs brings the first autonomous AI marketer to Grok. She learns your brand, builds a personalized strategy, and executes it 24/7—writing, publishing, optimizing, and reporting across SEO, social, ads, and email.",
       "category": "productivity",
       "source": {
         "source": "url",
         "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
-        "sha": "207d3ce083666fe06ea090bff60bdcaeaf3343e3"
+        "sha": "41a1ed56d7d7f969bcd06df1bf52a4ceafab725c"
       },
       "homepage": "https://enrichlabs.ai",
       "keywords": ["helena", "enrich labs", "helena ai marketer", "helena mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "helena",
+      "description": "Helena by Enrich Labs connects Grok to a brand-aware AI marketing coordinator for campaign planning, research, copy, and image, video, and audio creation.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/EnrichLabsAI/helena-grok-plugin.git",
+        "sha": "4d5e8aba3a40baba26e8cafc91abdebf30c8bf50"
+      },
+      "homepage": "https://enrichlabs.ai",
+      "keywords": ["helena", "enrich labs", "helena ai marketing coordinator", "helena mcp"],
+      "domains": ["enrichlabs.ai", "agent.enrichlabs.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "helena": {
-      "sha": "4d5e8aba3a40baba26e8cafc91abdebf30c8bf50",
+      "sha": "207d3ce083666fe06ea090bff60bdcaeaf3343e3",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,18 @@
         ]
       }
     },
+    "helena": {
+      "sha": "4d5e8aba3a40baba26e8cafc91abdebf30c8bf50",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "helena",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "helena": {
-      "sha": "42717a0fc19ae2ea3ba0ee68c7387cfcbc913d1a",
+      "sha": "29dd06b5cb25a8a7426326f901cb8687af70ce99",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "helena": {
-      "sha": "41a1ed56d7d7f969bcd06df1bf52a4ceafab725c",
+      "sha": "39e662fe75d497b68fdea2d203d610a398c80254",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "helena": {
-      "sha": "207d3ce083666fe06ea090bff60bdcaeaf3343e3",
+      "sha": "41a1ed56d7d7f969bcd06df1bf52a4ceafab725c",
       "version": "1.0.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -358,7 +358,7 @@
       }
     },
     "helena": {
-      "sha": "39e662fe75d497b68fdea2d203d610a398c80254",
+      "sha": "42717a0fc19ae2ea3ba0ee68c7387cfcbc913d1a",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

- Plugin name: `helena`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/EnrichLabsAI/helena-grok-plugin.git` at `9b71516e006144d323f138f1785f55123ec51931`
- Homepage: https://enrichlabs.ai

Adds the official Enrich Labs Helena plugin. Helena is an AI marketer that learns the user's business and plans, launches, and optimizes campaigns across SEO, ads, social, and email. The package contains one remote Streamable HTTP MCP server and no scripts, hooks, binaries, dependencies, or bundled credentials.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The source is published by the official `EnrichLabsAI` GitHub organization and licensed under Apache-2.0.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://agent.enrichlabs.ai/api/mcp`, the canonical Enrich Labs Streamable HTTP MCP endpoint used for Helena conversations and approved actions. The shorter setup URL `https://enrichlabs.ai/mcp` is only a reverse proxy to this same endpoint; both URLs reach the same MCP service and OAuth flow.
- Credentials/permissions it requires (and why): Enrich Labs OAuth 2.1 with PKCE. The user signs in, selects an Enrich Labs account, and authorizes Grok to call Helena for that account. Access requires completed onboarding and an eligible Enrich Labs plan.

The MCP tool is marked potentially destructive because, when explicitly asked and authorized by the user, Helena can use connected services to publish content, change storefront or campaign state, contact customers, or spend money. This capability and the approval boundary are disclosed in the source README.

## Notes for reviewers

The generated index identifies version `1.0.0` and exactly one MCP component, `helena`. The public source commit was also verified with `git ls-remote` before submission.
