### PR TITLE
Add Zero Slop writing skill and MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,21 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "zero-slop",
+      "description": "Writing skill with local checks for stock phrasing and changes to source details. Edit drafts in your assistant or use the hosted Zero Slop MCP for remote editing.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/manavmishra/ZeroSlop.git",
+        "sha": "d129abaa4d6208eedb44090cec6a5df0f8f7fc6b"
+      },
+      "homepage": "https://zero-slop.ai",
+      "keywords": ["zero-slop", "zero slop", "zeroslop"],
+      "domains": ["zero-slop.ai", "mcp.zero-slop.ai"],
+      "version": "2.9.1",
+      "author": { "name": "Manav Mishra" }
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1279,6 +1279,24 @@
           }
         ]
       }
+    },
+    "zero-slop": {
+      "sha": "d129abaa4d6208eedb44090cec6a5df0f8f7fc6b",
+      "version": "2.9.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "zero-slop",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "zero-slop",
+            "description": "Turn drafts into sharp, natural prose or inspect them without rewriting. Zero Slop runs inside the user's existing AI a…"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds Zero Slop, a writing skill with local checks for stock phrasing and changes to source details. The plugin also includes an HTTP MCP configuration for hosted editing.

- Plugin name: `zero-slop`
- Type: remote source
- Source: https://github.com/manavmishra/ZeroSlop.git
- Pinned SHA: `d129abaa4d6208eedb44090cec6a5df0f8f7fc6b` (release `v2.9.1`)
- Homepage: https://zero-slop.ai

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org, or I've explained why not below.

I'm Manav Mishra, the author and maintainer of Zero Slop. This is my independently maintained project, published under my GitHub account `manavmishra`; there is no separate organization. The source and plugin manifest identify me as the author. The plugin is licensed under MIT.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] The remote source pins a public, reachable, full 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` with the repository script.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set; the source includes its README and `.claude-plugin/plugin.json` manifest.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the installed plugin runtime.
- [ ] No reading/exfiltration of secrets, tokens, `.env`, or env vars. See the configuration-variable exception below.
- [x] Hooks and MCP scope are least-privilege: no hooks; one HTTP MCP connection exposing the `deslop` writing tool.

The local tools read `ZERO_SLOP_HOME`, `ZERO_SLOP_NO_NOTES`, and `ZS_NO_UPDATE_CHECK` for configuration. They do not read or transmit credentials. Local checks read the supplied draft; optional learning writes to the user's private Zero Slop directory. Local scoring does not transmit drafts.

Network endpoints:

- `https://api.github.com/repos/manavmishra/ZeroSlop/releases/latest`: optional metadata-only release check, disabled with `ZS_NO_UPDATE_CHECK=1`.
- `https://mcp.zero-slop.ai/mcp`: hosted editing when the MCP tool is called. Submitted drafts leave the client and are processed remotely. The service records aggregate usage and reliability events, excluding draft/rewrite text and stable user identifiers. Details are in the source's [MCP README](https://github.com/manavmishra/ZeroSlop/blob/d129abaa4d6208eedb44090cec6a5df0f8f7fc6b/mcp/README.md) and [security policy](https://github.com/manavmishra/ZeroSlop/blob/d129abaa4d6208eedb44090cec6a5df0f8f7fc6b/SECURITY.md).

Credentials: the hosted MCP requires no account or API key. The installed skill uses the user's existing assistant for editing; its local checks use standard-library Python.

## Notes for reviewers

The generated index finds one skill and one HTTP MCP server at version `2.9.1`. Keywords and domains are limited to Zero Slop's brand. No plugin files are vendored in this PR.

The source's release-manifest validation also passes: `python3 scripts/check_distribution_manifests.py`.
