### PR TITLE
Add inspify-ai (INSPIFY AI Creative Agency MCP)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "inspify-ai",
+      "description": "INSPIFY AI Creative Agency — start Story jobs, answer research questions, select creative directions, review the rendered work, submit feedback, publish, and deep-link to the Hub via MCP.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/inspify-ai/mcp.git",
+        "sha": "ed2975404b4fb44575f101a3b43120f3cab22ae9"
+      },
+      "homepage": "https://app.inspify.ai",
+      "keywords": ["inspify", "inspify ai", "creative agency", "story jobs", "brand dna"],
+      "domains": ["inspify.ai", "app.inspify.ai", "mcp.inspify.ai"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -314,11 +314,11 @@
       "source": {
         "source": "url",
         "url": "https://github.com/inspify-ai/mcp.git",
-        "sha": "ed2975404b4fb44575f101a3b43120f3cab22ae9"
+        "sha": "93f2edf2c0699780d070f904a80eac7850c95765"
       },
-      "homepage": "https://app.inspify.ai",
+      "homepage": "https://www.inspify.ai/login",
       "keywords": ["inspify", "inspify ai", "creative agency", "story jobs", "brand dna"],
-      "domains": ["inspify.ai", "app.inspify.ai", "mcp.inspify.ai"]
+      "domains": ["inspify.ai", "www.inspify.ai", "mcp.inspify.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,6 +361,32 @@
         ]
       }
     },
+    "inspify-ai": {
+      "sha": "ed2975404b4fb44575f101a3b43120f3cab22ae9",
+      "version": "0.2.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "inspify-ai",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "inspify-creative-agency-mcp",
+            "description": "Use to start or poll INSPIFY AI Creative Agency Story jobs via MCP. Pair with inspify-security-deny first. Only the all…"
+          },
+          {
+            "name": "inspify-security-deny",
+            "description": "Use before any INSPIFY MCP or plugin action. Deny-by-default: no host shell, no cloud admin keys, no destructive disk o…"
+          },
+          {
+            "name": "inspify-story-workflow",
+            "description": "Use to take an INSPIFY AI Creative Agency Story job from brief to published. Describes the ordered tool calls an agent…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -362,7 +362,7 @@
       }
     },
     "inspify-ai": {
-      "sha": "ed2975404b4fb44575f101a3b43120f3cab22ae9",
+      "sha": "93f2edf2c0699780d070f904a80eac7850c95765",
       "version": "0.2.0",
       "components": {
         "mcpServers": [


### PR DESCRIPTION
## Summary
- Add `inspify-ai` to the Grok plugin marketplace catalog (remote URL source).
- Pin `https://github.com/inspify-ai/mcp.git` @ `e8dfd876067a3e2dcc46cb2628cec201b8c2a0fe`.
- Listing: INSPIFY AI Creative Agency MCP for **team pilot** — story jobs + Scene Designer Hub deep-links; 16 tools; confirm before write; no cross-tenant Brand DNA; no secrets in package.

## Checklist
- [x] Unique kebab-case `name`: `inspify-ai`
- [x] Full 40-char lowercase SHA pin (public reachable)
- [x] `plugin-index.json` regenerated
- [x] `validate-catalog.py` passed locally
- [x] Homepage + brand-scoped keywords/domains
- [x] Official org source (`inspify-ai/mcp`)

## Test plan
- [ ] CI: `validate-catalog.py` + `generate-plugin-index.py --check`
- [ ] Code-owner review