### PR TITLE
Add RedReplier plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "redreplier",
+      "description": "RedReplier social listening (MCP server + skill). Monitor Reddit, Hacker News, X, and Bluesky for keyword mentions of your product, triage AI-scored leads with relevance reasoning and reply suggestions, manage monitored websites and keywords, and set alert digests.",
+      "category": "marketing",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/RedReplier/agent.git",
+        "sha": "6e7f15e43ebffdb59ea06550d9f52bff82c6e2a1"
+      },
+      "homepage": "https://redreplier.com",
+      "keywords": ["redreplier", "red replier", "redreplier mcp"],
+      "domains": ["redreplier.com", "app.redreplier.com", "mcp.redreplier.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -769,6 +769,24 @@
         ]
       }
     },
+    "redreplier": {
+      "sha": "6e7f15e43ebffdb59ea06550d9f52bff82c6e2a1",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "redreplier",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "redreplier",
+            "description": "Monitor Reddit, Hacker News, X, and Bluesky for keyword mentions of your product/website via the RedReplier API. Covers…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",


### PR DESCRIPTION
## What this PR does

Adds the redreplier plugin. RedReplier: social listening for Grok Build via a skill plus the hosted RedReplier MCP server. Monitor Reddit, Hacker News, X, and Bluesky for keyword mentions of a product, triage AI-scored leads with relevance reasoning and reply suggestions, manage monitored websites and keywords, and configure alert digests.

- Plugin name: redreplier
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/RedReplier/agent.git @ `6e7f15e43ebffdb59ea06550d9f52bff82c6e2a1`
- Homepage: https://redreplier.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, `LICENSE` in the source repo and `license` in `.claude-plugin/plugin.json`.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege. (No hooks. One remote MCP server, no local processes.)
- Network endpoints this plugin calls (and why):
- `https://mcp.redreplier.com/mcp` (hosted MCP server, streamable HTTP; every tool call)
- `https://ai.redreplier.com/ai-app/api/v1` (REST API used by the skill's CLI script)
- Credentials/permissions it requires (and why):
- `REDREPLIER_API_TOKEN` env var: a revocable API token the user creates at redreplier.com/api-tokens. Sent as a Bearer header to the two hosts above and nowhere else.

## Notes for reviewers

The skill's `scripts/redreplier.js` is a zero-dependency Node CLI that only calls the RedReplier API. The `mcp-server/` directory holds the server source that also runs the hosted endpoint; it is there so directories like Glama can build and score it, and is not executed by the plugin. Keywords and domains are brand-scoped to redreplier only.
