### PR TITLE
Add agent-ultramode

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,18 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "agent-ultramode",
+      "description": "Best-of-N with a reasoned same-model verifier and guided repair. /ultra runs N isolated attempts in parallel, picks the strongest with a skeptical verifier, then runs one guided repair pass that is kept only if it verifies better.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/maverick-tr/agent-ultramode.git",
+        "sha": "237fc6af9e891c79dc644774ca6906cc80cafb45"
+      },
+      "homepage": "https://github.com/maverick-tr/agent-ultramode",
+      "keywords": ["ultra", "agent-ultramode", "ultramode", "best-of-n"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "agent-ultramode": {
+      "sha": "237fc6af9e891c79dc644774ca6906cc80cafb45",
+      "version": "0.2.0",
+      "components": {
+        "skills": [
+          {
+            "name": "ultra",
+            "description": "Best-of-N with a reasoned verifier and guided repair. Invoke with /ultra <task> to run N isolated attempts in parallel,…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
Adds **agent-ultramode**, a `/ultra` slash command for Grok Build.
Repo: https://github.com/maverick-tr/agent-ultramode

`/ultra <task>` fans out N attempts in parallel isolated worktrees via `spawn_subagent`, picks the strongest with a reasoned same-model verifier, then runs one guided repair pass that is kept only if it verifies better than the winner. Attempts stream live in the Tasks pane.

### Why it is worth adding

It reliably gets results a single default agent run does not. Because the repair pass can synthesize a fix that none of the attempts produced, it goes past the best-of-N ceiling rather than just picking the least-bad attempt: on a 24-task SWE-bench Lite slice it reached **91.7%**, above the **87.5% oracle@5** of its own candidate pool, solving 2 tasks that no attempt solved. On Terminal-Bench 2.1 it lifted the same model from **78.7% base@1 to 87.6%**.

So it is aimed squarely at hard tasks where one shot is not enough, which is why it is called ultra. It uses only the host's own model and subagents, so there is no second model, no separate service and no logprob requirement.

Full method, benchmarks and the honest scope notes (including where it does **not** help) are in [PAPER.md](https://github.com/maverick-tr/agent-ultramode/blob/main/PAPER.md).

### Checklist

- Unique kebab-case name, valid JSON, appended without reformatting the rest of the catalog.
- Remote source pinned to a full 40-char lowercase SHA on a public commit: `237fc6af9e891c79dc644774ca6906cc80cafb45`.
- `plugin-index.json` regenerated with `scripts/generate-plugin-index.py` and committed. `scripts/validate-catalog.py` and `scripts/generate-plugin-index.py --check` both pass.
- `homepage`, clear `description`, product-scoped `keywords` and a `category` are set. No `domains`, since the project owns no product domain.
- Licensed **MIT**, stated in the repo's `LICENSE` and in the plugin manifest. The manifest is at `.claude-plugin/plugin.json`, which CONTRIBUTING lists as an accepted location for Claude-ecosystem plugins, and the skill lives at `skills/ultra/SKILL.md`. `grok plugin validate` passes on the repo.

### Notes for review

**This is an independent open-source project, not a vendor integration.** It is sourced from a personal account because there is no company behind it. It does not use, imply or trade on any brand, and the name refers only to the tool itself.

**Network endpoints.** The `/ultra` skill itself makes no network calls of its own: it orchestrates Grok's own subagents and tools, so all model traffic is Grok's. The repository also ships an optional standalone CLI and an opencode plugin (`cli.mjs`, `ultra.ts`) which, when used outside Grok, call an OpenAI-compatible endpoint that the user configures via `OPENAI_BASE_URL` / `OPENAI_API_KEY`. Neither is involved in the Grok plugin path. No credentials are bundled, and there is no install-time code execution.

**Verification.** The `/ultra` flow has been run end to end on a local Grok install, and separately on Claude Code.