### PR TITLE
Add Connections hosted MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,18 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "connections",
+      "description": "Connections business platform: host and ticket events, import and search contacts, post to the Deal Flow marketplace, keep notes, to-dos and agent memory, and take payments, via the hosted MCP at studio.connections.icu. Sign in with a Connections account on first connect.",
+      "category": "productivity",
+      "source": {
+        "type": "local",
+        "path": "./external_plugins/connections"
+      },
+      "homepage": "https://connections.icu",
+      "keywords": ["connections", "connections icu", "connections mcp", "deal flow"],
+      "domains": ["connections.icu", "studio.connections.icu", "accounts.connections.icu", "deals.connections.icu", "pass.connections.icu"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -215,6 +215,17 @@
         ]
       }
     },
+    "connections": {
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "connections",
+            "description": "http"
+          }
+        ]
+      }
+    },
     "datadog": {
       "sha": "083b4783095520f562534956578c8826613292a9",
       "version": "0.7.21",

--- a/external_plugins/connections/.grok-plugin/plugin.json
+++ b/external_plugins/connections/.grok-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "connections",
+  "version": "1.0.0",
+  "description": "Connections business platform via the hosted MCP at studio.connections.icu: host and ticket events, import and search contacts, post to the Deal Flow marketplace, keep notes, to-dos and agent memory, and take payments. Sign in with a Connections account on first connect.",
+  "author": {
+    "name": "Connections Global LLC",
+    "url": "https://github.com/Lunarwerx"
+  },
+  "homepage": "https://connections.icu",
+  "license": "Proprietary",
+  "keywords": [
+    "connections",
+    "connections icu",
+    "connections mcp",
+    "deal flow"
+  ]
+}

--- a/external_plugins/connections/.mcp.json
+++ b/external_plugins/connections/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "connections": {
+      "type": "http",
+      "url": "https://studio.connections.icu/v1/mcp"
+    }
+  }
+}

--- a/external_plugins/connections/README.md
+++ b/external_plugins/connections/README.md
@@ -1,0 +1,43 @@
+# Connections plugin for Grok Build
+
+Connect Grok Build to [Connections](https://connections.icu) - an AI-first business platform.
+Through one hosted MCP server an assistant can host and ticket events, invite and message guests,
+import and search contacts, post to and browse the Deal Flow marketplace, keep notes, to-dos and
+agent memory, and take payments.
+
+## Installation
+
+In Grok Build, open `/marketplace`, search for **Connections**, and install.
+
+On first connection Grok opens Connections sign-in in the browser. Sign in with a Connections
+account. Do not paste an API key or a token into chat - the plugin never asks for one.
+
+A free base plan covers the core tools; paid Pass tiers (Pro, Business, Business Plus) unlock the
+rest. Per-assistant setup steps for humans live at <https://studio.connections.icu/connect>.
+
+## Authentication
+
+The plugin connects only to `https://studio.connections.icu/v1/mcp`. Authentication is OAuth 2.1 with
+PKCE (S256) and dynamic client registration, against `accounts.connections.icu`.
+
+Network endpoints:
+
+- `https://studio.connections.icu/v1/mcp` - hosted MCP (streamable HTTP)
+- `https://studio.connections.icu/.well-known/oauth-protected-resource` - protected-resource metadata
+- `https://accounts.connections.icu/oauth/authorize`, `/oauth/token`, `/oauth` - OAuth 2.1 + DCR
+- `https://accounts.connections.icu` - human sign-in
+
+Credentials: a Connections account. The access token is issued by `accounts.connections.icu` and
+sent as `Authorization: Bearer` on `/v1/mcp`. No API key, secret or environment variable is read or
+stored by the plugin, and nothing is written to disk.
+
+## What it ships
+
+An MCP server only. No skills, no slash commands, no agents, no hooks, no LSP servers, and no code
+that executes on the installing machine. Tools are scoped to the workspaces the signed-in account
+can already access.
+
+## License
+
+Proprietary. Use of the hosted MCP is governed by Connections' terms at
+<https://connections.icu/terms>.


### PR DESCRIPTION
## What this adds

`connections` - the Connections hosted MCP server, vendored locally under `external_plugins/connections/`.

Connections is an AI-first business platform. Through one hosted MCP server an agent can host and ticket events, import and search contacts, browse and post Deal Flow marketplace deals, keep notes and agent memory, and take payments.

## Source and ownership

Submitted by Connections Global LLC, which operates the service. `author` and `homepage` name the company, and the server is our own first-party endpoint at `studio.connections.icu`, so this is not a third-party wrapper of somebody else's product.

## What it ships

An MCP server definition and nothing else: no skills, commands, agents, hooks, LSP servers or scripts, and no code that runs on the installing machine. Authentication is OAuth 2.1 with PKCE (S256) and dynamic client registration, completed in the browser on first connect. There is no API key, token or environment variable to set. Every network endpoint and the credential model are declared in the plugin README, per the security expectations in CONTRIBUTING.

## Checklist

- [x] One entry in `.grok-plugin/marketplace.json`, valid JSON, unique kebab-case `name`
- [x] Local source: files vendored under `external_plugins/connections/` with a `README.md` and a `.grok-plugin/plugin.json`
- [x] `.grok-plugin/plugin-index.json` regenerated with `scripts/generate-plugin-index.py`, never hand-edited
- [x] `homepage`, a clear `description`, brand-scoped `keywords` and `domains` we own, `category: productivity`
- [x] Licence stated in the manifest and the README
- [x] Validated locally: `scripts/validate-catalog.py` reports Catalog OK, and `scripts/generate-plugin-index.py --check` reports Plugin index OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)