### PR TITLE
Add mailtea plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "mailtea",
+      "description": "Mailtea email platform integration. Send transactional email, schedule and publish newsletters, manage contacts and senders, verify sending domains, and check delivery, with skills for email design and publication websites, directly from Grok.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/mailtea-app/mailtea-agent-plugin.git",
+        "sha": "06cccde8b066834bca3ec4e1a269b5043116ad1e"
+      },
+      "homepage": "https://github.com/mailtea-app/mailtea-agent-plugin",
+      "keywords": ["mailtea", "mailtea email", "mailtea newsletter", "send with mailtea"],
+      "domains": ["mailtea.app", "docs.mailtea.app", "api.mailtea.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,6 +395,32 @@
         ]
       }
     },
+    "mailtea": {
+      "sha": "06cccde8b066834bca3ec4e1a269b5043116ad1e",
+      "version": "0.3.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "mailtea",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "mailtea-email",
+            "description": "Send, schedule, and manage email with Mailtea from an AI agent. Use when the user wants to send a transactional email,…"
+          },
+          {
+            "name": "mailtea-email-design",
+            "description": "Design a beautiful, on-brand, deliverable email, newsletter or template in Mailtea. Use when an agent is about to build…"
+          },
+          {
+            "name": "mailtea-site-design",
+            "description": "Build and restyle a publication's public website with Mailtea from an AI agent — pages, sections, theme, and the design…"
+          }
+        ]
+      }
+    },
     "modern-web-guidance": {
       "sha": "bfd8c8dded770f3ba07a518e28991a32df40f902",
       "version": "0.0.187",


### PR DESCRIPTION
## Plugin: mailtea

Mailtea is an agent-native email platform. This entry adds it to the Grok Build catalog, sourced from the official `mailtea-app` org and SHA-pinned.

- **What it does:** send transactional email, schedule and publish newsletters, manage contacts and senders, verify sending domains, and design emails and publication websites — over an MCP server plus three skills.
- **Source:** `https://github.com/mailtea-app/mailtea-agent-plugin.git`, pinned to `37ba20cb587ce331840833aa0a00ada8250e3971` (tag `v0.3.0`).
- **Connection:** hosted MCP server at `https://api.mailtea.app/mcp` over Streamable HTTP, with browser-based OAuth 2.1 sign-in (DCR + PKCE S256). No token is pasted into config.
- **License:** MIT.

### Checklist
- [x] One entry in `.grok-plugin/marketplace.json`, valid JSON, `name` kebab-case and unique (`mailtea`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public and reachable.
- [x] `.grok-plugin/plugin-index.json` regenerated with `scripts/generate-plugin-index.py` and committed.
- [x] `homepage`, a clear `description`, brand-scoped `keywords`/`domains`, and a `category` (`productivity`).
- [x] Licensed (MIT), stated in the source repo.
- [x] Read the security expectations: the plugin ships no lifecycle hooks, runs no install scripts, and its MCP scope is Mailtea's own email tools reached over an authenticated hosted endpoint.

Validated locally with `python3 scripts/validate-catalog.py` and `python3 scripts/generate-plugin-index.py --check`.