### PR TITLE
Add Atlassian Teamwork Graph CLI plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "atlassian-twg-cli",
+      "description": "Teamwork Graph CLI is Atlassian's agent-first interface to your entire work context: Jira issues, Confluence pages, Bitbucket PRs, along with your connected third-party data sources. Purpose-built for coding agents like Grok Build, and powered by Atlassian's context graph. Run /twg-setup after install to connect Atlassian Teamwork Graph CLI to Grok Build.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/atlassian-labs/twg-plugins.git",
+        "sha": "d464e72e7750589e0f0867f171d2dd1d6eece924"
+      },
+      "homepage": "https://developer.atlassian.com/cloud/twg-cli/",
+      "keywords": ["twg", "twg cli", "teamwork graph", "teamwork graph cli", "atlassian teamwork graph", "jira", "confluence", "bitbucket"],
+      "domains": ["atlassian.net", "teamwork-graph.atlassian.com", "developer.atlassian.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,18 @@
 {
   "version": 1,
   "plugins": {
+    "atlassian-twg-cli": {
+      "sha": "d464e72e7750589e0f0867f171d2dd1d6eece924",
+      "version": "1.0.12",
+      "components": {
+        "skills": [
+          {
+            "name": "twg-setup",
+            "description": "Install, upgrade, authenticate, or repair `twg` for your coding agent, including missing CLI or skills and doctor/auth…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds Atlassian Teamwork Graph CLI as a remote-source productivity plugin for Grok Build.

- Plugin name: `atlassian-twg-cli`
- Type: remote source
- Source URL + pinned SHA: https://github.com/atlassian-labs/twg-plugins.git @ `d464e72e7750589e0f0867f171d2dd1d6eece924`
- Homepage: https://developer.atlassian.com/cloud/twg-cli/

The plugin provides the `twg-setup` skill, which installs or verifies TWG CLI and connects the coding agent to Atlassian work context across Jira, Confluence, Bitbucket, JSM, and connected third-party sources.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org.

The source is published by Atlassian under the official `atlassian-labs` organization and is licensed under Apache-2.0.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] The remote source pins a public, reachable, full 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, clear description, brand-scoped keywords/domains, and category are set.
- [x] License is stated (Apache-2.0 in the source repository).

## Security

- [ ] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The [setup skill](https://github.com/atlassian-labs/twg-plugins/blob/d464e72e7750589e0f0867f171d2dd1d6eece924/skills/twg-setup/SKILL.md) explicitly presents Atlassian's installer command, `curl -fsSL --retry 2 https://teamwork-graph.atlassian.com/cli/install | bash`, and requires explicit user approval before an agent may run it (it states: "**after explicit approval**, run the installer command outside the sandbox"). It is not a lifecycle hook or automatic install, but it matches the pattern called out by this repository's security policy and is disclosed for review.
- [x] No reading or exfiltration of secrets, tokens, or `.env` files. The setup guidance checks only `HOME` or `LOCALAPPDATA` to locate an existing CLI and does not transmit those values.
- [x] Hooks and MCP scope are least-privilege. The plugin contains no hooks or MCP server; it ships one setup skill with Bash access for installation and diagnostics.
- Network endpoints this plugin calls (and why):
  - `https://teamwork-graph.atlassian.com/cli/install` and `/cli/install.ps1` to retrieve the official TWG CLI installers.
  - Atlassian authentication and Teamwork Graph services used by the installed `twg` CLI; the plugin package itself contains no runtime wrapper or credentials.
- Credentials/permissions it requires (and why):
  - Interactive Atlassian OAuth through the installed TWG CLI to access the user's authorized work context.
  - No credentials are bundled in or requested by the plugin source.

## Notes for reviewers

The generated index identifies version `1.0.12` and one skill, `twg-setup`. The source repository is skills-only: it contains no CLI binary, runtime wrapper, lifecycle hooks, or bundled credentials. Keywords and domains are limited to Atlassian and Teamwork Graph product terms and owned domains.
