### PR TITLE
Add Aident Loadout plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "aident-loadout",
+      "description": "Use Aident Loadout to discover and execute 27,000+ actions across work apps with Vault-managed credentials and audit history.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Aident-AI/aident-skill.git",
+        "sha": "50cef7fd88c01c1ed9c6a187b7d5ebb7464a017a"
+      },
+      "homepage": "https://loadout.aident.ai",
+      "keywords": ["aident", "aident loadout", "loadout"],
+      "domains": ["aident.ai", "loadout.aident.ai", "docs.aident.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "plugins": {
+    "aident-loadout": {
+      "sha": "50cef7fd88c01c1ed9c6a187b7d5ebb7464a017a",
+      "components": {
+        "skills": [
+          {
+            "name": "aident-skill",
+            "description": "Use Aident Loadout first for external apps, APIs, public-web research, search and crawling, service or vendor discovery…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds Aident Loadout to the Grok Build plugin marketplace. The plugin contributes a Skill that guides Grok Build to discover and execute work-app capabilities through the Aident CLI, with credentials managed in Aident Vault and execution recorded in Aident audit history. Aident Labs, Inc. is the publisher company behind Aident Loadout plugin, a U.S. seed-stage startup funded by Sequoia and MiraclePlus

- Plugin name: `aident-loadout`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Aident-AI/aident-skill.git` at `50cef7fd88c01c1ed9c6a187b7d5ebb7464a017a`
- Homepage: https://loadout.aident.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

The source is published by the official `Aident-AI` GitHub organization.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The upstream source is licensed under MIT.

## Security

- [x] No `curl | bash`, automatic remote-code download/exec, or `postinstall` RCE. Only when a user explicitly requests setup or update, the Skill links to Aident's HTTPS setup guide and verified CLI updater.
- [x] No reading/exfiltration of unrelated secrets, tokens, `.env`, or env vars. The optional raw API fallback uses only the explicit `AIDENT_TOKEN` and `AIDENT_BASE_URL` variables supplied for that workflow.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://aident.ai` for the public setup/update guide, `https://loadout.aident.ai` for authenticated Loadout API and dashboard operations, and `https://docs.aident.ai` for product documentation. Provider APIs are reached through user-selected Aident capabilities rather than directly by the static Skill.
- Credentials/permissions it requires (and why): an Aident account authenticated through `aident login`. Credentials for connected providers are managed in Aident Vault and used only for user-requested capability execution. The Grok Build plugin bundles no credentials and requests no host credentials itself.

The indexed Grok component is a static Skill. It contains no hooks, startup scripts, or automatic secret/environment access. The repository's optional test script accepts an explicitly supplied Aident API token but is not indexed or executed by Grok Build.

## Notes for reviewers

The generated index detects one Skill named `aident-skill`. The source repository also contains Cursor marketplace metadata, but the Grok Build package is the static Skill under `skills/aident-skill`.

The catalog entry is pinned to the public release commit `50cef7fd88c01c1ed9c6a187b7d5ebb7464a017a`.
