### PR TITLE
Add Flowsery plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "flowsery",
+      "description": "Flowsery web analytics (MCP server + skill). Query visitors, sessions, revenue, goals, realtime map, and breakdowns by page, referrer, country, device, and campaign; pull visitor journeys and AI-detected site issues; record goals and payments from your backend.",
+      "category": "analytics",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Flowsery/agent.git",
+        "sha": "ff49c13fb81a48070ed14643ccb0fb4acbde19a6"
+      },
+      "homepage": "https://flowsery.com/docs/api-introduction",
+      "keywords": ["flowsery", "flowsery analytics", "flowsery mcp"],
+      "domains": ["flowsery.com", "app.flowsery.com", "mcp.flowsery.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -357,6 +357,24 @@
         ]
       }
     },
+    "flowsery": {
+      "sha": "ff49c13fb81a48070ed14643ccb0fb4acbde19a6",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "flowsery",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "flowsery",
+            "description": "Query web analytics data from Flowsery Analytics — a privacy-first web analytics platform. Retrieve real-time visitor c…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

Adds the flowsery plugin. Flowsery: privacy-first web analytics for Grok Build via a skill plus the hosted Flowsery MCP server. Overview, timeseries, realtime, breakdowns by page/referrer/country/device/campaign, visitor journeys, AI-detected site issues, and server-side goal and payment tracking.

- Plugin name: flowsery
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/Flowsery/agent.git @ `ff49c13fb81a48070ed14643ccb0fb4acbde19a6`
- Homepage: https://flowsery.com/docs/api-introduction

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, `LICENSE` in the source repo and `license` in `.claude-plugin/plugin.json`.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. (No hooks. One remote MCP server, no local processes.)
- Network endpoints this plugin calls (and why):
- `https://mcp.flowsery.com/mcp` (hosted MCP server, streamable HTTP; every tool call)
- `https://analytics.flowsery.com/analytics/api/v1` (REST API used by the skill's CLI script)
- Credentials/permissions it requires (and why):
- `FLOWSERY_API_KEY` env var: a revocable API key the user creates at flowsery.com/api-tokens. Sent as a Bearer header to the two hosts above and nowhere else.

## Notes for reviewers

The skill's `scripts/flowsery.js` is a zero-dependency Node CLI that only calls the Flowsery API. The `mcp-server/` directory holds the server source that also runs the hosted endpoint; it is there so directories like Glama can build and score it, and is not executed by the plugin. Keywords and domains are brand-scoped to flowsery only.
