### PR TITLE
Add piggywiggy education plugin (CodyBearTV)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -319,6 +319,20 @@
       "homepage": "https://github.com/OpenPhone/quo-grok-plugin",
       "keywords": ["quo", "quo mcp", "quo business phone", "openphone"],
       "domains": ["quo.com", "mcp.quo.com", "support.quo.com", "my.quo.com"]
+    },
+    {
+      "name": "piggywiggy",
+      "description": "PiggyWiggy the Hedgefund Companion by CodyBearTV. Cipher Coast Academy education agent for studio-scale liability defeasance. Character title only — not a hedge fund, not an investment adviser. Tuition SKU; SOP files are byproducts.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/contentctv/codybeartv-pack.git",
+        "sha": "a9414b1e833fc68445ef99b8f30f5346f04361e3",
+        "path": ".grok/plugins/piggywiggy"
+      },
+      "homepage": "https://github.com/contentctv/codybeartv-pack",
+      "keywords": ["piggywiggy", "codybeartv", "cipher coast academy"],
+      "domains": ["codybeartv.pw"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -562,6 +562,18 @@
         ]
       }
     },
+    "piggywiggy": {
+      "sha": "a9414b1e833fc68445ef99b8f30f5346f04361e3",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "piggywiggy",
+            "description": "PiggyWiggy the Hedgefund Companion by CodyBearTV. Cipher Coast Academy education agent. Teach inversion (do not tokeniz…"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "2b8ae2ee306f823d54879d3da7f8496b73c31d5d",
       "components": {


### PR DESCRIPTION
## Plugin
- **name:** `piggywiggy`
- **source:** https://github.com/contentctv/codybeartv-pack.git
- **sha:** `a9414b1e833fc68445ef99b8f30f5346f04361e3`
- **path:** `.grok/plugins/piggywiggy`

## What it is
Cipher Coast Academy education plugin. Display name: PiggyWiggy the Hedgefund Companion by CodyBearTV. Character title only — not a hedge fund, not an investment adviser, not a broker.

Skills only. No MCP servers, hooks, or shell. No secrets.

## Checklist
- [x] Own / have right to distribute
- [x] Remote source, full 40-char lowercase SHA
- [x] Source repo public and reachable
- [x] `validate-catalog.py` pass
- [x] `generate-plugin-index.py` regenerated and `--check` pass
- [x] Brand-scoped keywords (`piggywiggy`, `codybeartv`, `cipher coast academy`)
- [x] README + LICENSE + `.grok-plugin/plugin.json` in plugin path

Not a securities offering. Access is sold as tuition.