### PR TITLE
Add aden-mcp plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "aden-mcp",
+      "description": "MCP plugin for aden.space, the music catalog and artist workspace. Connect Grok to tracks, sessions, releases, and team workflows via OAuth.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/vermeerenmaxime/aden-mcp.git",
+        "sha": "3927e4a257ab3f696fe3d407014b21bbb5affe12"
+      },
+      "homepage": "https://www.aden.space",
+      "keywords": ["aden", "aden.space", "aden mcp"],
+      "domains": ["aden.space", "mcp.aden.space"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/adenspace/aden-mcp.git",
-        "sha": "f0b803ddad28b6fad72599a42c7235b4490f1bbb"
+        "sha": "3ebc9bfaf6e5d19de66665ea9604a59765ddb832"
       },
       "homepage": "https://www.aden.space",
       "keywords": ["aden", "aden.space", "aden mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -300,8 +300,8 @@
       "category": "productivity",
       "source": {
         "source": "url",
-        "url": "https://github.com/vermeerenmaxime/aden-mcp.git",
-        "sha": "3927e4a257ab3f696fe3d407014b21bbb5affe12"
+        "url": "https://github.com/adenspace/aden-mcp.git",
+        "sha": "f0b803ddad28b6fad72599a42c7235b4490f1bbb"
       },
       "homepage": "https://www.aden.space",
       "keywords": ["aden", "aden.space", "aden mcp"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,10 @@
 {
   "version": 1,
   "plugins": {
+    "aden-mcp": {
+      "sha": "3927e4a257ab3f696fe3d407014b21bbb5affe12",
+      "components": {}
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "aden-mcp": {
-      "sha": "3927e4a257ab3f696fe3d407014b21bbb5affe12",
+      "sha": "f0b803ddad28b6fad72599a42c7235b4490f1bbb",
       "components": {}
     },
     "axiom": {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -2,7 +2,7 @@
   "version": 1,
   "plugins": {
     "aden-mcp": {
-      "sha": "f0b803ddad28b6fad72599a42c7235b4490f1bbb",
+      "sha": "3ebc9bfaf6e5d19de66665ea9604a59765ddb832",
       "components": {}
     },
     "axiom": {


### PR DESCRIPTION
## What this PR does

Adds the aden.space remote MCP plugin to the Grok Build marketplace catalog.

- Plugin name: `aden-mcp`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/adenspace/aden-mcp.git` @ `f0b803ddad28b6fad72599a42c7235b4490f1bbb` (`main` HEAD at this update)
- Homepage: https://www.aden.space

Aden remote MCP wraps https://mcp.aden.space/mcp (streamable HTTP, OAuth).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

Public plugin source: `adenspace/aden-mcp` (Aden Space ApS / aden.space). Author in the plugin manifest is Aden Space ApS.

The previous personal copy `vermeerenmaxime/aden-mcp` is archived and points here. Use the org URL only.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` is SHA-consistent for this plugin (targeted fetch at the pin; other catalog entries unchanged).
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

License: MIT (Aden Space ApS), in the source repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.aden.space/mcp` (hosted MCP), plus OAuth/login on `aden.space` / `mcp.aden.space`.
- Credentials/permissions it requires (and why): OAuth sign-in with an aden.space account so Grok can call catalog/workspace tools (tracks, sessions, releases, team workflows). No API key in the plugin.

## Notes for reviewers

- SHA-pinned to `f0b803ddad28b6fad72599a42c7235b4490f1bbb`.
- Contact: support@aden.space
- The source repo is a thin public MCP plugin manifest (`plugin.json`, `mcp.json`, README). It does not vendor local skills, hooks, or shell. The generated `plugin-index.json` entry therefore has empty `components` because the indexer looks for `.mcp.json` / `.grok-plugin/plugin.json`; the MCP server is declared in root `mcp.json` as `{ "aden": { "url": "https://mcp.aden.space/mcp" } }`.
