### PR TITLE
Add LemMeBuyIt plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "lemmebuyit",
+      "description": "Official LemMeBuyIt MCP for Grok Build. Search live product catalogs across 103 US retailers, compare prices, look up stock, and pull retailer and Amazon price history through LemMeBuyIt's hosted OAuth MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/LemmeBuyIt/lemmebuyit-mcp.git",
+        "sha": "6133db55d891aa75b2b53e7d1698a6643d51aff2"
+      },
+      "homepage": "https://www.lemmebuyit.com",
+      "keywords": ["lemmebuyit", "lemme buy it", "lemmebuyit mcp"],
+      "domains": ["lemmebuyit.com", "www.lemmebuyit.com", "mcp.lemmebuyit.com", "api.lemmebuyit.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,24 @@
         ]
       }
     },
+    "lemmebuyit": {
+      "sha": "6133db55d891aa75b2b53e7d1698a6643d51aff2",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "lemmebuyit",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "lemmebuyit",
+            "description": "Use LemMeBuyIt's hosted MCP to search live US retailer catalogs, look up a product, compare prices, and pull price hist…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

- Plugin name: `lemmebuyit`
- Type: remote source
- Source URL + pinned SHA: https://github.com/LemmeBuyIt/lemmebuyit-mcp.git at `6133db55d891aa75b2b53e7d1698a6643d51aff2`
- Homepage: https://www.lemmebuyit.com

Adds LemMeBuyIt's official hosted MCP server to the xAI plugin marketplace. Grok Build users can search live product catalogs across 103 US retailers, look up stock, compare prices, and pull retailer / Amazon price history through browser-based OAuth.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is `LemmeBuyIt/lemmebuyit-mcp`, the public plugin package for the hosted server at `mcp.lemmebuyit.com`.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

Local `generate-plugin-index.py` could not fetch unrelated remotes on this machine (system git 2.10 lacks `--end-of-options`). The LemMeBuyIt index record was produced with the same `plugin_catalog.extract_plugin` path CI uses, against the pinned commit. `validate-catalog.py` passes.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.lemmebuyit.com/mcp` (official hosted MCP), plus LemMeBuyIt OAuth discovery/consent on `mcp.lemmebuyit.com` and `www.lemmebuyit.com`.
- Credentials/permissions it requires (and why): a LemMeBuyIt account authorized through browser-based OAuth. Once approved, the MCP exposes seven read-only retail search tools. No API key is pasted or stored by the plugin.

The upstream package contains only:

- `plugin.json` (Agent Plugins)
- `.cursor-plugin/plugin.json` / `.grok-plugin/plugin.json`
- `mcp.json` / `.mcp.json` pointing at `https://mcp.lemmebuyit.com/mcp` with no headers or secrets
- `skills/lemmebuyit/SKILL.md`
- README, MIT license, and logo

The generated index detects one HTTP MCP server named `lemmebuyit` and one skill, version `1.0.0`.

## Notes for reviewers

LemMeBuyIt is already listed on the official MCP registry (`com.lemmebuyit/lemmebuyit-mcp`), Claude Connectors, Smithery, and Glama. This PR is the Grok Build catalog entry for the same hosted server.