### PR TITLE
Add CourtsApp plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -319,6 +319,19 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "courtsapp",
+      "description": "Find and book racquet sport courts - pickleball, tennis, padel, badminton, racquetball, squash, and table tennis. Search live availability nearby and get a booking link with pricing via CourtsApp's hosted MCP server.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/courtsapp/courtsapp-grok-plugin.git",
+        "sha": "df38dede5b25fbfaaf2a131ebb07c3e04962dacf"
+      },
+      "homepage": "https://courtsapp.com",
+      "keywords": ["courtsapp", "courtsapp booking", "courtsapp courts"],
+      "domains": ["courtsapp.com", "www.courtsapp.com", "api.courtsapp.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -203,6 +203,18 @@
         ]
       }
     },
+    "courtsapp": {
+      "sha": "df38dede5b25fbfaaf2a131ebb07c3e04962dacf",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "courtsapp",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "datadog": {
       "sha": "083b4783095520f562534956578c8826613292a9",
       "version": "0.7.21",


### PR DESCRIPTION
## What this PR does

- Plugin name: courtsapp
- Type: remote source
- Source URL + pinned SHA: https://github.com/courtsapp/courtsapp-grok-plugin.git @ df38dede5b25fbfaaf2a131ebb07c3e04962dacf
- Homepage: https://courtsapp.com

CourtsApp is a public hosted MCP for finding and booking racquet sport courts (pickleball, tennis, padel, badminton, racquetball, squash, table tennis). The plugin registers that Streamable HTTP server only. No local binary, hooks, skills, or credentials.

The same MCP is already listed in ChatGPT Apps and Claude's connector directory (`https://api.courtsapp.com/mcp`).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

Source is [courtsapp/courtsapp-grok-plugin](https://github.com/courtsapp/courtsapp-grok-plugin) under the CourtsApp GitHub org. The main product repo is private; this public repo is the plugin surface.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. MIT in the source repo (`LICENSE`, README, `.grok-plugin/plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://api.courtsapp.com/mcp` — official hosted CourtsApp MCP (search availability, booking links, facility lookup).
- Credentials/permissions it requires (and why): none. Public server, all tools read-only. Booking happens in the browser on the returned CourtsApp URL.

## Notes for reviewers

Indexed components at the pinned commit:

- MCP server `courtsapp` (http)

Keywords and domains are brand-scoped (`courtsapp`, `courtsapp booking`, `courtsapp courts`, `courtsapp.com`) so the plugin CTA does not fire on generic court or booking requests.

Docs: https://api.courtsapp.com/mcp/docs
Privacy: https://courtsapp.com/privacy-policy
Terms: https://courtsapp.com/terms-of-use