### PR TITLE
Add sugra-api plugin (remote source, pinned)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,20 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "sugra-api",
+      "description": "Official Sugra API skills. Work over HTTPS and MCP. One key, seven product directions.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Sugra-Systems/sugra-api-skills.git",
+        "sha": "befa4551af1339a924ae1b4f2893d2a0da7d6cad",
+        "path": "plugins/sugra-api"
+      },
+      "homepage": "https://github.com/Sugra-Systems/sugra-api-skills",
+      "keywords": ["sugra", "sugra.ai", "sugra api", "mcp.sugra.ai"],
+      "domains": ["sugra.ai", "docs.sugra.ai", "app.sugra.ai", "mcp.sugra.ai", "sugra.systems"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -950,6 +950,42 @@
         ]
       }
     },
+    "sugra-api": {
+      "sha": "befa4551af1339a924ae1b4f2893d2a0da7d6cad",
+      "version": "1.0.0",
+      "components": {
+        "skills": [
+          {
+            "name": "auth-and-quota",
+            "description": "Authenticate to Sugra over HTTPS and MCP and stay inside the daily quota. Use when setting up a client or when a call r…"
+          },
+          {
+            "name": "connect",
+            "description": "Attach a client to Sugra over HTTPS or MCP. Use when setting up Claude Desktop, Claude Code, ChatGPT, claude.ai, Cursor…"
+          },
+          {
+            "name": "cross-domain-briefing",
+            "description": "Compose one briefing from two or three Sugra directions over HTTPS or MCP. Use when a question spans Finance, Macro, En…"
+          },
+          {
+            "name": "discover-and-call",
+            "description": "Find the right Sugra operation and call it over HTTPS or MCP. Use when the path or operation_id is unknown, before gues…"
+          },
+          {
+            "name": "envelope-and-attribution",
+            "description": "Parse Sugra API payloads over HTTPS or MCP, keep source attribution, and tell observation time from request time. Use w…"
+          },
+          {
+            "name": "live-docs",
+            "description": "Find current Sugra documentation. Use when an endpoint, parameter, count, or version might be stale. Canonical docs are…"
+          },
+          {
+            "name": "using-sugra-api",
+            "description": "Work with the Sugra API over HTTPS and MCP. Use when the task needs Sugra data, a key, product directions (Finance, Mac…"
+          }
+        ]
+      }
+    },
     "supabase": {
       "sha": "8629243d1cd72309b533090a4c742f21747d02fa",
       "version": "0.1.15",


### PR DESCRIPTION
## What this PR does

Adds the official Sugra API skill plugin (new).

- Plugin name: sugra-api
- Type: remote (url)
- Source URL + pinned SHA: https://github.com/Sugra-Systems/sugra-api-skills.git @ befa4551af1339a924ae1b4f2893d2a0da7d6cad
- Path: plugins/sugra-api
- Homepage: https://github.com/Sugra-Systems/sugra-api-skills

HTTPS and MCP skills for the Sugra API. No hooks, no install-time scripts, no bundled MCP server.

## Ownership

- I own this plugin or have the right to distribute it.
- The source repo is published under our official org (Sugra-Systems).

## Checklist

- Added/updated exactly one entry in .grok-plugin/marketplace.json (valid JSON, kebab-case name).
- Remote source pins a full 40-char lowercase commit sha, and that commit is public + reachable.
- .grok-plugin/plugin-index.json regenerated and committed (python3 scripts/generate-plugin-index.py).
- python3 scripts/validate-catalog.py and python3 scripts/generate-plugin-index.py --check both pass locally.
