### PR TITLE
Add Pulse Verity Index MCP plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -364,7 +364,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/PulseBet/pulse-verity.git",
-        "sha": "693438bda36011f69e0a931e4fdb6cad2eec8cae"
+        "sha": "95e32eed5e3b3d5568caf99ef2b75ff9372bcc7d"
       },
       "homepage": "https://thepulse.markets/developers",
       "keywords": ["pulse-verity", "pulse verity", "pulse verity index"],

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,19 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "pulse-verity",
+      "description": "Read-only access to signed, verifiable Pulse Verity Index crypto prices, asset discovery, batch reads, recorded prints and signature verification. BTC, ETH and SOL samples work without an API key.",
+      "category": "data",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/PulseBet/pulse-verity.git",
+        "sha": "693438bda36011f69e0a931e4fdb6cad2eec8cae"
+      },
+      "homepage": "https://thepulse.markets/developers",
+      "keywords": ["pulse-verity", "pulse verity", "pulse verity index"],
+      "domains": ["thepulse.markets", "mcp.thepulse.markets"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -807,8 +807,8 @@
       }
     },
     "pulse-verity": {
-      "sha": "693438bda36011f69e0a931e4fdb6cad2eec8cae",
-      "version": "1.2.4",
+      "sha": "95e32eed5e3b3d5568caf99ef2b75ff9372bcc7d",
+      "version": "1.2.5",
       "components": {
         "mcpServers": [
           {

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -806,6 +806,18 @@
         ]
       }
     },
+    "pulse-verity": {
+      "sha": "693438bda36011f69e0a931e4fdb6cad2eec8cae",
+      "version": "1.2.4",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "pulse-verity",
+            "description": "stdio"
+          }
+        ]
+      }
+    },
     "quo": {
       "sha": "04abd6ef9cd98ffba2105bb7437c13623c26a675",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

Add Pulse Verity Index as a remote MCP plugin. It provides five read-only tools for signed crypto index prices, batch reads, asset discovery, recorded prints and local signature verification. BTC, ETH and SOL samples work without a key; an optional free developer key enables additional requests subject to usage limits.

- Plugin name: `pulse-verity`
- Type: remote source
- Source URL: https://github.com/PulseBet/pulse-verity.git
- Pinned SHA: `95e32eed5e3b3d5568caf99ef2b75ff9372bcc7d`
- Homepage: https://thepulse.markets/developers
- License: MIT

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official publisher account; the account type is explained below.

PulseBet is Pulse's branded GitHub publisher account (GitHub account type `User`). The source is the public, MIT-licensed Pulse Verity repository, linked to the Pulse developer portal above.

## Checklist

- [x] Added exactly one entry in `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] Remote source pins a full 40-character lowercase commit SHA that is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json` with `python3 scripts/generate-plugin-index.py`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage and description are set; keywords and domains are scoped to Pulse Verity.
- [x] License is stated.

## Security

- The manifest starts only `npx -y pulse-verity@1.2.5`. It has no shell wrapper, downloaded installer, `postinstall` script or dynamic code evaluation.
- The plugin exposes five read-only MCP tools and no hooks, agents, skills, slash commands, filesystem tools or shell-execution tools.
- Network endpoints: GitHub supplies the plugin source; npm supplies the pinned package and its dependencies through the configured registry (`registry.npmjs.org` by default). Runtime GET requests go only to `https://mcp.thepulse.markets/api/index/v1/` for sample, price, batch, recorded-print, catalogue and public-key data. HTTP redirects are rejected.
- Credentials: only the optional `PULSE_API_KEY` environment variable. A configured key is sent only to the Pulse API origin for keyed requests. No key is needed for BTC, ETH and SOL sample prices or public-key reads. No project files are read and no separate telemetry is sent.

## Notes for reviewers

The manifest explicitly selects `.grok-plugin/mcp.json`, avoiding the root manual-client example. The plugin uses the existing published MCP package without changing its runtime or dependencies.

The source repository's four Grok manifest checks validate the explicit MCP path, package version pin and limited component set. Existing Cursor and Gemini manifest checks also pass. The marketplace extractor identifies version `1.2.5` and one `stdio` MCP server. No claim is made that a Grok CLI installation was performed locally.
