### PR TITLE
Add SuperMe plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -331,6 +331,19 @@
       "homepage": "https://www.omneky.com",
       "keywords": ["omneky", "omneky ads", "omneky mcp"],
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
+    },
+    {
+      "name": "superme",
+      "description": "Ask people who've been there. Search the SuperMe network for relevant experts, ask them your question, and gather several first-hand perspectives on a decision through SuperMe's hosted OAuth MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/superme-ai/superme-plugins.git",
+        "sha": "26a95563a45ed906c6351d2e035c03729b79b29d"
+      },
+      "homepage": "https://superme.ai",
+      "keywords": ["superme", "superme.ai", "ask superme", "superme network"],
+      "domains": ["superme.ai", "mcp.superme.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -944,6 +944,18 @@
         ]
       }
     },
+    "superme": {
+      "sha": "26a95563a45ed906c6351d2e035c03729b79b29d",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "superme",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "superpowers": {
       "sha": "b36e0829c6d0140e93cfef2ca599b1b07d4a7797",
       "version": "6.3.0",


### PR DESCRIPTION
## What this PR does

Adds SuperMe to the catalog. SuperMe lets you ask people who've been there — search the SuperMe network for relevant experts, put your question to them, and gather several first-hand perspectives on a decision without leaving Grok Build.

- Plugin name: `superme`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/superme-ai/superme-plugins.git` @ `26a95563a45ed906c6351d2e035c03729b79b29d`
- Homepage: https://superme.ai

The plugin is one hosted HTTP MCP server and nothing else — no skills, commands, agents, hooks or LSP servers — so the generated index entry lists a single `mcpServers` item. That is the whole plugin, not a truncated extraction.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

`superme-ai/superme-plugins` is SuperMe's official, public, MIT-licensed repo for marketplace manifests — same org as the product and the `superme.ai` domain in `domains`, so the brand matches the source. It is not a fork, and it is purpose-built for this: it carries its own `LICENSE` (MIT), a `README.md` documenting the server and its auth model, the `.grok-plugin/plugin.json` manifest and `.grok-plugin/mcp.json` config this entry resolves to, and a CI workflow (`scripts/validate_manifests.py`) that validates the manifests on every push.

The pinned SHA `26a95563a45ed906c6351d2e035c03729b79b29d` is current `main` HEAD of that repo, so the pinned commit is public and reachable.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

Licensed MIT ([LICENSE](https://github.com/superme-ai/superme-plugins/blob/main/LICENSE)).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.

**Network endpoints this plugin calls (and why):** `https://mcp.superme.ai` only — the hosted SuperMe MCP server, which is the entire plugin. No other host is contacted, and nothing runs locally: there is no command, no package install, no script.

**Credentials/permissions it requires (and why):** a SuperMe account, authorized over OAuth. The server config carries **no credential at all** — no `Authorization` header, no `${VAR}` placeholder, no `variables` block. `https://mcp.superme.ai` is an OAuth 2.1 protected resource: it serves `/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`, supports RFC 7591 dynamic client registration and PKCE `S256`, and answers unauthenticated requests with a `WWW-Authenticate: Bearer resource_metadata="…"` challenge. Grok's browser flow takes it from there and stores tokens in `~/.grok/mcp_credentials.json`.

We verified that handshake against the live server rather than assuming it: an unauthenticated `tools/list` returns `401` with the `WWW-Authenticate` challenge above, both discovery documents return `200`, `POST /register` returns `201` with a public client (`token_endpoint_auth_method: none`, no client secret), the authorization-server metadata advertises `code_challenge_methods_supported: ["S256"]`, and `GET /authorize` with that client and an `S256` challenge `302`s to the SuperMe sign-in page. The plugin reads no environment variables and no files on the user's machine.

## Notes for reviewers

- **On the merge in this branch.** This PR went `DIRTY` when daily pin bumps landed upstream. Rather than hand-edit, I merged `main` in and resolved `.grok-plugin/marketplace.json` as a **union** — upstream's new `modern-web-guidance` entry plus the SuperMe entry — then regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py` instead of resolving it by hand, per CONTRIBUTING. Both CI commands pass locally. The net diff against `main` is still just the two append-only hunks: +13 lines in `marketplace.json`, +12 in `plugin-index.json`, nothing else touched.
- **On the manifest layout.** The manifest sets `"mcpServers": "./.grok-plugin/mcp.json"` rather than shipping a root `.mcp.json`, because `superme-plugins` serves more than one marketplace from one repo: `.grok-plugin/` and `.cursor-plugin/` each hold their own `plugin.json` + `mcp.json`. Keeping each marketplace's config in its own directory avoids a root-level collision and keeps the Grok config independent of the Cursor one. This is the same string-path form `railway` uses (`"./.grok-plugin/mcp.json"`), and `supabase` and `mongodb` use for other paths.
- **On `keywords` and `domains`.** Deliberately brand-scoped per CONTRIBUTING — `superme`, `superme.ai`, `ask superme`, `superme network`, and only the two hosts we own. The same repo's Cursor manifest uses generic terms (`experts`, `knowledge`, `research`); those are intentionally **not** reused here, since they would mis-fire the CTA on unrelated requests.
- **On updates.** We've noted internally that you re-pin only on a `plugin.json` `version` change, so any future change to `.grok-plugin/` will bump `version` in the same commit rather than opening a parallel entry.

---
[huy 🐨 d3b: Unstick xAI marketplace PR #638 Add SuperMe plugin: resolve the regis…](https://huy.superme.koala.army/task/01a09334-ef7b-7ff0-bf9c-ea17d5dced3b)
