### PR TITLE
Add community NetEase email connector (MCP + skill)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,25 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "netease-email",
+      "description": "Community NetEase mailbox connector: configure your own account locally, then search/read mail and perform authorized writes. Not affiliated with NetEase.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/huaiwen/NetEaseEmailConnector.git",
+        "sha": "d805b309cae37b915e14273235169cf15b4cc741",
+        "path": "plugins/netease-email"
+      },
+      "homepage": "https://github.com/huaiwen/NetEaseEmailConnector",
+      "keywords": [
+        "netease-email-connector"
+      ],
+      "version": "0.2.0",
+      "author": {
+        "name": "huaiwen"
+      }
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/huaiwen/NetEaseEmailConnector.git",
-        "sha": "d805b309cae37b915e14273235169cf15b4cc741",
+        "sha": "4934686e069e5db0340b0fdcf0bc2d697d2c2a12",
         "path": "plugins/netease-email"
       },
       "homepage": "https://github.com/huaiwen/NetEaseEmailConnector",

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,14 +301,14 @@
       "source": {
         "source": "url",
         "url": "https://github.com/huaiwen/NetEaseEmailConnector.git",
-        "sha": "4934686e069e5db0340b0fdcf0bc2d697d2c2a12",
+        "sha": "066c98d1de08900e96ded5395f0c415dd583be48",
         "path": "plugins/netease-email"
       },
       "homepage": "https://github.com/huaiwen/NetEaseEmailConnector",
       "keywords": [
         "netease-email-connector"
       ],
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "huaiwen"
       }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -308,7 +308,7 @@
       "keywords": [
         "netease-email-connector"
       ],
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "huaiwen"
       }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -462,6 +462,24 @@
         ]
       }
     },
+    "netease-email": {
+      "sha": "d805b309cae37b915e14273235169cf15b4cc741",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "netease_email",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "netease-email",
+            "description": "Install, configure and use a personal NetEase mailbox through local IMAP/SMTP tools. Search and read mail, download att…"
+          }
+        ]
+      }
+    },
     "netlify": {
       "sha": "32a261b6b2437464aca7e51bf9b48bcac1e2835c",
       "version": "1.3.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -463,8 +463,8 @@
       }
     },
     "netease-email": {
-      "sha": "4934686e069e5db0340b0fdcf0bc2d697d2c2a12",
-      "version": "0.2.1",
+      "sha": "066c98d1de08900e96ded5395f0c415dd583be48",
+      "version": "0.2.2",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -463,8 +463,8 @@
       }
     },
     "netease-email": {
-      "sha": "d805b309cae37b915e14273235169cf15b4cc741",
-      "version": "0.2.0",
+      "sha": "4934686e069e5db0340b0fdcf0bc2d697d2c2a12",
+      "version": "0.2.1",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

Adds one community plugin, netease-email: an Agent Skill and a local stdio MCP server with eight scoped mail operations. Each user configures their own account; setup defaults to read-only.

- Type: remote source
- Source: https://github.com/huaiwen/NetEaseEmailConnector.git
- Pinned SHA: d805b309cae37b915e14273235169cf15b4cc741
- Plugin path: plugins/netease-email
- Homepage: https://github.com/huaiwen/NetEaseEmailConnector
- License: MIT

## Ownership

- [x] I own this implementation and may distribute it.
- [x] Personal-account source explained: this is an independent community project by huaiwen, not affiliated with NetEase, xAI or OpenAI. No third-party logo or domain ownership is claimed.

## Checklist

- [x] Exactly one catalog entry added, with public reachable full SHA.
- [x] Component index regenerated using the repository generator.
- [x] python3 scripts/validate-catalog.py passes.
- [x] python3 scripts/generate-plugin-index.py --check passes.
- [x] Homepage, README, Grok manifest and MIT license included.

Connector checks pass on Python 3.11–3.13. Isolated Pi skill discovery, installed wheel, npm launcher and MCP stdio checks pass. Eight real mail operations were tested on one enterprise account in v0.1.0; v0.2.0 adds packaging and configuration without changing the mail implementation. No personal mail or credentials are included.

## Security

Requires uv and Python 3.11+. No hooks, postinstall scripts, telemetry or curl-to-shell bootstrap. On user-initiated first use, uv installs the pinned release and dependencies from GitHub/Python package indexes. MCP exposes mail tools only, not a general shell.

Credential-file access is intentional: the connector reads only its own explicitly selected configuration, normally ~/.config/netease-email-connector/.env (mode 0600). It does not discover unrelated project .env files or upload credentials to the author. Account credentials go only to user-configured TLS IMAP/SMTP hosts. Standard accounts use NetEase 163/126/yeah hosts; enterprise hosts are explicitly configured. Mail results go to the invoking client/model. Writes require authorization; server read-only mode is enforced. There is no global EXPUNGE or automatic retry of uncertain sends.

## Notes for reviewers

This submission is for Grok Build, not the separate Grok Bot template marketplace. The plugin README documents required runtime installation, credential handling and network endpoints.