### PR TITLE
feat: add Muapi Grok Build plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "muapi",
+      "description": "Muapi generative-media integration for Grok. Discover models and create or transform images, videos, music, and audio through Muapi's hosted MCP server.",
+      "category": "creative",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/SamurAIGPT/muapi-cli.git",
+        "sha": "642fbed943429b4d386a09c12ec8b695233a66a2"
+      },
+      "homepage": "https://muapi.ai",
+      "keywords": ["muapi", "muapi.ai", "muapi image", "muapi video", "muapi audio", "muapi generative media"],
+      "domains": ["muapi.ai", "api.muapi.ai"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -491,6 +491,24 @@
         ]
       }
     },
+    "muapi": {
+      "sha": "642fbed943429b4d386a09c12ec8b695233a66a2",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "muapi",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "muapi-media",
+            "description": "Create, edit, enhance, and inspect AI images, videos, music, and audio through Muapi when the user asks for generative-…"
+          }
+        ]
+      }
+    },
     "neon": {
       "version": "1.0.0",
       "components": {


### PR DESCRIPTION
## What this PR does

- Plugin name: `muapi`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/SamurAIGPT/muapi-cli.git` @ `642fbed943429b4d386a09c12ec8b695233a66a2`
- Homepage: `https://muapi.ai`

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official organization (`SamurAIGPT`).

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json`.
- [x] Remote source pins a full 40-character lowercase commit SHA.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, description, and license are set.

## Security

- [x] No shell hooks, remote-code download/exec, or postinstall RCE.
- [x] No secret reading or telemetry.
- [x] MCP scope is limited to the Muapi hosted server.
- Network endpoint: `https://api.muapi.ai/mcp`, used for Muapi media-generation and model-discovery tools.
- Credentials: users provide their own `MUAPI_API_KEY`; the plugin sends it only as a bearer credential to the Muapi endpoint. No key is bundled or stored by the plugin.

## Notes for reviewers

The source plugin adds a `.mcp.json` entry for Muapi's Streamable HTTP MCP server and a focused `muapi-media` skill covering live model discovery, image/video/audio generation, async polling, credit transparency, and approval boundaries for account or publishing actions. The source repository is the public Muapi CLI maintained by the `SamurAIGPT` organization.
