### PR TITLE
Add PostLake plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "postlake",
+      "description": "Hosted MCP and skills so an agent can publish, schedule, reply, and measure social posts across connected networks.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/PostLake/postlake-mcp.git",
+        "sha": "ccd96c19283ab55ba470759f835a9fe73933d0f7"
+      },
+      "homepage": "https://postlake.dev",
+      "keywords": ["postlake", "postlake mcp", "postlake social"],
+      "domains": ["postlake.dev", "api.postlake.dev", "docs.postlake.dev", "app.postlake.dev"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -536,6 +536,52 @@
         ]
       }
     },
+    "postlake": {
+      "sha": "ccd96c19283ab55ba470759f835a9fe73933d0f7",
+      "version": "1.4.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "postlake",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "b2c-marketing",
+            "description": "B2C organic social media marketing for AI agents. TikTok and Instagram growth coach: account setup, 7-day warmup, conte…"
+          },
+          {
+            "name": "multi-account-operator",
+            "description": "Multi-account social media operator for AI agents. Run 15 to 400+ accounts without burning them: spacing, per-account c…"
+          },
+          {
+            "name": "postlake-accounts",
+            "description": "List the social accounts connected to PostLake (X, LinkedIn, Instagram, TikTok, Facebook, Threads, Bluesky, YouTube, Pi…"
+          },
+          {
+            "name": "postlake-analytics",
+            "description": "Read social media performance from PostLake: per-post results and normalised cross-platform analytics (impressions, rea…"
+          },
+          {
+            "name": "postlake-inbox",
+            "description": "Read and handle PostLake direct-message conversations across Facebook, Instagram, X, and Bluesky. Use when checking DMs…"
+          },
+          {
+            "name": "postlake-media",
+            "description": "Upload an image or video to PostLake and attach it to a post. Use when a post needs media, or for platforms that requir…"
+          },
+          {
+            "name": "postlake-publish",
+            "description": "Publish a social media post right now to one or more connected accounts (X, LinkedIn, Instagram, TikTok, Facebook, Thre…"
+          },
+          {
+            "name": "postlake-schedule",
+            "description": "Schedule a social media post for a future time through PostLake, and list, reschedule, or cancel scheduled posts. Use w…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "93b00b89ef425a9c1bac0d0b317dfc49c930ac99",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: `postlake`
- Type: remote source
- Source URL + pinned SHA: https://github.com/PostLake/postlake-mcp.git @ `ccd96c19283ab55ba470759f835a9fe73933d0f7`
- Homepage: https://postlake.dev

PostLake is a hosted MCP server and skill pack for social publishing. Grok Build clones this official org repo and connects to `https://api.postlake.dev/mcp` over Streamable HTTP. The owner approves once with OAuth. No local process, no shell hooks, no API key in chat.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source: [PostLake/postlake-mcp](https://github.com/PostLake/postlake-mcp), the same public repo used by the official MCP Registry (`dev.postlake/social`).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

MIT. Manifest version 1.4.0.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `https://api.postlake.dev/mcp` (hosted Streamable HTTP MCP; the only runtime endpoint)
  - `https://postlake.dev`, `https://docs.postlake.dev`, `https://app.postlake.dev` (docs and OAuth approval cited by skills)
- Credentials/permissions it requires (and why):
  - OAuth + PKCE against PostLake. The account owner signs in in the browser. Skills that talk to REST instead of MCP expect `POSTLAKE_API_KEY` in the agent runtime, never in the prompt.
  - No filesystem, SSH, or env scraping. No hooks.

`openclaw/` in the source repo is a separate OpenClaw package. Grok's extractor only indexes `skills/` and `.mcp.json`.

## Notes for reviewers

Indexed components at the pinned SHA: one HTTP MCP server (`postlake`) and eight skills (`postlake-accounts`, `postlake-publish`, `postlake-schedule`, `postlake-media`, `postlake-inbox`, `postlake-analytics`, `b2c-marketing`, `multi-account-operator`).

Keywords are brand-scoped (`postlake`, `postlake mcp`, `postlake social`). Domains are only hosts PostLake owns.


Made with [Cursor](https://cursor.com)