### PR TITLE
feat: add RecipeBee plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -293,6 +293,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "recipebee",
+      "description": "RecipeBee recipe discovery and guided cooking integration. Search recipes, inspect recipe details, and save generated recipes to your RecipeBee account through a hosted MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/praisondani/recipebee-cursor-plugin.git",
+        "sha": "cb6b8566e53e746a8cd449478df32eb9838d305c"
+      },
+      "homepage": "https://recipebee.app",
+      "keywords": ["recipebee", "recipebee recipes", "recipebee cooking"],
+      "domains": ["recipebee.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -769,6 +769,23 @@
         ]
       }
     },
+    "recipebee": {
+      "sha": "cb6b8566e53e746a8cd449478df32eb9838d305c",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "recipebee",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "save-generated-recipe",
+            "description": "Understand ordinary-language requests to preview recipes, privately save recipes, or add complete meal plans to RecipeB…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",


### PR DESCRIPTION
## Summary
- add RecipeBee as a third-party remote plugin
- pin the public source repository to commit `cb6b8566e53e746a8cd449478df32eb9838d305c`
- regenerate the component index

## Source
- Repository: https://github.com/praisondani/recipebee-cursor-plugin
- Homepage: https://recipebee.app
- Hosted MCP endpoint: https://recipebee.app/mcp

## Validation
- `python3 scripts/validate-catalog.py`
- `python3 scripts/generate-plugin-index.py --check`

The upstream repository contains the plugin README, MIT license, `.mcp.json`, skills, and public metadata. It does not include backend source or credentials.
