### PR TITLE
Add Calibrd Agent (calibrd)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,24 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "calibrd",
+      "description": "Calibrd Agent: would you make the shortlist? Score a job posting against your CV, get the full Calibrd report (gaps at your level, the questions each round asks, the interview process, a pay benchmark), review your CV and draft a cover letter on your Calibrd account.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/justinxcguo/calibrd-agent.git",
+        "sha": "c2b31b4ba341674575267b689f38ff012183d01a"
+      },
+      "homepage": "https://www.calibrd.com/agent",
+      "keywords": ["calibrd", "calibrd agent", "calibrd report", "calibrd shortlist"],
+      "domains": ["calibrd.com", "www.calibrd.com"],
+      "version": "1.0.0",
+      "author": {
+        "name": "Calibrd",
+        "url": "https://www.calibrd.com"
+      }
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -301,7 +301,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/justinxcguo/calibrd-agent.git",
-        "sha": "c2b31b4ba341674575267b689f38ff012183d01a"
+        "sha": "cc66c17e26b4336765f11fccf07d77d3cd1cb4ae"
       },
       "homepage": "https://www.calibrd.com/agent",
       "keywords": ["calibrd", "calibrd agent", "calibrd report", "calibrd shortlist"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -300,13 +300,13 @@
       "category": "productivity",
       "source": {
         "source": "url",
-        "url": "https://github.com/justinxcguo/calibrd-agent.git",
-        "sha": "cc66c17e26b4336765f11fccf07d77d3cd1cb4ae"
+        "url": "https://github.com/Calibrd/calibrd-agent.git",
+        "sha": "89d8cb8a63c335fae56a9937215d7a1b3831a469"
       },
       "homepage": "https://www.calibrd.com/agent",
       "keywords": ["calibrd", "calibrd agent", "calibrd report", "calibrd shortlist"],
       "domains": ["calibrd.com", "www.calibrd.com"],
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Calibrd",
         "url": "https://www.calibrd.com"

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -89,6 +89,24 @@
         ]
       }
     },
+    "calibrd": {
+      "sha": "c2b31b4ba341674575267b689f38ff012183d01a",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "calibrd",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "calibrd",
+            "description": "Use Calibrd to judge a job posting before applying. Score the person's CV against the posting, get the full Calibrd rep…"
+          }
+        ]
+      }
+    },
     "chrome-devtools": {
       "sha": "45f187b1e3202c9f32ddba913be5d68751c3caa3",
       "version": "1.8.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -90,8 +90,8 @@
       }
     },
     "calibrd": {
-      "sha": "cc66c17e26b4336765f11fccf07d77d3cd1cb4ae",
-      "version": "1.0.0",
+      "sha": "89d8cb8a63c335fae56a9937215d7a1b3831a469",
+      "version": "1.0.1",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -90,7 +90,7 @@
       }
     },
     "calibrd": {
-      "sha": "c2b31b4ba341674575267b689f38ff012183d01a",
+      "sha": "cc66c17e26b4336765f11fccf07d77d3cd1cb4ae",
       "version": "1.0.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## What this PR does

Adds Calibrd Agent as a new remote-source plugin. It gives Grok six tools that run
against the person's own Calibrd account: score a job posting against their CV,
generate the full report (gaps at their level, the questions each round asks, the
interview process, a pay benchmark), review a CV, draft a cover letter, check
status and get a pass.

- Plugin name: `calibrd`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/Calibrd/calibrd-agent.git` @ `89d8cb8a63c335fae56a9937215d7a1b3831a469`
- Homepage: https://www.calibrd.com/agent

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The source repo is `github.com/Calibrd/calibrd-agent`, the Calibrd org. The
homepage is on the same brand domain, and that domain publishes the Ed25519
domain proof for Calibrd's entry in the official MCP registry at
https://www.calibrd.com/.well-known/mcp-registry-auth (registry name
`com.calibrd/agent`), so the brand, the domain and the source repo all line up.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set.
- [x] License is stated (MIT, in the source repo).

## Security

The plugin ships one Streamable HTTP MCP server and one skill. No hooks, no
commands, no agents, no scripts, nothing that runs locally.

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://www.calibrd.com/mcp` only —
  the Calibrd MCP server, which runs the six tools listed above.
- Credentials/permissions it requires (and why): an OAuth sign-in to the user's own
  Calibrd account, so the tools read and meter against that account. No API keys, no
  filesystem access, no environment variables.

Data handling, stated the same way on the listing page: the CV, the job description
and the report pass through the assistant's provider under their terms. Calibrd
itself keeps none of it — reports and CVs are generated and returned, not stored.

## Notes for reviewers

`https://www.calibrd.com/mcp` answers an unauthenticated probe with `401` and a
`WWW-Authenticate` header pointing at
`https://www.calibrd.com/.well-known/oauth-protected-resource/mcp`. That is the
OAuth handshake working, not a broken endpoint — a client follows it to sign in.
