### PR TITLE
Add AdaptlyPost plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "adaptlypost",
+      "description": "AdaptlyPost social media publishing (MCP server + skill). Post and schedule to Instagram, TikTok, YouTube, X, LinkedIn, Facebook, Pinterest, Threads, and Bluesky, upload media, bulk-schedule, check per-platform results, and retry failed platforms.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/adaptlypost/agent.git",
+        "sha": "ce22848b6b2228210fef4bfaa02743d3975a6752"
+      },
+      "homepage": "https://adaptlypost.com/features/agents",
+      "keywords": ["adaptlypost", "adaptly post", "adaptlypost mcp"],
+      "domains": ["adaptlypost.com", "app.adaptlypost.com", "mcp.adaptlypost.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,24 @@
 {
   "version": 1,
   "plugins": {
+    "adaptlypost": {
+      "sha": "ce22848b6b2228210fef4bfaa02743d3975a6752",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "adaptlypost",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "adaptlypost",
+            "description": "Create, schedule, and manage social media posts across Instagram, TikTok, YouTube, X, LinkedIn, Facebook, Pinterest, Th…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds the adaptlypost plugin. AdaptlyPost: post and schedule to nine social networks (Instagram, TikTok, YouTube, X, LinkedIn, Facebook, Pinterest, Threads, Bluesky) from Grok Build via a skill plus the hosted AdaptlyPost MCP server.

- Plugin name: adaptlypost
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/adaptlypost/agent.git @ `ce22848b6b2228210fef4bfaa02743d3975a6752`
- Homepage: https://adaptlypost.com/features/agents

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, `LICENSE` in the source repo and `license` in `.claude-plugin/plugin.json`.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. (No hooks. One remote MCP server, no local processes.)
- Network endpoints this plugin calls (and why):
- `https://mcp.adaptlypost.com/mcp` (hosted MCP server, streamable HTTP; every tool call)
- `https://post.adaptlypost.com/post` (REST API used by the skill's CLI script)
- Media upload URLs the API returns are presigned R2 URLs under `cdn.adaptlypost.com`
- Credentials/permissions it requires (and why):
- `ADAPTLYPOST_API_KEY` env var: a revocable API token the user creates at adaptlypost.com/api-tokens. Sent as a Bearer header to the two hosts above and nowhere else.

## Notes for reviewers

The skill's `scripts/adaptlypost.js` is a zero-dependency Node CLI that only calls the AdaptlyPost API. The `mcp-server/` directory holds the server source that also runs the hosted endpoint; it is there so directories like Glama can build and score it, and is not executed by the plugin. Keywords and domains are brand-scoped to adaptlypost only.
