### PR TITLE
Add ArrowMem plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ArrowMem/arrowmem-grok-plugin.git",
-        "sha": "9dc48714a170f74bbc0ed646574367b318cea212"
+        "sha": "8646b90172bcee43134e091fff5bc9e3f2498b5d"
       },
       "homepage": "https://arrowmem.ca",
       "keywords": ["ollama", "self-hosted", "security", "mcp", "privacy"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ArrowMem/arrowmem-grok-plugin.git",
-        "sha": "942e3262da2379f2ddbdb86c2e5c6247f240ea42"
+        "sha": "51f91418361026290f4f51c14d1a4b5bf4a5ac7d"
       },
       "homepage": "https://arrowmem.ca",
       "keywords": ["ollama", "self-hosted", "security", "mcp", "privacy"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "arrowmem",
+      "description": "Check whether your self-hosted Ollama server is reachable from outside your machine, and get the complete fix. Also exposes ArrowMem's privacy and security architecture, the ArrowBridge local-model explainer, and the open Data Dignity Standard.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ArrowMem/arrowmem-grok-plugin.git",
+        "sha": "9dc48714a170f74bbc0ed646574367b318cea212"
+      },
+      "homepage": "https://arrowmem.ca",
+      "keywords": ["ollama", "self-hosted", "security", "mcp", "privacy"],
+      "domains": ["arrowmem.ca", "mcp.arrowmem.ca"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ArrowMem/arrowmem-grok-plugin.git",
-        "sha": "8646b90172bcee43134e091fff5bc9e3f2498b5d"
+        "sha": "08c18ca6a6442ba9642bd2af3ec920632062c035"
       },
       "homepage": "https://arrowmem.ca",
       "keywords": ["ollama", "self-hosted", "security", "mcp", "privacy"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/ArrowMem/arrowmem-grok-plugin.git",
-        "sha": "08c18ca6a6442ba9642bd2af3ec920632062c035"
+        "sha": "942e3262da2379f2ddbdb86c2e5c6247f240ea42"
       },
       "homepage": "https://arrowmem.ca",
       "keywords": ["ollama", "self-hosted", "security", "mcp", "privacy"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "arrowmem": {
-      "sha": "942e3262da2379f2ddbdb86c2e5c6247f240ea42",
+      "sha": "51f91418361026290f4f51c14d1a4b5bf4a5ac7d",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "arrowmem": {
-      "sha": "9dc48714a170f74bbc0ed646574367b318cea212",
+      "sha": "8646b90172bcee43134e091fff5bc9e3f2498b5d",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "arrowmem": {
-      "sha": "8646b90172bcee43134e091fff5bc9e3f2498b5d",
+      "sha": "08c18ca6a6442ba9642bd2af3ec920632062c035",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "plugins": {
+    "arrowmem": {
+      "sha": "9dc48714a170f74bbc0ed646574367b318cea212",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "arrowmem",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "arrowmem": {
-      "sha": "08c18ca6a6442ba9642bd2af3ec920632062c035",
+      "sha": "942e3262da2379f2ddbdb86c2e5c6247f240ea42",
       "components": {
         "mcpServers": [
           {


### PR DESCRIPTION
## What this PR does

Adds a new plugin: **ArrowMem**, a remote MCP server for people running their own local AI models. Nine free tools: an Ollama loopback-exposure check that returns the complete fix on failure, the full Ollama hardening guide, a hardening check against that guide, an inventory of the MCP servers configured on the user's own machine, ArrowMem's privacy and security architecture, a local-model explainer, the open Data Dignity Standard, org information, and the assistant pack list. MCP-only: no skills, commands, agents, hooks, or LSP servers.

- Plugin name: arrowmem
- Type: remote source
- Source URL + pinned SHA: https://github.com/ArrowMem/arrowmem-grok-plugin.git @ `51f91418361026290f4f51c14d1a4b5bf4a5ac7d`
- Homepage: https://arrowmem.ca

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (Apache-2.0, present at the pinned commit.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.arrowmem.ca/mcp` only. That is the ArrowMem MCP server itself; the plugin is a config pointing at it and calls nothing else.
- Credentials/permissions it requires (and why): none for the nine free tools, which need no authentication at all. Two tools (a whole-machine exposed-services sweep and an alert-relay enrolment) require an API key from an ArrowMem subscription and are not part of this listing; if a user supplies a key as a bearer token it is only used to authorize those two calls.

## Notes for reviewers

The plugin repo contains a `.mcp.json`, a README, and a license, nothing executable. All tools are read-only: they return documents or a check result, and none write to, modify, or install anything on the user's machine.
