### PR TITLE
Add buyer-engagement-sales-engine-free (1.0.10-free.5)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -280,7 +280,19 @@
       "homepage": "https://browser-use.com",
       "keywords": ["browser use", "browser-use", "browser use cloud"],
       "domains": ["browser-use.com", "cloud.browser-use.com"]
-    },
+    },,
+        {
+                "name": "buyer-engagement-sales-engine-free",
+                "description": "Free library + Fit Chat. Sales-process OS for Buyer Engagement on Grok/Claude -- learn as you go. Not an AI SDR. Not the paid engine.",
+                "category": "sales",
+                "homepage": "https://github.com/gregvanderlinde/buyer-engagement-sales-engine",
+                "keywords": ["buyer-engagement", "sales-process-os", "golden-wedge", "bese", "fit-chat", "local-first"],
+                "source": {
+                          "source": "url",
+                          "url": "https://github.com/gregvanderlinde/buyer-engagement-sales-engine.git",
+                          "sha": "d97e29b709e524bb5cb9a6e2185538ca7faf501c"
+                }
+        }
     {
       "name": "quo",
       "description": "Official Quo MCP for Grok Build. Send individual, group, or bulk SMS; manage contacts and tasks; review message history and call transcripts; and follow up on missed calls through Quo's hosted OAuth MCP server.",


### PR DESCRIPTION
## What this PR does

Adds `buyer-engagement-sales-engine-free` to `.grok-plugin/marketplace.json` with the requested metadata and pinned source SHA.

Version: `1.0.10-free.5`

Plugin-index regeneration was not available in the web editor; CI may need to regenerate `.grok-plugin/plugin-index.json`.