### PR TITLE
Add Kampalo plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -346,6 +346,19 @@
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
     },
     {
+      "name": "kampalo",
+      "description": "Kampalo ads and SEO workspace for Grok Build. Brief synced Google Ads, Meta Ads, GA4, and Search Console; propose and confirm campaign pauses; manage ads/SEO alerts and ROAS pause rules; generate report JSON.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Tekreign/kampalo-cursor-plugin.git",
+        "sha": "fe0d6a60c5cfabda34a8a4cf64af8e3f76a8b062"
+      },
+      "homepage": "https://app.kampalo.com",
+      "keywords": ["kampalo", "kampalo ads", "kampalo google ads", "kampalo meta ads", "kampalo kai"],
+      "domains": ["kampalo.com", "app.kampalo.com", "be.kampalo.com"]
+    },
+    {
       "name": "modern-web-guidance",
       "description": "Keep your coding agent up to date with modern web platform best practices",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -395,6 +395,28 @@
         ]
       }
     },
+    "kampalo": {
+      "sha": "fe0d6a60c5cfabda34a8a4cf64af8e3f76a8b062",
+      "version": "0.3.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "kampalo",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "automate-kampalo-work",
+            "description": "Automate Kampalo marketing work from synced data — propose or confirm campaign pauses, manage alert and ROAS automation…"
+          },
+          {
+            "name": "campaign-performance-brief",
+            "description": "Brief Kampalo campaign and marketing performance from synced database tools. Use when the user asks about Google Ads, M…"
+          }
+        ]
+      }
+    },
     "modern-web-guidance": {
       "sha": "56c61c9ee79a8df1a98822309c04847a57f56000",
       "version": "0.0.186",


### PR DESCRIPTION
## What this PR does

- Plugin name: kampalo
- Type: remote source
- Source URL + pinned SHA: https://github.com/Tekreign/kampalo-cursor-plugin.git @ `fe0d6a60c5cfabda34a8a4cf64af8e3f76a8b062`
- Homepage: https://app.kampalo.com

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The `source` repo is published under our official org (or I've explained why not below).

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` (`python3 scripts/generate-plugin-index.py`).
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] `homepage` + clear `description` set; local plugins include `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated.

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege.
- Network endpoints this plugin calls (and why): `https://be.kampalo.com/mcp` — Kampalo's hosted FastMCP (streamable HTTP) for read tools over synced ads/SEO/GA4 data and `automate_*` write tools already in the product.
- Credentials/permissions it requires (and why): `KAMPALO_MCP_API_KEY` sent as `Authorization: Bearer …`, matching backend `MCP_API_KEY`. Required so the MCP port is not an unauthenticated read/write surface. Tools also require a Kampalo `user_id` or `user_email`. Pause is two-step (propose, then `confirm=true`). Live ROAS rules need `confirm_live=true`.

## Notes for reviewers

Kampalo is a B2B marketing dashboard (Google Ads, Meta Ads, GA4, Search Console). The plugin is a thin Grok Build wrapper around existing FastMCP — skills plus `.mcp.json`, no hooks or local shell MCP. Source lives under the Tekreign org. In-app Kai stays read-only; only this MCP catalog exposes `automate_*`.