### PR TITLE
Add Apollo Invoicing MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,23 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "apollo-invoicing",
+      "description": "Find Apollo customers, review invoices, and create drafts with entity-scoped OAuth access.",
+      "category": "productivity",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/apollo-invoicing"
+      },
+      "homepage": "https://getapollo.io/global/en/",
+      "keywords": [
+        "apollo invoicing",
+        "getapollo"
+      ],
+      "domains": [
+        "getapollo.io"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,17 @@
 {
   "version": 1,
   "plugins": {
+    "apollo-invoicing": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "apollo-invoicing",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",

--- a/external_plugins/apollo-invoicing/.grok-plugin/plugin.json
+++ b/external_plugins/apollo-invoicing/.grok-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "apollo-invoicing",
+  "version": "1.0.0",
+  "description": "Find Apollo customers, review invoices, and create drafts with entity-scoped OAuth access.",
+  "author": {
+    "name": "Studio 404 d.o.o.",
+    "url": "https://getapollo.io"
+  },
+  "homepage": "https://getapollo.io/global/en/",
+  "license": "MIT",
+  "keywords": [
+    "apollo invoicing",
+    "getapollo"
+  ],
+  "logo": "assets/logo.svg"
+}

--- a/external_plugins/apollo-invoicing/.mcp.json
+++ b/external_plugins/apollo-invoicing/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "apollo-invoicing": {
+      "type": "http",
+      "url": "https://eu.spaceinvoices.com/mcp/r/wlr_156199db8087faa6901fdb63ed664604"
+    }
+  }
+}

--- a/external_plugins/apollo-invoicing/LICENSE
+++ b/external_plugins/apollo-invoicing/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Studio 404 d.o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/external_plugins/apollo-invoicing/README.md
+++ b/external_plugins/apollo-invoicing/README.md
@@ -1,0 +1,44 @@
+# Apollo Invoicing
+
+Connect Grok Build to your Apollo invoicing account through the official remote MCP service maintained by Studio 404 d.o.o.
+
+## Connect
+
+Install Apollo Invoicing from the marketplace, then open `/mcps` and authenticate the `apollo-invoicing` server. Sign in with your Apollo account, select your business and environment, and approve read-only access first. Read/write access is optional and requires a suitable role. An existing Apollo account and entity are required.
+
+Manual connection before marketplace approval:
+
+```sh
+grok mcp add --transport http apollo-invoicing https://eu.spaceinvoices.com/mcp/r/wlr_156199db8087faa6901fdb63ed664604
+```
+
+## Try it
+
+- List my overdue invoices.
+- Find Acme and show its latest invoices.
+- Summarize unpaid invoices by currency.
+- Create a draft invoice for my monthly retainer (requires read/write consent).
+
+## Tools and permissions
+
+`search_operations` finds available business operations; `describe_operation` returns the selected operation's schema; `execute_read` runs permitted reads; `execute_write` performs permitted changes and external effects. Read-only connections do not expose `execute_write`.
+
+Each connection is bound to the Apollo user, account, entity, environment and OAuth resource. Existing permissions are checked for every operation. Review the operation and arguments before approving writes. Revocation is available in Apollo Settings → Integrations. Do not automatically retry an uncertain write outcome.
+
+## Network and data
+
+The plugin contains only metadata and remote MCP configuration. Its service endpoint is:
+
+https://eu.spaceinvoices.com/mcp/r/wlr_156199db8087faa6901fdb63ed664604
+
+The Space Invoices platform hosts Apollo's dedicated white-label resource. OAuth discovery, registration, authorization, token and revocation endpoints are on `https://eu.spaceinvoices.com`; Apollo sign-in uses `https://v2.getapollo.io`. OAuth handles credentials; no API key or environment variable is embedded or required by this package. Invoice/customer data is returned to the connected AI client only under the user's authorization.
+
+- Website: https://getapollo.io/global/en/
+- Privacy: https://getapollo.io/global/en/privacy/
+- Service terms: https://getapollo.io/global/en/terms/
+- Support: support@getapollo.io
+- MCP technical reference: https://docs.spaceinvoices.com/guides/mcp
+
+## License
+
+The integration configuration and documentation are MIT licensed; see LICENSE. Apollo service access remains governed by its service terms. The Apollo logo remains the property of its owner and is included only to identify this integration.

--- a/external_plugins/apollo-invoicing/assets/logo.svg
+++ b/external_plugins/apollo-invoicing/assets/logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#5c63e5"/>
+      <stop offset="42%" stop-color="#563e72"/>
+      <stop offset="100%" stop-color="#2b1c3d"/>
+    </linearGradient>
+    <linearGradient id="stroke" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#f3eef9"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="84" height="84" rx="22" fill="url(#bg)"/>
+  <rect x="8.75" y="8.75" width="82.5" height="82.5" rx="21.25" fill="none" stroke="rgba(255,255,255,0.12)" stroke-width="1.5"/>
+  <path d="M50 20 L16 80 L37 80 L50 68 L63 80 L84 80 Z" fill="none" stroke="url(#stroke)" stroke-width="11.5" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## What this PR does

Adds Apollo Invoicing as an installable remote OAuth MCP connector. Users authorize one Apollo entity/environment, starting with read-only access.

- Plugin name: apollo-invoicing
- Type: local (external_plugins)
- Vendored path: external_plugins/apollo-invoicing
- Homepage: https://getapollo.io/global/en/

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repo is published under our official org (or explained below).

Submitted from the official 404-studio organization. Apollo is operated by Studio 404 d.o.o. This local package vendors integration metadata, documentation and the Apollo icon; the service backend remains provider-hosted. The official MCP Registry entry is io.github.404-studio/apollo-invoicing, version 1.0.0.

## Checklist

- [x] Added exactly one entry in .grok-plugin/marketplace.json (valid JSON, unique kebab-case name).
- [ ] Remote source pins a full 40-char lowercase commit sha, public and reachable — not applicable: local vendored package.
- [x] Regenerated .grok-plugin/plugin-index.json using python3 scripts/generate-plugin-index.py.
- [x] python3 scripts/validate-catalog.py passes locally.
- [x] python3 scripts/generate-plugin-index.py --check passes locally.
- [x] Homepage and clear description set; local plugin includes README.md and .grok-plugin/plugin.json. Keywords/domains are brand-scoped.
- [x] License is stated: integration configuration/documentation are MIT; the Apollo logo remains its owner's property and identifies this integration.

## Security

- [x] No curl | bash, remote-code download/exec, or postinstall RCE.
- [x] No reading/exfiltration of secrets, tokens, .env, or env vars.
- [x] Hooks and MCP scope are least-privilege: no hooks/scripts/dependencies; read-only consent excludes execute_write, and writes require optional authorization and a suitable role.
- Network endpoints: https://eu.spaceinvoices.com/mcp/r/wlr_156199db8087faa6901fdb63ed664604 is Apollo's dedicated MCP resource. OAuth discovery/registration/authorization/token/revocation services use eu.spaceinvoices.com; Apollo sign-in uses v2.getapollo.io. These are documented in README.md.
- Credentials/permissions: an Apollo account and entity; explicit OAuth consent. No embedded credentials or API key required. Current role, entity, environment and resource restrictions apply. Installation creates no user authorization. Review operation arguments before approving writes.

## Notes for reviewers

Apollo protected-resource metadata returns 200 and identifies Apollo. Unauthenticated initialize returns 401 with the matching OAuth metadata challenge. End-to-end signed-in Grok installation, OAuth and tool execution have not yet been verified; these HTTP checks do not establish that behavior.

The generic Space Invoices MCP resource is not listed. Apollo's dedicated white-label resource is hosted by the Space Invoices platform, as explained in README.md. Service access is governed by Apollo's published terms.
