### PR TITLE
Add warmysender

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "warmysender",
+      "description": "WarmySender for AI agents — run cold email, email warmup, LinkedIn, Instagram and WhatsApp outreach on autopilot, verify emails and tap a 200M B2B lead database. The agent never sends directly and never raises a limit: WarmySender's scheduler paces every action inside safe limits.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/fortuneflick/warmysender-claude-plugin.git",
+        "sha": "a6bc067975ef239b6d9a48ee3a06d184077b2c01"
+      },
+      "homepage": "https://warmysender.com/ai-agents",
+      "keywords": ["warmysender", "warmysender cold email", "warmysender warmup", "warmysender linkedin outreach", "warmysender email verification", "warmysender leads"],
+      "domains": ["warmysender.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1264,6 +1264,36 @@
         ]
       }
     },
+    "warmysender": {
+      "sha": "a6bc067975ef239b6d9a48ee3a06d184077b2c01",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "warmysender",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "campaign-doctor",
+            "description": "Diagnose why a WarmySender campaign is sending little or nothing, across email, LinkedIn and Instagram. Use when the us…"
+          },
+          {
+            "name": "cold-email-launch",
+            "description": "Build and launch a cold email campaign on WarmySender end to end — sequence copy, prospects, safe launch. Use when the…"
+          },
+          {
+            "name": "list-hygiene",
+            "description": "Verify email lists with WarmySender and turn the results into a clean prospect list. Use when the user wants to verify…"
+          },
+          {
+            "name": "warmysender",
+            "description": "Run cold email, email warmup, LinkedIn, Instagram and WhatsApp outreach, email verification and a 200M+ B2B lead databa…"
+          }
+        ]
+      }
+    },
     "wix": {
       "sha": "572357b791a91a5138c050e08eb718b150be21cb",
       "version": "1.18.1",


### PR DESCRIPTION
## Plugin

**warmysender** — WarmySender for AI agents: run cold email, email warmup, LinkedIn, Instagram and WhatsApp outreach on autopilot, verify emails and search a 200M B2B lead database from Grok Build.

- Source: https://github.com/fortuneflick/warmysender-claude-plugin (remote source, pinned to `a6bc067975ef239b6d9a48ee3a06d184077b2c01`)
- Homepage: https://warmysender.com/ai-agents
- License: MIT
- Manifest: `.grok-plugin/plugin.json` + `.grok-plugin/marketplace.json` in the source repo

## What it ships

- Skill `warmysender` (root `SKILL.md`, mirrored at `skills/warmysender/SKILL.md`) plus three workflow skills (`campaign-doctor`, `cold-email-launch`, `list-hygiene`).
- One hosted MCP server declared via `mcpServers`: `https://warmysender.com/mcp` (streamable HTTP, OAuth 2.1 with dynamic client registration — the user signs in to WarmySender on first connection; no token to paste).

## Security

- No hooks, no scripts, no binaries, no `postinstall`, no telemetry. The manifests and skills contain no executable code.
- The only network endpoint is `https://warmysender.com/mcp`; credentials are the user's own WarmySender sign-in (OAuth) or an API key they create themselves.
- Every tool is annotated read-only / write / destructive. The agent never sends a message itself and can never raise a limit — WarmySender's scheduler paces every action inside per-account safe limits.

## Checklist

- [x] Entry appended to `.grok-plugin/marketplace.json`, kebab-case name, unique
- [x] Full 40-char lowercase commit `sha` pinned, commit is public and reachable
- [x] `python3 scripts/generate-plugin-index.py` run and `.grok-plugin/plugin-index.json` committed
- [x] `python3 scripts/validate-catalog.py` and `generate-plugin-index.py --check` pass locally
- [x] Brand-scoped `keywords` and `domains` only
- [x] `homepage`, description, README and license present

🤖 Generated with [Claude Code](https://claude.com/claude-code)