### PR TITLE
Add Auto Captions plugin by Yaps

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,27 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "yaps-auto-captions",
+      "description": "Add styled captions and word highlighting to local videos with Yaps. Review editable captions and export a separate captioned MP4.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/richawo/yaps-plugins.git",
+        "sha": "84b97889aa96ab3aef57b0a36bf6150dce9babbe",
+        "path": "grok/plugins/yaps-auto-captions"
+      },
+      "homepage": "https://yaps.ai",
+      "keywords": [
+        "yaps auto captions",
+        "yaps video captions",
+        "yaps subtitles",
+        "yaps word highlighting"
+      ],
+      "domains": [
+        "yaps.ai"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1317,6 +1317,24 @@
           }
         ]
       }
+    },
+    "yaps-auto-captions": {
+      "sha": "84b97889aa96ab3aef57b0a36bf6150dce9babbe",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "yaps-auto-captions",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "yaps-auto-captions",
+            "description": "Add styled, timed captions to a local video with Yaps and export a new captioned MP4. Use for animated captions, word h…"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## What this PR does

Adds **yaps-auto-captions**, a purpose-specific Yaps plugin for Grok Build. Add styled captions and word highlighting to local videos with Yaps. Review editable captions and export a separate captioned MP4.

- Type: remote source, one skill and one local stdio MCP server.
- Source: https://github.com/richawo/yaps-plugins/tree/84b97889aa96ab3aef57b0a36bf6150dce9babbe/grok/plugins/yaps-auto-captions
- Pinned SHA: `84b97889aa96ab3aef57b0a36bf6150dce9babbe`
- Homepage: https://yaps.ai
- Runtime: exact `yaps-cursor-runtime@0.3.0`. The shared npm name retains Cursor for compatibility; this manifest sets the host to Grok.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source ownership is explained below.

Richard Awoyemi maintains Yaps under the established `richawo` GitHub account, including the existing public Yaps plugin repository and published Cursor packages. This is the maintainer's source, not an unofficial copy. There is no separate Yaps GitHub organization for this package. The source and skill are MIT licensed, with the license included in the plugin folder. Desktop models keep their own licenses.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a full public, reachable, 40-character commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json` using the upstream generator.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, clear description, brand-scoped keywords, README, and Grok manifest included.
- [x] License is stated.

## Security

- [x] No `curl | bash`, arbitrary remote scripts, downloaded native executables, or installation lifecycle scripts. The explicit npm bootstrap is described below.
- [x] No plugin code reads or exfiltrates SSH keys, `.env` files, tokens, or credential files.
- [x] No lifecycle hooks or generic shell-execution tools. The server exposes the selected workflow's tools and its readiness/setup controls.

`npx` downloads the exact declared package and its JavaScript dependencies from `registry.npmjs.org`, then starts a local stdio server. This is a disclosed executable dependency, not a claim that installation runs no downloaded code. The readable package starts only the already installed Yaps CLI or native MCP helper. It does not download a desktop engine.

The existing desktop app can contact `yaps-api.richardawoyemi.workers.dev` for account refresh, model assets, and diagnostics. Asset endpoints vary with the installed desktop release; older versions can use Hugging Face and GitHub assets. Required model installation follows the user's authorization and reuses installed models. The wrapper has no separate telemetry uploader. The README describes this boundary and links the desktop privacy policy.

The plugin uses the existing signed-in Yaps desktop account and requests no API keys or separate credentials. Media and notes remain on disk unless returned as requested tool results to the Grok host; returned results are subject to that host's data handling. Local file access and existing Yaps permissions apply. The MCP tool profile limits this entry to the described workflow; output-producing tools preserve the original input file.

## Notes for reviewers

This is one of twelve separately scoped workflows sharing one maintained runtime. Each is submitted in its own PR to follow the one-entry rule. Source subdirectories avoid duplicating helper implementations or requiring twelve new repositories.

All twelve skills pass the skill validator and the upstream component extractor reports exactly one skill and one MCP server per package. The exact published npm package has direct macOS MCP initialization and readiness coverage using the Grok configuration, with the expected tool profile.

These checks do not establish live Grok host tool execution, fresh Windows testing of this package, full workflow output quality, or a fresh model download for every feature. The integration requires a Grok Build environment that can start local MCP processes beside an installed Yaps desktop engine; cloud-only access to another computer is not claimed.
