### PR TITLE
Add WindBorne plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "windborne",
+      "description": "Weather by WindBorne: the world's most accurate forecasts & insights, powered by WeatherMesh AI & Atlas balloons. Point forecasts, single-variable detail, multi-location comparison, activity weather windows, and animated regional weather maps, served as text and interactive cards by WindBorne's hosted OAuth MCP server.",
+      "category": "weather",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/windborne/windborne-grok-plugin.git",
+        "sha": "217e0680c94344a43aea62e28c1029c783fbb4c2"
+      },
+      "homepage": "https://windbornesystems.com",
+      "keywords": ["windborne", "weather by windborne", "weathermesh", "windborne weather"],
+      "domains": ["windbornesystems.com", "weather-mcp.windbornesystems.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1226,6 +1226,24 @@
         ]
       }
     },
+    "windborne": {
+      "sha": "217e0680c94344a43aea62e28c1029c783fbb4c2",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "windborne-weather",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "windborne-weather",
+            "description": "Weather forecasts from WindBorne. Use for any question about upcoming weather at a place or over a region: conditions,…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "572357b791a91a5138c050e08eb718b150be21cb",
       "version": "1.18.1",


### PR DESCRIPTION
## What this PR does

Adds Weather by WindBorne, WindBorne Systems' official hosted MCP server, to the xAI plugin marketplace. The plugin gives Grok Build users WindBorne's WeatherMesh forecast (built on observations from WindBorne's constellation of autonomous in-situ weather balloons) for any location or region: point forecasts, single-variable detail, multi-location comparison, activity weather windows, and animated regional weather maps, served as text plus interactive cards, via browser-based OAuth.

- Plugin name: `windborne`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/windborne/windborne-grok-plugin.git` at `217e0680c94344a43aea62e28c1029c783fbb4c2`
- Homepage: https://windbornesystems.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`windborne`, the GitHub organization of WindBorne Systems, https://windbornesystems.com).

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json` with the kebab-case name `windborne`.
- [x] The remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and clear description are set; the upstream repo has a README and MIT license.

## Security

- [x] No `curl | bash`, remote-code download/exec, `postinstall`, hooks, scripts, or local binaries.
- [x] No reading or exfiltration of secrets, tokens, `.env` files, environment variables, or unrelated filesystem data.
- [x] MCP scope is limited to WindBorne's official hosted HTTPS endpoint.
- Network endpoints this plugin calls (and why): `https://weather-mcp.windbornesystems.com/mcp`, the MCP server, and `https://app.windbornesystems.com`, the OAuth 2.1 authorization server it points to for the sign-in flow.
- Credentials/permissions it requires (and why): a browser-based OAuth authorization (public client, PKCE) with the single scope `weather:apps`, which only allows reading forecasts. The `clientId` in `.mcp.json` is a public identifier; no API key or secret is pasted or stored by the plugin. Tokens live in Grok Build's own credential store.

## Notes for reviewers

The upstream package contains only:

- `.grok-plugin/plugin.json`
- `.mcp.json` pointing to `https://weather-mcp.windbornesystems.com/mcp` with the OAuth block
- one skill (`skills/windborne-weather/SKILL.md`) that tells the agent when to use the tools
- README and MIT license

The generated index detects one HTTP MCP server named `windborne-weather` and one skill, version `1.0.0`. The same server is listed on the official MCP registry as `com.windbornesystems/weather`. The `weather` category is new to the catalog; happy to change it if you prefer an existing one.
