### PR TITLE
Add expodesk plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "expodesk",
+      "description": "Trade-show lead capture for exhibitors — events, leads, follow-ups via Expodesk MCP",
+      "category": "productivity",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/ryantenor2/expodesk-grok-plugin.git",
+        "sha": "2fdf6d63690ce97294e1a65b5584560842994700"
+      },
+      "homepage": "https://expodesk.app",
+      "keywords": ["expodesk", "expodesk.app"],
+      "domains": ["expodesk.app", "app.expodesk.app", "www.expodesk.app"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -261,6 +261,47 @@
         ]
       }
     },
+    "expodesk": {
+      "sha": "2fdf6d63690ce97294e1a65b5584560842994700",
+      "components": {
+        "agents": [
+          {
+            "name": "expodesk-booth",
+            "description": "Booth-side Expodesk operator — queue the follow-up queue, brief leads, log touches after you send them outside Expodesk"
+          }
+        ],
+        "commands": [
+          {
+            "name": "expodesk-brief",
+            "description": "Pull the full Expodesk brief for a named lead and suggest the next touch"
+          },
+          {
+            "name": "expodesk-due",
+            "description": "List Expodesk follow-ups due for the active (or named) show"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "expodesk",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "expodesk-booth-followups",
+            "description": "Use when clearing Expodesk follow-ups after a trade show — due queue, lead briefs, logging touches on email/WhatsApp/Te…"
+          },
+          {
+            "name": "expodesk-lead-export",
+            "description": "Use when exporting Expodesk leads to CRM/CSV for one event, respecting consent and pagination"
+          },
+          {
+            "name": "expodesk-leads",
+            "description": "Use when working with Expodesk trade-show leads, events, or follow-ups — listing shows, scanning leads, drafting or log…"
+          }
+        ]
+      }
+    },
     "figma": {
       "sha": "f74a51c9aaec87a2e65c9121753b63fb42203d96",
       "version": "2.2.108",


### PR DESCRIPTION
Remote catalog entry for Expodesk trade-show lead capture, pinned to 2fdf6d63690ce97294e1a65b5584560842994700, with regenerated plugin-index.

<!--
Adding or updating a plugin? Read CONTRIBUTING.md first.
Run these locally before opening the PR — they're exactly what CI checks:
  python3 scripts/generate-plugin-index.py
  python3 scripts/validate-catalog.py
  python3 scripts/generate-plugin-index.py --check
-->

## What this PR does

<!-- New plugin? Plugin update? Which plugin and what changed? -->

- Plugin name:
- Type: <!-- remote source / local (external_plugins) -->
- Source URL + pinned SHA (remote), or vendored path (local):
- Homepage:

## Ownership

<!-- Confirm you can distribute this. Sourcing from your official org speeds up review. -->

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

<!-- Reviewers statically audit MCP configs, hooks, scripts, and skills. See CONTRIBUTING.md. -->

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why):
- Credentials/permissions it requires (and why):

## Notes for reviewers

<!-- Anything that helps: relationship to your org, prior art, why a personal-account source, etc. -->
**Network endpoints this plugin calls (and why):**
- https://app.expodesk.app/mcp — official Expodesk MCP server (streamable HTTP, POST only) for events, leads and follow-ups.
- https://app.expodesk.app/.well-known/oauth-protected-resource/mcp, /.well-known/oauth-authorization-server, /oauth/register, /oauth/authorize, /oauth/token — standard OAuth 2.1 discovery, dynamic client registration and PKCE token exchange on first connect. No other hosts.

**Credentials/permissions it requires (and why):**
- Expodesk OAuth on first connect (scope mcp:use; rights follow the signed-in user's role in their workspace, revocable in Expodesk Settings → Integrations). No key to copy.
- Optional: EXPODesk_API_KEY (Bearer) read from the environment only by bin/expodesk-mcp-proxy.py, for hosts without OAuth. Not used by the normal Grok install. The key is sent only to app.expodesk.app.

**Notes for reviewers**
Plugin owned by Expodesk (expodesk.app, hello@expodesk.app). Source is under ryantenor2/expodesk-grok-plugin, the founder's account, until it moves to an official Expodesk GitHub org; the pinned SHA will be re-submitted after the move. MIT licensed. No hooks that shell out on tool calls; the MCP server is scoped to that one endpoint and one OAuth scope. Server-side docs: https://app.expodesk.app/mcp/docs.