### PR TITLE
Add DiscoLike plugin to marketplace catalog

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "discolike",
+      "description": "DiscoLike company search for agents. Find target accounts, firmographics, technographics, and decision-maker contacts across 80M+ business websites via the DiscoLike MCP server, CLI, or Python SDK.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Discolike/discolike-skills.git",
+        "sha": "0b7aa7058f8be6f4b4d8e83fe1fe74897a9bb420"
+      },
+      "homepage": "https://discolike.com/mcp/",
+      "keywords": ["discolike"],
+      "domains": ["discolike.com"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -364,7 +364,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/Discolike/discolike-skills.git",
-        "sha": "0b7aa7058f8be6f4b4d8e83fe1fe74897a9bb420"
+        "sha": "3dabdb0329ce740a1c00424b3d7c1263b8333135"
       },
       "homepage": "https://discolike.com/mcp/",
       "keywords": ["discolike"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -237,6 +237,18 @@
         ]
       }
     },
+    "discolike": {
+      "sha": "0b7aa7058f8be6f4b4d8e83fe1fe74897a9bb420",
+      "version": "0.1.0",
+      "components": {
+        "skills": [
+          {
+            "name": "discolike",
+            "description": "Use when the task involves finding companies, building a target account or TAM list, lookalikes of existing customers,…"
+          }
+        ]
+      }
+    },
     "exa": {
       "sha": "879fae0c814765c43f39ea8f56aae1d44e9d9bc8",
       "version": "1.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -238,9 +238,15 @@
       }
     },
     "discolike": {
-      "sha": "0b7aa7058f8be6f4b4d8e83fe1fe74897a9bb420",
+      "sha": "3dabdb0329ce740a1c00424b3d7c1263b8333135",
       "version": "0.1.0",
       "components": {
+        "mcpServers": [
+          {
+            "name": "discolike",
+            "description": "http"
+          }
+        ],
         "skills": [
           {
             "name": "discolike",


### PR DESCRIPTION
Adds DiscoLike as a remote plugin: skills plus the hosted MCP server for company discovery, enrichment, and contact search across 80M+ business websites. The MCP server (`https://api.discolike.com/v1/mcp`) is streamable HTTP with OAuth 2.1 and dynamic client registration; users sign in on first connection.

- Source: https://github.com/Discolike/discolike-skills (MIT), pinned to 3dabdb0
- Homepage: https://discolike.com/mcp/
- Ran `scripts/generate-plugin-index.py` and `scripts/validate-catalog.py`, both pass