### PR TITLE
Add agentguard plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,18 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "agentguard",
+      "description": "Scan agent extensions for unsafe patterns before you install them. Static rules cover skills, plugins, hooks and MCP server configs, flagging prompt injection, credential exfiltration, unpinned sources and insecure transport. Runs as a CLI or a GitHub Action.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/tainguyen091994/agentguard.git",
+        "sha": "97bb8dba240a3519f58f28f53c3719f3d6f2816c"
+      },
+      "homepage": "https://github.com/tainguyen091994/agentguard",
+      "keywords": ["agentguard", "agentguard scan", "agent guard"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "agentguard": {
+      "sha": "97bb8dba240a3519f58f28f53c3719f3d6f2816c",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "agentguard-review",
+            "description": "Scan agent extensions for unsafe patterns and explain the findings. Use before installing a skill, plugin, hook, or MCP…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds one remote-source catalog entry for agentguard, a scanner for agent extensions.

- Plugin name: `agentguard`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/tainguyen091994/agentguard.git` @ `97bb8dba240a3519f58f28f53c3719f3d6f2816c`
- Homepage: https://github.com/tainguyen091994/agentguard

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (explained below).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated: Apache-2.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): **none.** The scanner reads files from the local scan root and matches them against rules. There is no telemetry, no update check, and no outbound request at any point.
- Credentials/permissions it requires (and why): **none.** Read access to the directory being scanned is all it uses.

The plugin ships one skill (`agentguard-review`) and nothing else. No hooks, no MCP servers, no commands, no agents. The single runtime dependency is `yaml`. The only `exec` calls in the source are `RegExp.prototype.exec`, not `child_process`.

## Notes for reviewers

**On the personal-account source.** agentguard is an individual open-source project, not a product of a company whose brand it carries, so there is no official org to move it under. The name is not a brand belonging to anyone else, which I hope makes the impersonation concern in CONTRIBUTING inapplicable here. If you would prefer it vendored under `external_plugins/` instead of a remote source, I am happy to resubmit that way.

**Relationship to this repo.** agentguard's `AG012` rule enforces the same policy this marketplace does: a plugin source that points at a remote repo without a pinned commit SHA is flagged, and the rule cites this repo's requirement as the reason. Two further rules (`AG016`, `AG017`) exist because Grok Build and Claude Code share an extension layout but not their environment variables, so a hook written for one silently breaks on the other.

**Maturity, stated plainly.** The project is new: first commit 2026-09-04, 0 stars at the time of writing, published to npm as `@hachiman94/agentguard`. It has 19 rules, each a YAML file with a passing and a failing fixture, and CI runs the full fixture suite on Linux, macOS and Windows against Node 20 and 22. I would rather you know that up front than find it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
