### PR TITLE
Add Sumble plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "sumble",
+      "description": "Sumble's official MCP server and GTM skills. Research accounts and buying committees, track hiring and technology signals, and score, clean, and plan territories against your CRM. Sign in with your Sumble account on first connection; no API key to paste.",
+      "category": "sales",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/SumbleData/agents.git",
+        "sha": "f11dae97d105cc63df21a1e54dc93be65f5da056"
+      },
+      "homepage": "https://sumble.com",
+      "keywords": ["sumble", "sumble mcp", "sumble api", "sumble signals"],
+      "domains": ["sumble.com", "mcp.sumble.com", "api.sumble.com", "docs.sumble.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -889,6 +889,47 @@
         ]
       }
     },
+    "sumble": {
+      "sha": "f11dae97d105cc63df21a1e54dc93be65f5da056",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "sumble",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "sumble-account-research",
+            "description": "Research and prospect accounts using Sumble's MCP and other context auto-pulled from live connectors. Opens with a sing…"
+          },
+          {
+            "name": "sumble-account-scoring",
+            "description": "Build an account-scoring AND/OR whitespace web app powered by Sumble data and optional first-party data. One skill, thr…"
+          },
+          {
+            "name": "sumble-crm-cleaning",
+            "description": "Build a CRM-cleaning review web app powered by Sumble data. Finds (1) potential duplicate accounts — CRM accounts that…"
+          },
+          {
+            "name": "sumble-direct-mail-audience",
+            "description": "Install and launch the supplied Marimo app for building direct-mail audiences near company offices. Use when a user wan…"
+          },
+          {
+            "name": "sumble-mcp",
+            "description": "Use Sumble MCP for account research, prospecting, people/job/technology searches, organization/contact list workflows,…"
+          },
+          {
+            "name": "sumble-people-scoring",
+            "description": "Build a people-scoring web app powered by Sumble data and optional first-party data. Interviews the user about their IC…"
+          },
+          {
+            "name": "sumble-territory-planning",
+            "description": "Companion to sumble-account-scoring: plan and rebalance sales territories. Interviews the user about their segments (de…"
+          }
+        ]
+      }
+    },
     "supabase": {
       "sha": "8629243d1cd72309b533090a4c742f21747d02fa",
       "version": "0.1.15",


### PR DESCRIPTION
## What this PR does

New plugin: Sumble.

- Plugin name: sumble
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/SumbleData/agents.git @ f11dae97d105cc63df21a1e54dc93be65f5da056
- Homepage: https://sumble.com

Ships one hosted MCP server (https://mcp.sumble.com, OAuth) and seven skills: sumble-mcp, sumble-account-research, sumble-account-scoring, sumble-crm-cleaning, sumble-people-scoring, sumble-territory-planning, sumble-direct-mail-audience.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. MIT: `LICENSE` in the source repo, stated in its README and in `.grok-plugin/plugin.json`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): https://mcp.sumble.com is the MCP server (OAuth). Skill scripts run only when a user invokes a skill and call https://api.sumble.com (Sumble REST API, with the user's own API key); https://api.parallel.ai (the direct-mail skill, and an optional whitespace filter in account scoring); https://api.anthropic.com, https://api.openai.com, https://generativelanguage.googleapis.com and https://api.exa.ai (the same optional filter, one provider chosen by the user); https://geocoding.geo.census.gov (direct-mail geocoding, no credential); PyPI through `uv sync --locked` (direct mail only, versions pinned in `uv.lock`). The full table is in the README under "Network endpoints and credentials".
- Credentials/permissions it requires (and why): a Sumble account sign-in for the MCP server (OAuth in the browser; the client stores the token, no key to paste). A Sumble API key for the scoring, cleaning and territory-planning scripts, read from `SUMBLE_API_KEY`, a key file under `~/.config/sumble/` (mode 0600), or a terminal prompt, and sent only to api.sumble.com as a bearer token. Optional third-party keys (`PARALLEL_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `EXA_API_KEY`) for the optional providers above. No hooks, no agents, no LSP servers.

## Notes for reviewers

I'm on Sumble's engineering team (member of github.com/SumbleData). These are the same skills we publish for Claude Code, Codex and Cursor: the repo root doubles as a Claude marketplace through `.claude-plugin/marketplace.json`, and Grok reads `.grok-plugin/plugin.json` plus `.mcp.json`. Tested at the pinned commit with Grok Build: install with `--trust`, OAuth sign-in from `/mcps`, a tool call, and the skills loading as slash commands.

The manifest carries no `version` on purpose, so the daily pin-bump bot tracks our main. `sales` is a new category for this catalog; happy to switch to `productivity` if you prefer an existing one.
