### PR TITLE
Add aihelp-stack plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -356,6 +356,18 @@
       },
       "homepage": "https://github.com/GoogleChrome/modern-web-guidance",
       "keywords": ["modern web", "web best practices", "web guidance"]
+    },
+    {
+      "name": "aihelp-stack",
+      "description": "Connect Grok to the AIHelp development stack (GitLab, Jenkins, ELK, DB, Apollo, ZenTao) on the company intranet. Requires VPN and ~/.aihelp-stack.env credentials.",
+      "category": "development",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/XiangYeee/aihelp-stack.git",
+        "sha": "4298e555ba313996db51bfe2f7315e77f3ebaa1d"
+      },
+      "homepage": "https://github.com/XiangYeee/aihelp-stack",
+      "keywords": ["aihelp", "aihelp stack", "aihelp gitlab", "aihelp jenkins"]
     }
   ]
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -1,6 +1,72 @@
 {
   "version": 1,
   "plugins": {
+    "aihelp-stack": {
+      "sha": "4298e555ba313996db51bfe2f7315e77f3ebaa1d",
+      "version": "v0.2.1",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "aihelp-account",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-apollo",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-db",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-elk",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-gitlab",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-jenkins",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-langfuse",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-wiki",
+            "description": "http"
+          },
+          {
+            "name": "aihelp-zentao",
+            "description": "http"
+          },
+          {
+            "name": "jumpserver",
+            "description": "http"
+          },
+          {
+            "name": "zabbix-mcp",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "aihelp-bug",
+            "description": "AIHelp bug investigation skill for AIHelp-related tasks that require bug troubleshooting, root cause analysis, abnormal…"
+          },
+          {
+            "name": "aihelp-guide",
+            "description": "AIHelp environment, workflow, and tool-routing skill. Trigger when the user explicitly mentions `aihelp`/`AIHelp`, asks…"
+          },
+          {
+            "name": "aihelp-ship",
+            "description": "零配置发版与上线编排：测试发版（test 分支 + Jenkins）与正式上线通知（禅道 + develop MR + 群文案）。自然语言组合本地 git 与 GitLab/Jenkins/禅道 MCP。触发如「合并本周四开发分支构建 e…"
+          }
+        ]
+      }
+    },
     "axiom": {
       "sha": "0e98ebaeec76a70c8fda9a7737605800c2f1245d",
       "version": "1.0.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: `aihelp-stack`
- Type: remote source
- Source URL + pinned SHA: `https://github.com/XiangYeee/aihelp-stack.git` @ `4298e555ba313996db51bfe2f7315e77f3ebaa1d`
- Homepage: https://github.com/XiangYeee/aihelp-stack

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [ ] The `source` repo is published under our official org (or I've explained why not below).

The plugin is published from the author's personal GitHub account (`XiangYeee`) because AIHelp does not currently have an official GitHub org for this internal tooling. The plugin is intended for AIHelp employees on the company intranet.

## Checklist

- [x] Added/updated exactly one entry in `.grok-plugin/marketplace.json` (valid JSON, kebab-case `name`).
- [x] Remote source pins a full 40-char lowercase commit `sha`, and that commit is public + reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [ ] `python3 scripts/generate-plugin-index.py --check` not re-run end-to-end locally (full catalog fetch); index entry was generated with `plugin_catalog.extract_plugin` against the pinned commit tree.
- [x] `homepage` + clear `description` set; plugin includes `README.md` + `.grok-plugin/plugin.json`.
- [x] License is stated (`UNLICENSED`, AIHelp employees on intranet).

## Security

- [x] No `curl | bash`, remote-code download/exec, or `postinstall` RCE.
- [x] No reading/exfiltration of secrets, tokens, `.env`, or env vars.
- [x] Hooks and MCP scope are least-privilege (no hooks; MCP is HTTP client config only).
- Network endpoints this plugin calls (and why): company-intranet MCP gateway `http://$AIHELP_MCP_HOST:18100-18111/mcp` for GitLab, Jenkins, ELK, DB, Apollo, account, wiki, ZenTao, JumpServer, Langfuse, Zabbix. Public internet cannot reach these hosts.
- Credentials/permissions it requires (and why): user-supplied env vars `AIHELP_MCP_HOST`, `AIHELP_MCP_BASIC`, `AIHELP_GITLAB_MCP_TOKEN`, `JUMPSERVER_MCP_ACCESSKEY`, `AIHELP_LANGFUSE_MCP_BASIC`. Values are not shipped in the plugin.

## Notes for reviewers

This is an internal company plugin. It only works on the AIHelp intranet or VPN. Skills route GitLab / Jenkins / ELK / DB / Apollo / ZenTao work; MCP is client config, not a bundled server process.