### PR TITLE
Add Prompeteer hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -331,6 +331,25 @@
       "homepage": "https://www.omneky.com",
       "keywords": ["omneky", "omneky ads", "omneky mcp"],
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
+    },
+    {
+      "name": "prompeteer",
+      "description": "Generates contextual prompts and agent skills tuned to 140+ AI platforms, with a 16-dimension Prompt Score and a saved prompt vault. Free to start.",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/prompeteer/prompeteer-mcp.git",
+        "sha": "2a6adb08296816192600f909f4278cc743527b72"
+      },
+      "homepage": "https://prompeteer.ai/connect",
+      "keywords": [
+        "prompeteer",
+        "prompeteer.ai",
+        "promptdrive"
+      ],
+      "domains": [
+        "prompeteer.ai"
+      ]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -573,6 +573,18 @@
         ]
       }
     },
+    "prompeteer": {
+      "sha": "2a6adb08296816192600f909f4278cc743527b72",
+      "version": "2.0.3",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "prompeteer",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "pstack": {
       "sha": "2b8ae2ee306f823d54879d3da7f8496b73c31d5d",
       "components": {


### PR DESCRIPTION
## What this PR does

Adds Prompeteer's hosted MCP plugin so Grok Build users can generate and score contextual prompts and agent skills, work with their saved PromptDrive records, and use authorized Prompeteer Memory.

- Plugin name: `prompeteer`
- Type: remote source
- Source: https://github.com/prompeteer/prompeteer-mcp.git
- Pinned SHA: `2a6adb08296816192600f909f4278cc743527b72`
- Homepage: https://prompeteer.ai/connect

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official `prompeteer` organization.

This submission is made by Prompeteer's maintainer. The official source repository provides the MIT license and identifies Prompeteer's website and support contact.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`, with a unique kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA, publicly reachable in the official repository.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set. The remote source includes a README and a valid `.claude-plugin/plugin.json` manifest.
- [x] MIT license is stated in the manifest and repository.

Keywords are limited to `prompeteer`, `prompeteer.ai`, and `promptdrive`; the only discovery domain is `prompeteer.ai`.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE in the declared plugin.
- [x] No reading or exfiltration of local secrets, `.env` files, or environment variables in the declared plugin.
- [x] No hooks; one MCP connection scoped to Prompeteer's service.

The plugin declares only an HTTP MCP server at `https://prompeteer.ai/mcp`. It has no local command, lifecycle hook, skill, agent, shell execution, or filesystem access declaration. Grok Build does not execute the repository's separately distributed npm bridge for this plugin.

Network access goes to `prompeteer.ai` for MCP and OAuth. Interactive sign-in may redirect the user to their chosen identity provider. A Prompeteer account and user-approved OAuth access are required. Available scopes cover saved prompts, generation and private Prompeteer Memory; the README explains these capabilities, plan quotas, and privacy/terms links.

Generation consumes quota and successful generation automatically saves its result to PromptDrive; the returned `savedToVault`/`promptId` values indicate persistence outcome. Explicit save and Memory preference changes also write account data. Prompeteer Memory is the user's authorized knowledge in Prompeteer; the plugin does not request host memory or unrelated chat history.

## Notes for reviewers

The official Claude Code 2.1.267 validator reports `Validation passed` for the native manifest. The generated Grok component index resolves the pinned public source to version `2.0.3` and exactly one HTTP MCP server named `prompeteer`.

These checks establish manifest/catalog structure and source reachability. An authenticated Grok Build end-to-end connection and tool-call test has not been performed for this submission; no functional certification or prior directory approval is claimed.
