### PR TITLE
feat(plugins): add CentricMem

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/zeyu-j/centricmem-skill.git",
-        "sha": "299c6f0c32bf7cb32cb70de2bbb87c2f135d8517"
+        "sha": "284ddb5e02cff752efb6feb4d2702f217d1fb66c"
       },
       "homepage": "https://centricmem.com",
       "keywords": ["centricmem", "centricmem librarian", "centricmem mcp"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "centricmem",
+      "description": "Hosted librarian for agent memory. Organise and retrieve Markdown cards via host MCP. Authenticate with a /connect?device= link; never paste keys in chat.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/zeyu-j/centricmem-skill.git",
+        "sha": "299c6f0c32bf7cb32cb70de2bbb87c2f135d8517"
+      },
+      "homepage": "https://centricmem.com",
+      "keywords": ["centricmem", "centricmem librarian", "centricmem mcp"],
+      "domains": ["centricmem.com", "mem.centricmem.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,18 @@
         ]
       }
     },
+    "centricmem": {
+      "sha": "299c6f0c32bf7cb32cb70de2bbb87c2f135d8517",
+      "version": "0.21.26",
+      "components": {
+        "skills": [
+          {
+            "name": "centricmem-agent",
+            "description": "Organises and retrieves Markdown memory on the hosted CentricMem librarian via host MCP (search, notes, decisions, tran…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -90,8 +90,8 @@
       }
     },
     "centricmem": {
-      "sha": "299c6f0c32bf7cb32cb70de2bbb87c2f135d8517",
-      "version": "0.21.26",
+      "sha": "284ddb5e02cff752efb6feb4d2702f217d1fb66c",
+      "version": "0.21.27",
       "components": {
         "skills": [
           {


### PR DESCRIPTION
## What this PR does

- Plugin name: `centricmem`
- Type: remote source
- Source URL + pinned SHA: https://github.com/zeyu-j/centricmem-skill.git @ `299c6f0c32bf7cb32cb70de2bbb87c2f135d8517`
- Homepage: https://centricmem.com

Adds the hosted CentricMem librarian Skill to the Grok Build catalog. Agents organise and retrieve Markdown cards over host MCP at `https://mem.centricmem.com/mcp`. Authentication is a ten-minute `/connect?device=` page so keys never land in chat.

Local checks:

- `python scripts/generate-plugin-index.py`
- `python scripts/validate-catalog.py`
- `python scripts/generate-plugin-index.py --check`

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

There is no separate GitHub org yet. `zeyu-j/centricmem-skill` is the canonical public Skill package (same author as centricmem.com / mem.centricmem.com). The private client stays out of this catalog.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python scripts/generate-plugin-index.py`).
- [x] `python scripts/validate-catalog.py` passes locally.
- [x] `python scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated.

License: PolyForm-Noncommercial-1.0.0 (stated in `.grok-plugin/plugin.json` on the pinned commit).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mem.centricmem.com/mcp` (Streamable HTTP host MCP) and `https://centricmem.com/connect?device=` (human-only key entry). Dashboard/login stay on centricmem.com.
- Credentials/permissions it requires (and why): an agent key the human enters on the connect page. Agents must not ask the user to paste keys, tokens, or transcript jsonl into chat.

## Notes for reviewers

Keywords/domains are brand-scoped (`centricmem`, `centricmem librarian`, `centricmem mcp`; `centricmem.com`, `mem.centricmem.com`). The plugin is a Skill + host MCP client, not a local hub bootstrap.

Made with [Cursor](https://cursor.com)