### PR TITLE
Add payhelm plugin entry

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "payhelm",
+      "description": "Official PayHelm plugin for Grok Build (hosted OAuth MCP server + skills). Query orders, revenue, products, customers, inventory, ad performance, email marketing, shipping, and web traffic across the stores and ad platforms connected to your PayHelm account, and take confirmed actions on them.",
+      "category": "analytics",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/payhelm/payhelm-grok-plugin.git",
+        "sha": "b895223e576ff77a49427940ebd4e3ef9e0816d1"
+      },
+      "homepage": "https://payhelm.com",
+      "keywords": ["payhelm", "payhelm mcp", "payhelm analytics", "payhelm reports", "payhelm ai agent"],
+      "domains": ["payhelm.com", "app.payhelm.com", "mcp.payhelm.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -601,6 +601,48 @@
         ]
       }
     },
+    "payhelm": {
+      "sha": "b895223e576ff77a49427940ebd4e3ef9e0816d1",
+      "version": "0.1.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "payhelm",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "advertising",
+            "description": "Use for paid media questions or actions on Google Ads, Meta/Facebook Ads, Amazon Ads, TikTok Ads, Pinterest Ads, or X A…"
+          },
+          {
+            "name": "email-marketing",
+            "description": "Use for Klaviyo or Mailchimp questions and actions through PayHelm, including campaign and flow performance, segments,…"
+          },
+          {
+            "name": "getting-started",
+            "description": "Use when a user installs or activates the PayHelm plugin, asks how to connect PayHelm, reports authentication or \"API k…"
+          },
+          {
+            "name": "sales-reporting",
+            "description": "Use for questions about sales, revenue, orders, customers, products, SKUs, brands, variants, trends, year-over-year com…"
+          },
+          {
+            "name": "shipping",
+            "description": "Use for shipping and fulfilment tasks through PayHelm, including Shippo shipments, rates, labels, tracking, address val…"
+          },
+          {
+            "name": "storefront-operations",
+            "description": "Use for platform-level store data and catalog actions through PayHelm on Shopify, BigCommerce, WooCommerce and WordPres…"
+          },
+          {
+            "name": "web-analytics-seo",
+            "description": "Use for website traffic, conversion funnel, Google Analytics 4, Google Tag Manager, Google Search Console, Google Merch…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "2b8ae2ee306f823d54879d3da7f8496b73c31d5d",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds the official PayHelm plugin for Grok Build: a remote-source entry pointing at PayHelm's hosted OAuth MCP server plus seven skills (getting started, sales reporting, advertising, email marketing, storefront operations, shipping, web analytics/SEO).

- Plugin name: `payhelm`
- Type: remote source
- Source URL + pinned SHA (remote): https://github.com/payhelm/payhelm-grok-plugin.git @ `b895223e576ff77a49427940ebd4e3ef9e0816d1`
- Homepage: https://payhelm.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (MIT, `LICENSE` in the source repo and `license` in `.grok-plugin/plugin.json`).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://mcp.payhelm.com/mcp` (the PayHelm MCP server, streamable HTTP) and, during sign-in only, `https://client.payhelm.com` (PayHelm's OAuth 2.0 authorization server, discovered through RFC 9728 protected-resource metadata on the MCP endpoint).
- Credentials/permissions it requires (and why): a PayHelm account login completed via OAuth 2.0 authorization code + PKCE with dynamic client registration. Tokens are held by Grok Build; the plugin defines no headers, env vars, hooks, commands, agents, or scripts. The `.mcp.json` is a single `type: http` server with a URL and nothing else.

## Notes for reviewers

- Source repo lives under PayHelm's GitHub org (`payhelm`), matching the plugin brand. PayHelm is a Sukow product; the same org publishes our Claude plugin (`payhelm/payhelm-claude-plugin`).
- `keywords` and `domains` are brand-scoped per CONTRIBUTING; `category: analytics` is new to the catalog because none of the existing categories fit an e-commerce analytics product. Happy to change it if you prefer an existing one.
- The MCP server enforces auth server-side: unauthenticated `tools/list` returns 401 with a `WWW-Authenticate` resource-metadata challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
