### PR TITLE
feat: add Scout portfolio research plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -331,6 +331,22 @@
       "homepage": "https://www.omneky.com",
       "keywords": ["omneky", "omneky ads", "omneky mcp"],
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
+    },
+    {
+      "name": "scout-portfolio",
+      "description": "Scout onchain portfolio research: source-linked DeFi knowledge, exposure analysis, yield scenarios and Zerion-only action plans. Fixture mode by default; optional unsigned EVM preparation cannot sign or submit trades.",
+      "category": "finance",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/gabchess/scout-onchain.git",
+        "sha": "74131d4dae5bca301ecf8d24139dcf220a0e2559"
+      },
+      "homepage": "https://github.com/gabchess/scout-onchain",
+      "keywords": [
+        "scout-portfolio",
+        "scout onchain",
+        "scout portfolio manager"
+      ]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -339,7 +339,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/gabchess/scout-onchain.git",
-        "sha": "74131d4dae5bca301ecf8d24139dcf220a0e2559"
+        "sha": "7d2e5dd8ad5cd5045c57f2b7bdf1280b6fab3ff9"
       },
       "homepage": "https://github.com/gabchess/scout-onchain",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -339,7 +339,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/gabchess/scout-onchain.git",
-        "sha": "0941cf224255468bc8f713e8ac20667bf4b50d59"
+        "sha": "8d24abc88482f48b564d8c7f0bba4b952251c841"
       },
       "homepage": "https://github.com/gabchess/scout-onchain",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -339,7 +339,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/gabchess/scout-onchain.git",
-        "sha": "7d2e5dd8ad5cd5045c57f2b7bdf1280b6fab3ff9"
+        "sha": "0941cf224255468bc8f713e8ac20667bf4b50d59"
       },
       "homepage": "https://github.com/gabchess/scout-onchain",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -815,7 +815,7 @@
       }
     },
     "scout-portfolio": {
-      "sha": "0941cf224255468bc8f713e8ac20667bf4b50d59",
+      "sha": "8d24abc88482f48b564d8c7f0bba4b952251c841",
       "version": "0.5.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -815,7 +815,7 @@
       }
     },
     "scout-portfolio": {
-      "sha": "74131d4dae5bca301ecf8d24139dcf220a0e2559",
+      "sha": "7d2e5dd8ad5cd5045c57f2b7bdf1280b6fab3ff9",
       "version": "0.4.0",
       "components": {
         "mcpServers": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -815,8 +815,8 @@
       }
     },
     "scout-portfolio": {
-      "sha": "7d2e5dd8ad5cd5045c57f2b7bdf1280b6fab3ff9",
-      "version": "0.4.0",
+      "sha": "0941cf224255468bc8f713e8ac20667bf4b50d59",
+      "version": "0.5.0",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -814,6 +814,32 @@
         ]
       }
     },
+    "scout-portfolio": {
+      "sha": "74131d4dae5bca301ecf8d24139dcf220a0e2559",
+      "version": "0.4.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "scout-portfolio",
+            "description": "stdio"
+          }
+        ],
+        "skills": [
+          {
+            "name": "defi-research",
+            "description": "Explains Ethereum and Solana terms, evaluates DeFi yield and exit risks, and structures trading research using Scout so…"
+          },
+          {
+            "name": "portfolio-intelligence",
+            "description": "Reviews onchain portfolios with holdings, PnL, concentration, stress scenarios, DeFi risk, yield decomposition, and Zer…"
+          },
+          {
+            "name": "watch",
+            "description": "Builds one on-demand Scout portfolio report from a shared wallet observation"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",


### PR DESCRIPTION
Add Scout Portfolio to the Grok Build plugin catalog, pinned to source commit `8d24abc88482f48b564d8c7f0bba4b952251c841` (version 0.5.0). Scout provides three skills and one stdio MCP server for portfolio analysis, DeFi research and Zerion action proposals.

The default uses bundled fixture data. Live Zerion observation is opt-in. Optional transaction preparation produces unsigned EVM proposals through the official Zerion CLI; Scout cannot sign or broadcast a trade.

Validation:
- Official catalog validation and generated-index comparison pass.
- A fresh Grok Build 1.0.25 install discovers three skills and one MCP server; installed knowledge files match the pinned source.
- Scout source checks include 427 container tests and real fixture MCP calls.
- Independent AI review retained its initial failed criterion. After correction, 4/4 exposed regression cases and 6/6 fresh holdout cases pass their gates. Full reports and limitations are in the pinned source.

Source PR https://github.com/gabchess/scout-onchain/pull/17 is merged. Scout v0.5.0 is published at https://github.com/gabchess/scout-onchain/releases/tag/v0.5.0. The catalog pins that release commit. This catalog contribution targets Grok Build. Grok Bot activation and native model invocation remain unverified.
