### PR TITLE
Add GrantTap plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -306,6 +306,20 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "granttap",
+      "description": "Pair Grok Build with GrantTap and approve, answer, inspect, or steer local coding-agent work from iPhone and Apple Watch. Installing the plugin registers the GrantTap MCP; scan a one-time QR in the GrantTap iPhone app to pair this computer.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sergii-ziborov/granttap-mcp.git",
+        "sha": "b05327592d9819703b5852588497f5c18ebce1e0",
+        "path": "plugins/granttap"
+      },
+      "homepage": "https://granttap.com",
+      "keywords": ["granttap", "granttap mcp", "granttap pairing"],
+      "domains": ["granttap.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -361,6 +361,24 @@
         ]
       }
     },
+    "granttap": {
+      "sha": "b05327592d9819703b5852588497f5c18ebce1e0",
+      "version": "0.1.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "granttap",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "granttap-connect",
+            "description": "Connect, reconnect, or pair this computer with GrantTap. Use when the user asks to install GrantTap, connect an agent,…"
+          }
+        ]
+      }
+    },
     "mongodb": {
       "sha": "47cc46148f53145eb9b880d2bf1aa89bc9097818",
       "version": "1.2.1",


### PR DESCRIPTION
## What this PR does

- Plugin name: granttap
- Type: remote source
- Source URL + pinned SHA: https://github.com/sergii-ziborov/granttap-mcp.git @ b05327592d9819703b5852588497f5c18ebce1e0 (`plugins/granttap`)
- Homepage: https://granttap.com

GrantTap pairs local coding agents with one encrypted machine connection so you can approve requests, answer questions, inspect work, and steer tasks from iPhone and Apple Watch. The plugin registers the GrantTap MCP (`npx granttap-mcp`) and a connect skill that shows a one-time pairing QR when needed.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

The public plugin repository is `sergii-ziborov/granttap-mcp`, the same source Claude Code and Codex already install from (`claude plugin marketplace add sergii-ziborov/granttap-mcp`). There is not a separate GrantTap GitHub organization yet. Product site, privacy policy, and terms are on [granttap.com](https://granttap.com).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

The plugin is licensed under the GrantTap Commercial Source License. Production use requires Authorized Access to GrantTap.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
  - `npx -y granttap-mcp@0.8.7` downloads the public npm package and starts a local stdio MCP.
  - The MCP talks to GrantTap's production zero-knowledge relay at `wss://relay.granttap.com` only after the user pairs this computer from the GrantTap iPhone app.
- Credentials/permissions it requires (and why):
  - No API key is embedded in the plugin. Pairing is a one-time QR / manual code in the GrantTap iPhone app. Provider CLI login (Claude, Codex, Cursor, Grok) stays separate from GrantTap pairing.

## Notes for reviewers

Indexed components at the pinned commit:

- MCP server `granttap` (stdio)
- Skill `granttap-connect`

Keywords and domains are brand-scoped (`granttap`, `granttap mcp`, `granttap pairing`, `granttap.com`) so the plugin CTA does not fire on generic MCP or approval requests.