### PR TITLE
Add bland plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "bland",
+      "description": "Official Bland plugin (hosted MCP server + skills + the Norm agent builder). Build, test, and run Bland voice agents from Grok Build: author conversational pathways as local files, simulate and converge them until a call passes, review real calls, run evals, query call analytics, and manage tools, personas, knowledge bases, and automations.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/CINTELLILABS/bland-plugins.git",
+        "sha": "3af221d7194cf7c4fa5cef6653fd3cbdeeed7dbc"
+      },
+      "homepage": "https://bland.ai",
+      "keywords": ["bland", "bland ai", "bland voice agents", "bland pathways", "bland mcp", "norm"],
+      "domains": ["bland.ai", "app.bland.ai", "docs.bland.ai", "api.bland.ai"]
     }
   ]
 }

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -364,7 +364,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/CINTELLILABS/bland-plugins.git",
-        "sha": "3af221d7194cf7c4fa5cef6653fd3cbdeeed7dbc"
+        "sha": "9e5a326f55a21ab4c038a190d488be6672e2245c"
       },
       "homepage": "https://bland.ai",
       "keywords": ["bland", "bland ai", "bland voice agents", "bland pathways", "bland mcp", "norm"],

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -71,6 +71,124 @@
         ]
       }
     },
+    "bland": {
+      "sha": "3af221d7194cf7c4fa5cef6653fd3cbdeeed7dbc",
+      "version": "2.0.5",
+      "components": {
+        "agents": [
+          {
+            "name": "norm",
+            "description": "Use this agent for Norm/SuperNorm pathway work: create, edit, validate, simulate, test, commit, publish, and debug Blan…"
+          },
+          {
+            "name": "norm_judge",
+            "description": "Use this agent when a simulated or real Bland call transcript must be graded against a FIXED outcome checklist — fresh-…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "clone",
+            "description": "List Bland pathways, clone one into a local file workspace, or scaffold a brand-new one. Use when the user wants to see…"
+          },
+          {
+            "name": "commit",
+            "description": "Commit the local pathway workspace back to the Bland server as a new working version (promoting production for new path…"
+          },
+          {
+            "name": "loop",
+            "description": "Convergence loop — drive a Claude-native simulated call against a pathway, verify the expected outcomes, and keep editi…"
+          },
+          {
+            "name": "norm",
+            "description": "Activate Norm, the end-to-end Bland agent builder. Use when the user wants to create, build, edit, fix, simulate, test,…"
+          },
+          {
+            "name": "status",
+            "description": "Show the current Bland workspace state — active pathway, working version, local vs server drift, dirty files, pending w…"
+          },
+          {
+            "name": "test",
+            "description": "Test the local Bland pathway — a focused node/runtime check when a node is named, or a full agent-to-agent simulation o…"
+          },
+          {
+            "name": "validate",
+            "description": "Validate the local pathway workspace with the authoritative server compiler. Use when the user wants to check, compile,…"
+          }
+        ],
+        "hooks": [
+          {
+            "name": "PostToolUse",
+            "description": "Write|Edit|MultiEdit"
+          },
+          {
+            "name": "PreToolUse",
+            "description": "Bash"
+          },
+          {
+            "name": "SessionStart"
+          },
+          {
+            "name": "Stop"
+          }
+        ],
+        "mcpServers": [
+          {
+            "name": "bland",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "analytics",
+            "description": "Use when the user asks for call metrics, stats, or reports — volume, success/completion rates, outcomes, durations, tra…"
+          },
+          {
+            "name": "api",
+            "description": "Use when the user wants to hit the Bland REST API directly — mentions a specific endpoint or /v1 path, asks to GET/POST…"
+          },
+          {
+            "name": "automations",
+            "description": "Use when the user works with Bland AUTOMATIONS — triggers, event pipelines, and their executions: 'when X happens, plac…"
+          },
+          {
+            "name": "call-review",
+            "description": "Use when a real Bland call needs reviewing or debugging — why it routed wrong, looped, dropped, hit voicemail, failed a…"
+          },
+          {
+            "name": "debug",
+            "description": "Use when something on the Bland surface misbehaves and needs SYSTEMATIC root-cause debugging — a pathway routing wrong…"
+          },
+          {
+            "name": "evals",
+            "description": "Use when the user wants to evaluate, score, grade, or judge Bland calls — building eval agents (LLM judges) and their r…"
+          },
+          {
+            "name": "knowledge",
+            "description": "Use when the user mentions knowledge bases, KBs, RAG, or mid-call retrieval — ingesting or uploading documents, FAQs, o…"
+          },
+          {
+            "name": "pathways",
+            "description": "Use whenever the user wants to create, edit, fix, test, simulate, debug, publish, or inspect a Bland voice/phone agent…"
+          },
+          {
+            "name": "persona",
+            "description": "Use when the user works on a Bland persona or agent profile — picking or changing a voice, setting call config, attachi…"
+          },
+          {
+            "name": "setup",
+            "description": "Use when the Bland plugin needs to be connected or is failing to connect — the user asks how to set up, log in, add or…"
+          },
+          {
+            "name": "tools",
+            "description": "Use when the user wants to build, test, update, or manage Bland custom integrations — creating a custom tool or REST AP…"
+          },
+          {
+            "name": "triage",
+            "description": "Use when the user wants to file, log, track, or manage issues found in Bland agents — reporting a bug or problem, attac…"
+          }
+        ]
+      }
+    },
     "browser-use": {
       "sha": "4749bcbfe456e5384b98281a8a66119352197f59",
       "version": "0.1.0",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -72,8 +72,8 @@
       }
     },
     "bland": {
-      "sha": "3af221d7194cf7c4fa5cef6653fd3cbdeeed7dbc",
-      "version": "2.0.5",
+      "sha": "9e5a326f55a21ab4c038a190d488be6672e2245c",
+      "version": "2.1.0",
       "components": {
         "agents": [
           {
@@ -155,6 +155,10 @@
             "description": "Use when a real Bland call needs reviewing or debugging — why it routed wrong, looped, dropped, hit voicemail, failed a…"
           },
           {
+            "name": "calls",
+            "description": "Use when the user wants to place a phone call with Bland, wait on or watch a call in progress, listen to it live, stop…"
+          },
+          {
             "name": "debug",
             "description": "Use when something on the Bland surface misbehaves and needs SYSTEMATIC root-cause debugging — a pathway routing wrong…"
           },
@@ -165,6 +169,10 @@
           {
             "name": "knowledge",
             "description": "Use when the user mentions knowledge bases, KBs, RAG, or mid-call retrieval — ingesting or uploading documents, FAQs, o…"
+          },
+          {
+            "name": "messaging",
+            "description": "Use when the user wants to text someone from a Bland number, run a two-way SMS conversation toward a goal (book an appo…"
           },
           {
             "name": "pathways",


### PR DESCRIPTION
New plugin: the official Bland plugin for Grok Build.

- Plugin name: `bland`
- Type: remote source
- Source URL + pinned SHA (remote), or vendored path (local): https://github.com/CINTELLILABS/bland-plugins.git @ `9e5a326f55a21ab4c038a190d488be6672e2245c`
- Homepage: https://bland.ai

Bland is a voice AI platform. The plugin bundles the hosted Bland MCP server plus 14 skills (pathways, calls, messaging, analytics, evals, call review, tools, personas, knowledge bases, automations, triage, debug, api, setup), 7 slash commands for a local pathway file workspace, and 2 agents (the Norm agent builder and a fresh-context judge for a simulate-grade-fix convergence loop).

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

CINTELLILABS is Bland's GitHub org (it also hosts the Claude Code, Cursor, and Codex marketplace sources for this plugin). I'm a Bland engineer.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated. (MIT, in `LICENSE` and every manifest.)

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): only the Bland API at `https://api.bland.ai` (or the server the user sets in `BLAND_API_URL`): the hosted MCP server at `/v1/mcp`, and through its passthrough tools the documented `/v1/*` REST endpoints. No telemetry, no other hosts.
- Credentials/permissions it requires (and why): one Bland API key, read from `BLAND_API_KEY` in the environment (`.grok-plugin/mcp.json` uses `${BLAND_API_KEY:-}`) and sent only as a Bearer header to that server. `BLAND_API_URL` is optional and defaults to production.

Hooks (`hooks/hooks.json`): SessionStart prints workspace status; PreToolUse on `Bash` pre-approves only the plugin's own offline codec scripts under its `bin/`; PostToolUse on `Write|Edit|MultiEdit` lints pathway workspace files; Stop gates the convergence loop and warns on uncommitted workspace changes. All hooks are plain unminified Node with no dependencies and run offline.

Two files reviewers will likely look at, both documented in the README's "Security and network access" section:
- `bin/engine.bundle.cjs` (479 KB, unminified esbuild bundle) is Bland's server-side pathway codec so local files round-trip byte-identically with the server. Pure data transformation, no I/O (no `fs`, `net`, `http`, `child_process`, or `fetch`).
- `bin/_credentials.cjs` is used only by the Claude Desktop stdio bridge (`bin/bland-mcp-desktop`), which cannot receive plugin config from that app. It resolves the Bland key from Claude's plugin settings, the Bland CLI profile, or the macOS keychain entry for this plugin, and forwards it only to the Bland MCP endpoint. Nothing on Grok Build invokes it: no command, agent, hook, or MCP config references it.

## Notes for reviewers

The plugin also ships on the Claude Code, Cursor, and Codex marketplaces from the same repo. Grok Build reads `.grok-plugin/plugin.json` first, which points `mcpServers` at `.grok-plugin/mcp.json` (env-var based) instead of the Claude manifest's `${user_config.*}` config. Verified the component extraction with `scripts/plugin_catalog.py` against the pinned commit: version 2.1.0, 14 skills, 7 commands, 2 agents, 4 hook events, 1 MCP server.