### PR TITLE
Add There's An AI For That (taaft) Grok Build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,22 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "taaft",
+      "description": "Search and discover AI tools on There's An AI For That. Query the There's An AI For That directory via the public remote MCP server (search_tools, get_tool).",
+      "category": "search",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/taaft"
+      },
+      "homepage": "https://theresanaiforthat.com/",
+      "keywords": ["there's an ai for that", "theresanaiforthat", "theres an ai for that", "taaft", "ai tools directory"],
+      "domains": ["theresanaiforthat.com", "www.theresanaiforthat.com"],
+      "author": {
+        "name": "There's An AI For That",
+        "email": "razvan@theresanaiforthat.com"
+      }
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -947,6 +947,17 @@
         ]
       }
     },
+    "taaft": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "taaft",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "tavily": {
       "sha": "0cfd0c2be2df4a2a90c683abaadaf36ef7f2f59d",
       "version": "1.0.0",

--- a/external_plugins/taaft/.grok-plugin/plugin.json
+++ b/external_plugins/taaft/.grok-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "taaft",
+  "version": "1.0.0",
+  "description": "Search and discover AI tools on There's An AI For That.",
+  "author": {
+    "name": "There's An AI For That",
+    "email": "razvan@theresanaiforthat.com",
+    "url": "https://theresanaiforthat.com/"
+  },
+  "homepage": "https://theresanaiforthat.com/",
+  "license": "MIT",
+  "keywords": ["theresanaiforthat", "there's an ai for that", "taaft", "ai tools directory"]
+}

--- a/external_plugins/taaft/.mcp.json
+++ b/external_plugins/taaft/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "taaft": {
+      "type": "http",
+      "url": "https://theresanaiforthat.com/mcp/"
+    }
+  }
+}

--- a/external_plugins/taaft/README.md
+++ b/external_plugins/taaft/README.md
@@ -1,0 +1,33 @@
+# There's An AI For That
+
+Grok Build plugin that wraps the public There's An AI For That remote MCP server so you can search and discover AI tools from the There's An AI For That directory.
+
+## Homepage
+
+- Website: https://theresanaiforthat.com/
+- Privacy: https://theresanaiforthat.com/privacy/
+
+## MCP server
+
+- URL: `https://theresanaiforthat.com/mcp/`
+- Transport: HTTP (remote)
+- Authentication: none (public)
+
+### Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_tools` | Search the There's An AI For That directory for AI tools |
+| `get_tool` | Get details for a specific tool in the directory |
+
+## Network endpoints
+
+This plugin connects only to:
+
+- `https://theresanaiforthat.com/mcp/` — hosted MCP server for search and tool lookup
+
+No API keys or OAuth are required.
+
+## License
+
+MIT


### PR DESCRIPTION
## What this PR does

- Plugin name: `taaft` (There's An AI For That)
- Type: local (`external_plugins`)
- Source URL + pinned SHA (remote), or vendored path (local): `./external_plugins/taaft`
- Homepage: https://theresanaiforthat.com/

Adds There's An AI For That to the Grok Build plugin marketplace for T-9062 by vendoring a small local plugin that wraps the public remote MCP server at https://theresanaiforthat.com/mcp/ (tools: `search_tools`, `get_tool`; no auth).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Vendored under `external_plugins/taaft/` because the main There's An AI For That application repository is private. The MCP endpoint itself is public HTTPS.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://theresanaiforthat.com/mcp/` — hosted MCP for searching/discovering AI tools in the There's An AI For That directory.
- Credentials/permissions it requires (and why): none (public MCP).

## Notes for reviewers

Local/vendored third-party plugin mirroring the Neon MCP shape (`.mcp.json` HTTP remote + `.grok-plugin/plugin.json` + README). Category: search. Brand-scoped keywords/domains for theresanaiforthat.com / taaft.
