### PR TITLE
Add Aave plugin (MCP server + skills)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -331,6 +331,20 @@
       "homepage": "https://www.omneky.com",
       "keywords": ["omneky", "omneky ads", "omneky mcp"],
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
+    },
+    {
+      "name": "aave",
+      "description": "Official Aave plugin: the Aave MCP server plus skills. Read live V3 and V4 markets, reserve rates and risk parameters, inspect wallet positions and health factor, follow DAO governance, and prepare unsigned non-custodial transactions for the user's own wallet to sign.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/aave/skills.git",
+        "sha": "82746bccf7fd71e8bc8b7cf15dbf26c480c6800e",
+        "path": "plugins/mcp"
+      },
+      "homepage": "https://aave.com/docs/mcp",
+      "keywords": ["aave", "aave v4", "aave mcp", "gho", "aave governance"],
+      "domains": ["aave.com", "app.aave.com", "mcp.aave.com"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,40 @@
 {
   "version": 1,
   "plugins": {
+    "aave": {
+      "sha": "82746bccf7fd71e8bc8b7cf15dbf26c480c6800e",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "aave",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "account-activity",
+            "description": "An Aave account's history — past supplies, borrows, repays, withdrawals and collateral changes, and how net worth or he…"
+          },
+          {
+            "name": "deleverage",
+            "description": "Reduce the risk on an Aave position — \"reduce my risk\", \"unwind\", \"get my health factor up\", \"I'm close to liquidation\"…"
+          },
+          {
+            "name": "safe-transactions",
+            "description": "Prepare an Aave state change — supply, borrow, withdraw, repay, or any other prepare_* action — when asked to supply/bo…"
+          },
+          {
+            "name": "tx-confirmation",
+            "description": "Confirm what an Aave transaction did after the user signed it — \"did it go through\", \"was my supply processed\", \"check…"
+          },
+          {
+            "name": "yield-analysis",
+            "description": "Compare Aave yields and rates — best APY for an asset, rates across chains or between V3 and V4, APY history and stabil…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Adds one catalog entry for Aave's official plugin, sourced from `aave/skills`. It ships the Aave MCP
server (`https://mcp.aave.com`, remote, no auth) plus five skills: yield analysis, account activity,
safe transaction building, transaction confirmation, and deleveraging.

- Plugin name: `aave`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/aave/skills.git` @
  `82746bccf7fd71e8bc8b7cf15dbf26c480c6800e`, subdir `plugins/mcp`
- Homepage: https://aave.com/docs/mcp

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (`github.com/aave`, MIT).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + description set. License is MIT, stated in the plugin manifest and repo.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE. The plugin is markdown plus
      one MCP server URL; it runs no code locally and spawns no process.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or env vars. No hooks, no scripts.

Notes for review:

**Transport.** Streamable HTTP, no auth. Verified live today: an anonymous `initialize` answers on
protocol 2025-06-18, and `tools/list` returns 40 tools. A GET asking for `text/event-stream` returns
405 by design, so `sse` is the wrong choice here; `.mcp.json` declares `"type": "http"`.

**Non-custodial by construction.** 38 of the 40 tools carry `readOnlyHint`, and every tool carries a
title. Each `prepare_*` tool returns an unsigned transaction or EIP-712 typed data for the user's own
wallet to review and sign, so those are read-only too: the server holds no keys and cannot sign or
submit. The two writes relay a signature the user already produced. `submit_signed_order` forwards a
CoW Protocol order whose signature covers price, amounts, recipient and deadline, so the relay cannot
alter its terms, and `cancel_order` cancels the user's own order.

**MCP scope.** One vendor-hosted server for one protocol. No shell exec, no generic HTTP or SQL tool,
no meta-tool gateway. Tools are scoped to Aave market data, public wallet positions, DAO governance,
and transaction preparation.

**Data handling** is declared in the plugin README, with the privacy policy and terms linked from it
and from the server card.
