### PR TITLE
Add Send plugin

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -346,6 +346,19 @@
       "domains": ["omneky.com", "mcp.omneky.com", "app.omneky.com"]
     },
     {
+      "name": "send",
+      "description": "Create any HTML and Send publishes it as a sharable link. Host on your domain, control who can access, and get analytics on all your sites.",
+      "category": "documents-and-files",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/send-co/send-plugin.git",
+        "sha": "57a73d29e397f3959e4642fea15c39ce2a02984f"
+      },
+      "homepage": "https://www.send.co",
+      "keywords": ["send.co", "send mcp", "publish to send.co"],
+      "domains": ["send.co", "www.send.co"]
+    },
+    {
       "name": "modern-web-guidance",
       "description": "Keep your coding agent up to date with modern web platform best practices",
       "category": "development",

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -842,6 +842,24 @@
         ]
       }
     },
+    "send": {
+      "sha": "57a73d29e397f3959e4642fea15c39ce2a02984f",
+      "version": "1.0.0",
+      "components": {
+        "mcpServers": [
+          {
+            "name": "send",
+            "description": "http"
+          }
+        ],
+        "skills": [
+          {
+            "name": "creating-sites-with-send",
+            "description": "Publish work as a live, shareable page using Send. Use when someone asks for a page, dashboard, site, landing page, pro…"
+          }
+        ]
+      }
+    },
     "sentry": {
       "sha": "91e0cb6c79730e02bcf8f7dbcb1795e677fe8cc5",
       "version": "1.4.0",


### PR DESCRIPTION
## What this PR does

- Plugin name: send
- Type: remote source
- Source URL + pinned SHA: https://github.com/send-co/send-plugin.git @ 57a73d29e397f3959e4642fea15c39ce2a02984f
- Homepage: https://www.send.co

Create any HTML and Send publishes it as a sharable link. Host on your domain, control who can access, and get analytics on all your sites.

## Ownership

- [x] I own this plugin or have the right to distribute it.
- [x] The source repository is published under our official Send organization.

## Checklist

- [x] Added exactly one entry to `.grok-plugin/marketplace.json` with a unique kebab-case name.
- [x] The remote source pins a full 40-character lowercase commit SHA, and that commit is public and reachable.
- [x] Regenerated `.grok-plugin/plugin-index.json`.
- [x] `python3 scripts/validate-catalog.py` passes locally.
- [x] `python3 scripts/generate-plugin-index.py --check` passes locally.
- [x] Homepage, clear description, README, plugin manifest, and MIT license are present.

## Security

- [x] No remote-code download, `curl | bash`, `eval`, or postinstall execution.
- [x] No reading or exfiltration of secrets, tokens, `.env`, or environment variables.
- [x] No hooks or shell execution; MCP scope is least-privilege.

Network endpoints this plugin calls and why:
- `https://www.send.co/mcp` — the hosted Send Streamable HTTP MCP endpoint used to create, edit, manage, and analyze Send sites.

Credentials and permissions required and why:
- A Send account is required.
- Authentication uses OAuth 2.1 with dynamic client registration.
- No API key, local filesystem access, shell access, or environment-variable access is required.

## Notes for reviewers

The source is maintained under the official `send-co` GitHub organization. The plugin includes the hosted Send MCP server and the `creating-sites-with-send` skill. Requested category: `documents-and-files`.